### PR TITLE
chore: add CODEOWNERS so require_code_owner_review rule actually enforces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every file in this repo requires review from @jahwag before merge to main.
+# Matches the "require_code_owner_review" rule in the "master rule" ruleset.
+# Keep this list tight — adding owners widens who can approve PRs on main.
+* @jahwag


### PR DESCRIPTION
Adds `.github/CODEOWNERS` listing `@jahwag` for every path.

The `master rule` ruleset has `require_code_owner_review: true` but without a CODEOWNERS file that setting is a no-op — any reviewer satisfies it. This PR closes the gap so review must actually come from @jahwag.

Also dogfoods the branch protection: this is the first PR through the master rule.