### PR TITLE
seo: add canonical + JSON-LD + sitemap + robots; README links to myclementine.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@
   <a href="https://github.com/jahwag/clem/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs welcome"></a>
 </p>
 
+<p align="center">
+  <a href="https://myclementine.ai"><b>myclementine.ai</b></a> &middot;
+  <a href="https://github.com/jahwag/clem#quickstart">Quickstart</a> &middot;
+  <a href="https://github.com/jahwag/clem/releases/latest">Download</a> &middot;
+  <a href="https://discord.gg/pR4qeMH4u4">Discord</a>
+</p>
+
 `clem` runs a team of Claude Code agents 24/7 on any Linux host. Each agent is a separate OS user in a tmux session under systemd. Agents coordinate over Discord or Slack, pick up tasks, write code, and open PRs. A watchdog restarts anything that crashes. You configure it once and walk away.
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,34 @@
 <meta property="og:url" content="https://myclementine.ai/">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="canonical" href="https://myclementine.ai/">
 <link rel="icon" type="image/png" href="logo.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "clem",
+  "description": "Continuously Looping Engineering Machines. docker-compose for Claude Code agents - persistent teams, 24/7, on any Linux host.",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Linux",
+  "url": "https://myclementine.ai/",
+  "downloadUrl": "https://github.com/jahwag/clem/releases/latest",
+  "softwareVersion": "0.1.1",
+  "license": "https://github.com/jahwag/clem/blob/main/LICENSE",
+  "programmingLanguage": "Go",
+  "codeRepository": "https://github.com/jahwag/clem",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "jahwag",
+    "url": "https://github.com/jahwag"
+  }
+}
+</script>
 <script src="https://cdn.tailwindcss.com"></script>
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://myclementine.ai/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://myclementine.ai/</loc>
+    <lastmod>2026-04-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Closes the discoverability + SEO gaps.

### README
Adds a prominent links row under the badges: **myclementine.ai** · Quickstart · Download · Discord. Previously the domain wasn't mentioned anywhere in the README.

### Landing page (`docs/index.html`)
- `<link rel='canonical' href='https://myclementine.ai/'>`
- JSON-LD `SoftwareApplication` schema (tells Google: software product, DeveloperApplication category, Linux, MIT licensed, repo URL, author). Rich-result candidate.

### Crawling
- `docs/sitemap.xml` - one URL (single-page site for now; grows when more pages land)
- `docs/robots.txt` - allow all + points at sitemap

### Companion (already applied via gh api, not in this PR)
- repo.homepage = https://myclementine.ai
- repo.description filled in

### Still to do (manual)
- Submit https://myclementine.ai/sitemap.xml to Google Search Console once this merges