### PR TITLE
security: detect code reading protected secret env vars in pre-push hook

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -108,15 +108,31 @@ func chownToUser(path, username string) error {
 // false positives block pushes, which is annoying but safe.
 const SecretPatternRegex = `ghp_[A-Za-z0-9]{36}|gho_[A-Za-z0-9]{36}|ghs_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{70,}|sk-[A-Za-z0-9_-]{20,}|xox[bapr]-[0-9A-Za-z-]{10,}|AKIA[0-9A-Z]{16}|AGE-SECRET-KEY-1[A-Z0-9]+|-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----`
 
+// SecretCodePatternRegex is the ERE alternation the pre-push hook uses as a
+// second pass: it detects code that reads protected secret env vars at runtime
+// (Go, Python, Node). Exported so tests share one source of truth with the
+// bash hook. Shell variable expansions are excluded — false-positive rate is
+// too high in shell scripts that legitimately forward these vars.
+// To skip this pass for a repo where the reads are intentional and reviewed,
+// push with CLEM_HOOK_SKIP_CODE_SCAN=1 in the environment.
+// Single-quoted Python access (os.environ['KEY']) is intentionally excluded:
+// the single quote cannot appear inside a bash single-quoted assignment without
+// complex escaping, and double-quoted access is the dominant style for secrets.
+const SecretCodePatternRegex = `os\.Getenv\("(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)"\)|os\.environ\["(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)"\]|process\.env\.(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)`
+
 // prePushHookContent is the pre-push hook installed for every agent user.
-// Pure bash + grep; no gitleaks dependency. The regex comes from
-// SecretPatternRegex so Go tests and the bash hook share one source of truth.
+// Pure bash + grep; no gitleaks dependency. The regexes come from
+// SecretPatternRegex and SecretCodePatternRegex so Go tests and the bash
+// hook share one source of truth.
 var prePushHookContent = fmt.Sprintf(`#!/bin/bash
 # Installed by clem provision. Do not edit by hand - will be overwritten.
-# Refuses to push commits whose diff contains patterns matching common secrets.
+# Pass 1-3: literal credential patterns (tokens, keys, PEM blocks).
+# Pass 4:   code that reads protected secret env vars (Go/Python/Node).
+#           Skip with: CLEM_HOOK_SKIP_CODE_SCAN=1 git push
 
 zero="0000000000000000000000000000000000000000"
 patterns='%s'
+code_patterns='%s'
 
 while read local_ref local_sha remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue
@@ -137,9 +153,19 @@ while read local_ref local_sha remote_ref remote_sha; do
     echo "for a false positive, push with --no-verify (think first)." >&2
     exit 1
   fi
+  if [ "${CLEM_HOOK_SKIP_CODE_SCAN:-0}" != "1" ]; then
+    code_hits=$($diff_cmd 2>/dev/null | grep -E "$code_patterns" | head -3)
+    if [ -n "$code_hits" ]; then
+      echo "clem pre-push hook: push blocked - diff reads a protected secret env var in $range" >&2
+      echo "$code_hits" | sed 's/^/  /' >&2
+      echo "" >&2
+      echo "Set CLEM_HOOK_SKIP_CODE_SCAN=1 if this read is intentional and reviewed." >&2
+      exit 1
+    fi
+  fi
 done
 exit 0
-`, SecretPatternRegex)
+`, SecretPatternRegex, SecretCodePatternRegex)
 
 // InstallGitHooks writes a global pre-push hook for the agent user and points
 // their git config at it via core.hooksPath. Idempotent - safe to call every

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -132,6 +132,117 @@ func TestPrePushHook_AllowsCleanPush(t *testing.T) {
 	}
 }
 
+// TestSecretCodePatternRegex_MatchesKnownPatterns verifies the code-scan regex
+// catches Go, Python, and Node patterns that read protected secret env vars.
+func TestSecretCodePatternRegex_MatchesKnownPatterns(t *testing.T) {
+	re, err := regexp.Compile(SecretCodePatternRegex)
+	if err != nil {
+		t.Fatalf("regex compile: %v", err)
+	}
+
+	positives := []struct {
+		name  string
+		input string
+	}{
+		{"go GH_TOKEN", `token := os.Getenv("GH_TOKEN")`},
+		{"go DISCORD_TOKEN", `d := os.Getenv("DISCORD_TOKEN")`},
+		{"go ANTHROPIC_API_KEY", `k := os.Getenv("ANTHROPIC_API_KEY")`},
+		{"go AWS_SECRET_ACCESS_KEY", `s := os.Getenv("AWS_SECRET_ACCESS_KEY")`},
+		{"go SLACK_MCP_XOXP_TOKEN", `t := os.Getenv("SLACK_MCP_XOXP_TOKEN")`},
+		{"python double-quote GH_TOKEN", `tok = os.environ["GH_TOKEN"]`},
+		{"node GH_TOKEN", `const t = process.env.GH_TOKEN`},
+		{"node ANTHROPIC_API_KEY", `const k = process.env.ANTHROPIC_API_KEY`},
+	}
+	for _, tc := range positives {
+		if !re.MatchString(tc.input) {
+			t.Errorf("regex should match %s (%q) but did not", tc.name, tc.input)
+		}
+	}
+}
+
+// TestSecretCodePatternRegex_DoesNotMatchBenign ensures benign env reads are
+// not flagged. False positives teach developers to always --no-verify.
+func TestSecretCodePatternRegex_DoesNotMatchBenign(t *testing.T) {
+	re, err := regexp.Compile(SecretCodePatternRegex)
+	if err != nil {
+		t.Fatalf("regex compile: %v", err)
+	}
+
+	negatives := []struct {
+		name  string
+		input string
+	}{
+		{"go PATH", `p := os.Getenv("PATH")`},
+		{"go HOME", `h := os.Getenv("HOME")`},
+		{"go unrelated name", `x := os.Getenv("MY_APP_CONFIG")`},
+		{"python HOME", `h = os.environ["HOME"]`},
+		{"node NODE_ENV", `const e = process.env.NODE_ENV`},
+		{"node PORT", `const p = process.env.PORT`},
+		{"comment mentioning GH_TOKEN", `// reads GH_TOKEN from the environment`},
+	}
+	for _, tc := range negatives {
+		if re.MatchString(tc.input) {
+			t.Errorf("regex should NOT match %s (%q) but did", tc.name, tc.input)
+		}
+	}
+}
+
+// TestPrePushHookContent_EmbedsCodePattern ensures the hook template embeds the
+// code pattern regex and the skip-env variable name.
+func TestPrePushHookContent_EmbedsCodePattern(t *testing.T) {
+	if !strings.Contains(prePushHookContent, SecretCodePatternRegex) {
+		t.Error("pre-push hook should embed SecretCodePatternRegex verbatim")
+	}
+	if !strings.Contains(prePushHookContent, "CLEM_HOOK_SKIP_CODE_SCAN") {
+		t.Error("pre-push hook should reference CLEM_HOOK_SKIP_CODE_SCAN escape hatch")
+	}
+}
+
+// TestPrePushHook_BlocksCodeSecretRead verifies the hook exits non-zero when
+// the diff contains a Go os.Getenv call on a protected secret env var name.
+func TestPrePushHook_BlocksCodeSecretRead(t *testing.T) {
+	for _, bin := range []string{"bash", "grep"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+
+	hookPath := writeTestableHook(t,
+		`echo '+	tok := os.Getenv("GH_TOKEN")'`)
+
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("hook should have exited non-zero on code secret read, got exit 0. output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "push blocked") {
+		t.Errorf("hook output missing 'push blocked' message:\n%s", out)
+	}
+}
+
+// TestPrePushHook_AllowsCodeReadWithSkipEnv verifies that setting
+// CLEM_HOOK_SKIP_CODE_SCAN=1 bypasses the code-pattern pass while still
+// running the credential-literal pass.
+func TestPrePushHook_AllowsCodeReadWithSkipEnv(t *testing.T) {
+	for _, bin := range []string{"bash", "grep"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+
+	hookPath := writeTestableHook(t,
+		`echo '+	tok := os.Getenv("GH_TOKEN")'`)
+
+	cmd := exec.Command("bash", hookPath)
+	cmd.Env = append(cmd.Environ(), "CLEM_HOOK_SKIP_CODE_SCAN=1")
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hook should have exited 0 with CLEM_HOOK_SKIP_CODE_SCAN=1, got error %v. output:\n%s", err, out)
+	}
+}
+
 // writeTestableHook writes a copy of prePushHookContent to a temp file with
 // the $diff_cmd substring replaced by a stubbed command that emits a fixed
 // payload. Returns the path.
@@ -139,7 +250,7 @@ func writeTestableHook(t *testing.T, stubDiffCmd string) string {
 	t.Helper()
 	dir := t.TempDir()
 	hookPath := filepath.Join(dir, "pre-push")
-	patched := strings.Replace(prePushHookContent, "$diff_cmd", stubDiffCmd, 1)
+	patched := strings.Replace(prePushHookContent, "$diff_cmd", stubDiffCmd, 2)
 	if err := os.WriteFile(hookPath, []byte(patched), 0755); err != nil {
 		t.Fatalf("write hook: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #26.

Adds pass 4 to the global pre-push hook: blocks diffs containing Go (`os.Getenv`), Python (`os.environ[""]`), or Node (`process.env.`) reads of protected secret env var names (GH_TOKEN, DISCORD_TOKEN, ANTHROPIC_API_KEY, AWS_SECRET_ACCESS_KEY, SLACK_MCP_XOXP_TOKEN).

Mitigates red-team attack A8: attacker tricks the agent into committing code that reads and forwards a secret at runtime rather than embedding a literal token. The existing literal-credential scan (passes 1-3) cannot catch this because no actual token appears in the diff.

## Design decisions

**Shell expansion excluded.** `$GH_TOKEN` in shell scripts would trigger too many false positives — legitimate scripts forward these vars without exfil intent.

**Python single-quoted access excluded.** `os.environ['KEY']` requires a literal single quote inside a bash single-quoted assignment, which is not expressible without complex escaping. Double-quoted access (`os.environ["KEY"]`) is the dominant style for secrets and is detected.

**Escape hatch.** Set `CLEM_HOOK_SKIP_CODE_SCAN=1` in the environment before pushing when the reads are intentional and reviewed (e.g. clem's own provision code legitimately reads GH_TOKEN).

**Single source of truth.** `SecretCodePatternRegex` is an exported Go const — Go tests and the bash hook share exactly the same pattern, same as the existing `SecretPatternRegex`.

## Test plan

- [x] `TestSecretCodePatternRegex_MatchesKnownPatterns` — Go, Python, Node positives
- [x] `TestSecretCodePatternRegex_DoesNotMatchBenign` — PATH, HOME, NODE_ENV do not trigger
- [x] `TestPrePushHookContent_EmbedsCodePattern` — hook contains the exported const
- [x] `TestPrePushHook_BlocksCodeSecretRead` — integration: hook exits 1 on `os.Getenv("GH_TOKEN")` in diff
- [x] `TestPrePushHook_AllowsCodeReadWithSkipEnv` — integration: hook exits 0 with `CLEM_HOOK_SKIP_CODE_SCAN=1`
- [x] `go test ./...` green