### PR TITLE
chore(release): drop darwin from goreleaser targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,12 @@ builds:
       - -trimpath
     ldflags:
       - -s -w -X github.com/jahwag/clem/cmd.Version={{ .Version }}
+    # Linux-only: provisioning uses systemd, useradd, and /home/<user> paths.
+    # A darwin build would compile but `sudo clem provision` fails on the
+    # first useradd call. Re-enable once the host layer is abstracted
+    # (see the macOS-port roadmap issue).
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
The darwin binaries (amd64 + arm64) compiled but don't actually work - `sudo clem provision` fails on the first `useradd` call. Host layer is Linux-only (systemd, useradd, /home/<user>). Ship honest Linux-only artefacts until the host layer is abstracted (tracked as a separate Ada issue).