### PR TITLE
chore(agent): disable Claude Co-authored-by trailer in agent commits

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -264,10 +264,15 @@ func WriteSettings(username string) error {
 		return fmt.Errorf("creating .claude dir: %w", err)
 	}
 
+	// includeCoAuthoredBy=false suppresses the "Co-authored-by: Claude ..."
+	// trailer Claude Code otherwise appends to commits it creates. Agents
+	// should author commits under their own identity, not leak that an LLM
+	// drove them - clem PRs go through normal human review regardless.
 	settings := `{
   "hasTrustDialogAccepted": true,
   "hasCompletedProjectOnboarding": true,
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "includeCoAuthoredBy": false
 }
 `
 	settingsPath := filepath.Join(claudeDir, "settings.json")


### PR DESCRIPTION
Sets `includeCoAuthoredBy: false` in the settings.json that `clem provision` writes for each agent. Claude Code otherwise appends `Co-authored-by: Claude ...` to commits it creates.

Agents commit under their own identity; the LLM trailer is visual noise that doesn't carry information the clem PR review flow wouldn't already catch.