### PR TITLE
feat(config): default subagent_model to claude-sonnet-4-6 when unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ agents:
     prompt: string          # injected at start of each session
     web_terminal_port: int  # optional - ttyd port (1024-65535) for read-only viewing
     caveman: off|lite|full|ultra  # optional - install caveman plugin (compresses output ~75%); true → ultra (legacy compat)
-    subagent_model: string  # optional - CLAUDE_CODE_SUBAGENT_MODEL for Task tool / Explore / general-purpose
+    subagent_model: string  # optional - CLAUDE_CODE_SUBAGENT_MODEL for Task tool / Explore / general-purpose; defaults to claude-sonnet-4-6; set to "off" to inherit main model
     provider: string        # optional - anthropic (default) | bedrock | vertex | ollama | openai-compat
     provider_url: string    # required when provider is ollama or openai-compat
     runtime: string         # optional - claude-code (default) | opencode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,11 +270,16 @@ const DefaultSubagentModel = "claude-sonnet-4-6"
 
 // normalizeSubagentModel applies the default and maps the "off" sentinel to
 // empty string. Called from Load after YAML parse so runner.go stays simple.
+// Default only applies to Anthropic-backed providers (anthropic, bedrock,
+// vertex); ollama and openai-compat cannot use CLAUDE_CODE_SUBAGENT_MODEL.
 func (ac *AgentConfig) normalizeSubagentModel() {
 	switch ac.SubagentModel {
 	case "off":
 		ac.SubagentModel = ""
 	case "":
-		ac.SubagentModel = DefaultSubagentModel
+		switch ac.Provider {
+		case "", "anthropic", "bedrock", "vertex":
+			ac.SubagentModel = DefaultSubagentModel
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,6 +256,25 @@ func Load(path string) (*Config, error) {
 			}
 			usedPorts[ac.WebTerminalPort] = key
 		}
+		ac.normalizeSubagentModel()
+		cfg.Agents[key] = ac
 	}
 	return &cfg, nil
+}
+
+// DefaultSubagentModel is applied when subagent_model is unset in clem.yaml.
+// Subagents (Task tool, Explore, general-purpose) handle most work well with
+// Sonnet; defaulting avoids silent Opus-on-Opus cost when running an Opus main
+// session. Opt out with subagent_model: "off" in clem.yaml.
+const DefaultSubagentModel = "claude-sonnet-4-6"
+
+// normalizeSubagentModel applies the default and maps the "off" sentinel to
+// empty string. Called from Load after YAML parse so runner.go stays simple.
+func (ac *AgentConfig) normalizeSubagentModel() {
+	switch ac.SubagentModel {
+	case "off":
+		ac.SubagentModel = ""
+	case "":
+		ac.SubagentModel = DefaultSubagentModel
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -196,3 +196,49 @@ func TestLoad_SubagentModelOffDisables(t *testing.T) {
 		t.Errorf("SubagentModel = %q, want empty (disabled)", got)
 	}
 }
+
+func TestLoad_SubagentModelNoDefaultForOllama(t *testing.T) {
+	yaml := `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "llama3"
+    provider: ollama
+`
+	path := writeYAML(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].SubagentModel; got != "" {
+		t.Errorf("SubagentModel = %q, want empty (ollama cannot use CLAUDE_CODE_SUBAGENT_MODEL)", got)
+	}
+}
+
+func TestLoad_SubagentModelDefaultsForBedrock(t *testing.T) {
+	yaml := `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-opus-4-7"
+    provider: bedrock
+`
+	path := writeYAML(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].SubagentModel; got != DefaultSubagentModel {
+		t.Errorf("SubagentModel = %q, want %q (bedrock is Anthropic-backed)", got, DefaultSubagentModel)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -146,3 +146,53 @@ agents:
 		t.Errorf("PrimaryMilestone = %q, want empty", cfg.PrimaryMilestone)
 	}
 }
+
+func subagentYAML(subagentModel string) string {
+	line := ""
+	if subagentModel != "" {
+		line = "\n    subagent_model: " + subagentModel
+	}
+	return `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-opus-4-7"` + line + "\n"
+}
+
+func TestLoad_SubagentModelDefaultsWhenUnset(t *testing.T) {
+	path := writeYAML(t, subagentYAML(""))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].SubagentModel; got != DefaultSubagentModel {
+		t.Errorf("SubagentModel = %q, want %q", got, DefaultSubagentModel)
+	}
+}
+
+func TestLoad_SubagentModelExplicitValuePreserved(t *testing.T) {
+	path := writeYAML(t, subagentYAML(`"claude-haiku-4-5-20251001"`))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].SubagentModel; got != "claude-haiku-4-5-20251001" {
+		t.Errorf("SubagentModel = %q, want %q", got, "claude-haiku-4-5-20251001")
+	}
+}
+
+func TestLoad_SubagentModelOffDisables(t *testing.T) {
+	path := writeYAML(t, subagentYAML("off"))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["lead"].SubagentModel; got != "" {
+		t.Errorf("SubagentModel = %q, want empty (disabled)", got)
+	}
+}


### PR DESCRIPTION
## Summary

When `subagent_model` is unset, subagents (Task tool, Explore, general-purpose) inherit the main session model — often Opus. For Opus-main sessions this is pure cost waste; Sonnet handles most subagent work fine.

This PR defaults `subagent_model` to `claude-sonnet-4-6` when unset.

## Implementation

`Load()` calls `normalizeSubagentModel()` on each agent after YAML parse:

| clem.yaml value | Effective SubagentModel |
|---|---|
| *(absent / empty)* | `claude-sonnet-4-6` |
| `"off"` | `""` (inherit main model, no env var exported) |
| any other string | used as-is |

The `"off"` sentinel is required because `yaml.v3` cannot distinguish an absent key from `subagent_model: ""` at the Go string level.

## What doesn't change

- `runner.go` is untouched — it already skips the export when `SubagentModel == ""`
- Agents that already have `subagent_model` set explicitly are unaffected
- `opencode` agents are also covered (the env var is harmless there)

## Test plan

- [ ] `go test ./internal/config/ -run TestLoad_Subagent` — three new cases (unset→default, explicit value, off→disabled)
- [ ] `go test ./...` green
- [ ] Config with no `subagent_model` field produces `CLAUDE_CODE_SUBAGENT_MODEL="claude-sonnet-4-6"` in runner script

Closes #5.