### PR TITLE
config: expose caveman level as off|lite|full|ultra instead of bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ agents:
     vaults: [string]        # vault names merged into .env (later vaults win)
     prompt: string          # injected at start of each session
     web_terminal_port: int  # optional - ttyd port (1024-65535) for read-only viewing
-    caveman: bool           # optional - install caveman plugin (compresses output ~75%)
+    caveman: off|lite|full|ultra  # optional - install caveman plugin (compresses output ~75%); true → ultra (legacy compat)
     subagent_model: string  # optional - CLAUDE_CODE_SUBAGENT_MODEL for Task tool / Explore / general-purpose
     provider: string        # optional - anthropic (default) | bedrock | vertex | ollama | openai-compat
     provider_url: string    # required when provider is ollama or openai-compat

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -113,7 +113,7 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  wrote /home/%s/.claude/settings.json\n", osUser)
 
 		// 3aa. Install caveman plugin if enabled (reduces output tokens ~75%)
-		if ac.Caveman {
+		if ac.Caveman.Enabled() {
 			if err := agent.InstallCaveman(osUser); err != nil {
 				fmt.Printf("  warning: caveman install for %s: %v\n", osUser, err)
 			} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,54 @@ import (
 
 var validName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}$`)
 
+// CavemanLevel controls whether and at what intensity the caveman plugin is
+// injected. Accepts "off"/""  (disabled), "lite", "full", "ultra", or the
+// legacy boolean true (→ "ultra") / false (→ "off").
+type CavemanLevel string
+
+const (
+	CavemanOff   CavemanLevel = ""
+	CavemanLite  CavemanLevel = "lite"
+	CavemanFull  CavemanLevel = "full"
+	CavemanUltra CavemanLevel = "ultra"
+)
+
+// Enabled reports whether the caveman plugin should be installed and injected.
+func (cl CavemanLevel) Enabled() bool { return cl != CavemanOff }
+
+// Level returns the intensity string ("lite", "full", "ultra").
+// Callers should check Enabled() first.
+func (cl CavemanLevel) Level() string { return string(cl) }
+
+// UnmarshalYAML accepts string levels, "off", and legacy booleans.
+func (cl *CavemanLevel) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Tag {
+	case "!!bool":
+		if value.Value == "true" {
+			*cl = CavemanUltra
+		} else {
+			*cl = CavemanOff
+		}
+		return nil
+	case "!!str", "!!null":
+		switch value.Value {
+		case "", "off", "null":
+			*cl = CavemanOff
+		case "lite":
+			*cl = CavemanLite
+		case "full":
+			*cl = CavemanFull
+		case "ultra":
+			*cl = CavemanUltra
+		default:
+			return fmt.Errorf("invalid caveman value %q (valid: off, lite, full, ultra)", value.Value)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid caveman value %q (valid: off, lite, full, ultra)", value.Value)
+	}
+}
+
 type Config struct {
 	Project          string                 `yaml:"project"`
 	PrimaryMilestone string                 `yaml:"primary_milestone"`
@@ -41,7 +89,7 @@ type AgentConfig struct {
 	// 127.0.0.1 for safety (expects SSH tunnel or reverse proxy). Use
 	// 0.0.0.0 when running inside a container with host port-forward.
 	WebTerminalBind string `yaml:"web_terminal_bind"`
-	Caveman         bool   `yaml:"caveman"`
+	Caveman         CavemanLevel `yaml:"caveman"`
 	// Runtime selects which CLI drives the agent's session. Default is
 	// claude-code. opencode talks to 75+ providers (including Ollama) via
 	// models.dev without the Anthropic-format translator in the middle.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,94 @@ func writeYAML(t *testing.T, content string) string {
 	return path
 }
 
+func minYAML(caveman string) string {
+	cavemanLine := ""
+	if caveman != "" {
+		cavemanLine = "\n    caveman: " + caveman
+	}
+	return `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"` + cavemanLine + "\n"
+}
+
+func TestCavemanLevel_StringLevels(t *testing.T) {
+	cases := []struct {
+		yaml    string
+		want    CavemanLevel
+		enabled bool
+	}{
+		{"lite", CavemanLite, true},
+		{"full", CavemanFull, true},
+		{"ultra", CavemanUltra, true},
+		{"off", CavemanOff, false},
+	}
+	for _, tc := range cases {
+		path := writeYAML(t, minYAML(tc.yaml))
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("caveman=%q: Load: %v", tc.yaml, err)
+		}
+		got := cfg.Agents["lead"].Caveman
+		if got != tc.want {
+			t.Errorf("caveman=%q: got %q, want %q", tc.yaml, got, tc.want)
+		}
+		if got.Enabled() != tc.enabled {
+			t.Errorf("caveman=%q: Enabled()=%v, want %v", tc.yaml, got.Enabled(), tc.enabled)
+		}
+		if tc.enabled && got.Level() != tc.yaml {
+			t.Errorf("caveman=%q: Level()=%q, want %q", tc.yaml, got.Level(), tc.yaml)
+		}
+	}
+}
+
+func TestCavemanLevel_LegacyBool(t *testing.T) {
+	// true → ultra
+	path := writeYAML(t, minYAML("true"))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("caveman=true: Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].Caveman; got != CavemanUltra {
+		t.Errorf("caveman=true: got %q, want %q", got, CavemanUltra)
+	}
+
+	// false → off
+	path = writeYAML(t, minYAML("false"))
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatalf("caveman=false: Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].Caveman; got != CavemanOff {
+		t.Errorf("caveman=false: got %q, want %q", got, CavemanOff)
+	}
+}
+
+func TestCavemanLevel_UnsetIsOff(t *testing.T) {
+	path := writeYAML(t, minYAML(""))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Agents["lead"].Caveman.Enabled() {
+		t.Error("expected caveman disabled when unset")
+	}
+}
+
+func TestCavemanLevel_InvalidStringRejectsAtLoad(t *testing.T) {
+	path := writeYAML(t, minYAML("maximum"))
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid caveman value, got nil")
+	}
+}
+
 func TestLoad_PrimaryMilestoneParsed(t *testing.T) {
 	path := writeYAML(t, `
 project: myteam

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -297,8 +297,8 @@ func Generate(cfg *config.Config, agentKey string) string {
 	iterSec := int(iterDur.Seconds())
 
 	promptText := ac.Prompt
-	if ac.Caveman {
-		promptText = "/caveman ultra\n" + promptText
+	if ac.Caveman.Enabled() {
+		promptText = "/caveman " + ac.Caveman.Level() + "\n" + promptText
 	}
 	// Interactive TUIs (claude-code, opencode) do not exit after completing a
 	// prompt — they wait for the next tmux-injected input. The runner loop

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -22,6 +22,36 @@ func baseCfg(agentKey string, ac config.AgentConfig) *config.Config {
 	}
 }
 
+func TestGenerate_CavemanInjectsLevel(t *testing.T) {
+	for _, level := range []config.CavemanLevel{config.CavemanLite, config.CavemanFull, config.CavemanUltra} {
+		cfg := baseCfg("lead", config.AgentConfig{
+			Name:      "Lead",
+			Model:     "claude-opus-4-7",
+			Iteration: "1m",
+			Prompt:    "do the thing",
+			Caveman:   level,
+		})
+		out := Generate(cfg, "lead")
+		want := "/caveman " + level.Level()
+		if !strings.Contains(out, want) {
+			t.Errorf("level=%q: expected %q in runner, got:\n%s", level, want, out)
+		}
+	}
+}
+
+func TestGenerate_CavemanOffNoInjection(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+	if strings.Contains(out, "/caveman") {
+		t.Fatalf("expected no /caveman when unset, got:\n%s", out)
+	}
+}
+
 func TestGenerate_SubagentModelExportPresent(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:          "Lead",


### PR DESCRIPTION
## Summary

- Replace `AgentConfig.Caveman bool` with `CavemanLevel` string type accepting `off`/`""`, `lite`, `full`, `ultra`
- Legacy `caveman: true` maps to `ultra`; `caveman: false` maps to `off` (backward compat via `UnmarshalYAML`)
- Invalid strings fail at `config.Load` time with a clear error message
- `runner.go` now injects `/caveman <level>` instead of hardcoded `/caveman ultra`
- README reference table updated

## Test plan

- [x] `TestCavemanLevel_StringLevels` — each valid string parses correctly
- [x] `TestCavemanLevel_LegacyBool` — `true` → ultra, `false` → off
- [x] `TestCavemanLevel_UnsetIsOff` — unset field is disabled
- [x] `TestCavemanLevel_InvalidStringRejectsAtLoad` — unknown value errors at load
- [x] `TestGenerate_CavemanInjectsLevel` — runner injects correct level for lite/full/ultra
- [x] `TestGenerate_CavemanOffNoInjection` — no `/caveman` injected when unset
- [x] `go vet ./...` passes
- [x] `go build ./...` passes

Closes #4.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)