### PR TITLE
fix(cmd): skip config load for update command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,10 @@ func loadConfig(cmd *cobra.Command, args []string) error {
 	if cmd.Name() == "init" {
 		return nil
 	}
+	// update is a binary-management command; no project config needed
+	if cmd.Name() == "update" {
+		return nil
+	}
 
 	var err error
 	cfg, err = config.Load(configPath)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// loadConfig must not touch clem.yaml for commands that don't need it.
+func TestLoadConfigSkipsConfigForSpecialCommands(t *testing.T) {
+	tmp := t.TempDir() // no clem.yaml here
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(prev) }()
+
+	for _, name := range []string{"update", "init", "vault"} {
+		cmd := &cobra.Command{Use: name}
+		if err := loadConfig(cmd, nil); err != nil {
+			t.Errorf("loadConfig(%q) returned error: %v", name, err)
+		}
+	}
+}
+
+func TestLoadConfigRequiresConfigForOtherCommands(t *testing.T) {
+	tmp := t.TempDir() // no clem.yaml
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(prev) }()
+
+	cmd := &cobra.Command{Use: "provision"}
+	if err := loadConfig(cmd, nil); err == nil {
+		t.Error("loadConfig(provision) expected error without clem.yaml, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

`clem update` downloads and replaces the binary — it never reads `clem.yaml`. Running it from any directory without a config file failed with:

```
loading config: reading config clem.yaml: open clem.yaml: no such file or directory
```

This blocked the common `cd ~ && sudo clem update` flow.

## Changes

- `cmd/root.go`: add `"update"` to the `loadConfig` skip-list alongside the existing `"init"` and `"vault"` exemptions
- `cmd/root_test.go`: new tests asserting the skip-list works and that other commands (e.g. `provision`) still require config

## Test plan

- [ ] `go test ./cmd/ -run TestLoadConfig` passes
- [ ] `go test ./...` green
- [ ] `cd /tmp && sudo clem update` works without a `clem.yaml` present

Closes #20.