### PR TITLE
ci: suppress Node 20 deprecation warnings in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ permissions:
   id-token: write       # needed for SLSA provenance via OIDC
   attestations: write   # needed for actions/attest-build-provenance
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow `env:` level in `ci.yml` and `release.yml`
- Silences Node 20 deprecation warnings emitted on every CI run without requiring action version bumps

## Test plan

- [ ] CI run on this PR shows no Node 20 deprecation warnings in step output
- [ ] All existing jobs (test, lint) still pass

Closes #16.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)