### PR TITLE
fix(vault): make Init idempotent when age keys.txt already exists

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -30,12 +30,17 @@ func Init() error {
 		return fmt.Errorf("age-keygen not found — install age: https://github.com/FiloSottile/age")
 	}
 
-	out, err := exec.Command("age-keygen", "-o", keysPath).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("age-keygen: %w\n%s", err, out)
+	if _, err := os.Stat(keysPath); os.IsNotExist(err) {
+		out, err := exec.Command("age-keygen", "-o", keysPath).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("age-keygen: %w\n%s", err, out)
+		}
+		fmt.Printf("Age keypair generated at: %s\n", keysPath)
+	} else {
+		fmt.Printf("Age key already exists at %s — reusing.\n", keysPath)
 	}
 
-	// Extract public key from the generated file
+	// Extract public key from the generated or existing file
 	data, err := os.ReadFile(keysPath)
 	if err != nil {
 		return fmt.Errorf("reading keys file: %w", err)
@@ -49,7 +54,6 @@ func Init() error {
 		}
 	}
 
-	fmt.Printf("Age keypair generated at: %s\n", keysPath)
 	fmt.Printf("Public key: %s\n", pubKey)
 
 	// Write .sops.yaml if it doesn't already exist

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -167,7 +167,7 @@ func TestInit_FreshInit(t *testing.T) {
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
-	defer os.Chdir(prevCwd)
+	defer func() { _ = os.Chdir(prevCwd) }()
 
 	if err := Init(); err != nil {
 		t.Fatalf("Init fresh: %v", err)
@@ -209,7 +209,7 @@ func TestInit_ReuseExistingKey(t *testing.T) {
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
-	defer os.Chdir(prevCwd)
+	defer func() { _ = os.Chdir(prevCwd) }()
 
 	if err := Init(); err != nil {
 		t.Fatalf("Init reuse: %v", err)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -144,3 +144,83 @@ func TestSet_RejectsMalformedKeyval(t *testing.T) {
 		t.Errorf("expected error to mention 'KEY=value', got: %v", err)
 	}
 }
+
+// requireAgeKeygen skips if age-keygen is not on PATH.
+func requireAgeKeygen(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("age-keygen"); err != nil {
+		t.Skip("age-keygen not on PATH — skipping integration test")
+	}
+}
+
+func TestInit_FreshInit(t *testing.T) {
+	requireAgeKeygen(t)
+
+	tmpHome := t.TempDir()
+	tmpDir := t.TempDir()
+
+	prevHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", prevHome)
+
+	prevCwd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(prevCwd)
+
+	if err := Init(); err != nil {
+		t.Fatalf("Init fresh: %v", err)
+	}
+
+	keysPath := filepath.Join(tmpHome, defaultAgeKeysPath)
+	if _, err := os.Stat(keysPath); err != nil {
+		t.Errorf("keys.txt not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, ".sops.yaml")); err != nil {
+		t.Errorf(".sops.yaml not created: %v", err)
+	}
+}
+
+func TestInit_ReuseExistingKey(t *testing.T) {
+	requireAgeKeygen(t)
+
+	tmpHome := t.TempDir()
+	tmpDir := t.TempDir()
+
+	keysPath := filepath.Join(tmpHome, defaultAgeKeysPath)
+	if err := os.MkdirAll(filepath.Dir(keysPath), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	out, err := exec.Command("age-keygen", "-o", keysPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("age-keygen setup: %v\n%s", err, out)
+	}
+
+	data, _ := os.ReadFile(keysPath)
+	originalContent := string(data)
+
+	prevHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", prevHome)
+
+	prevCwd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(prevCwd)
+
+	if err := Init(); err != nil {
+		t.Fatalf("Init reuse: %v", err)
+	}
+
+	// Key file must be unchanged — age-keygen was not re-run.
+	after, _ := os.ReadFile(keysPath)
+	if string(after) != originalContent {
+		t.Error("keys.txt was overwritten; Init should reuse existing key")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, ".sops.yaml")); err != nil {
+		t.Errorf(".sops.yaml not created: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `clem vault init` failed with `age-keygen: file exists` when `~/.config/sops/age/keys.txt` already existed
- Now checks for existing key first; skips `age-keygen` and reuses the pubkey
- Prints a message indicating the existing key is being reused
- `.sops.yaml` handling unchanged (already idempotent)

## Test plan

- [ ] `TestInit_FreshInit` — generates new keypair, creates `.sops.yaml`
- [ ] `TestInit_ReuseExistingKey` — skips `age-keygen`, keys.txt unchanged, `.sops.yaml` created
- [ ] Both tests skip gracefully if `age-keygen` not on PATH
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes

Closes #3.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)