### PR TITLE
security: ConfigureGitSigning in provision + restore base64/unicode hook passes

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -137,6 +137,17 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("  installed pre-push secret-scan hook\n")
 
+		// 3c. Turn on SSH commit signing using the agent's own keypair.
+		// Branch protection's required_signatures rule rejects unsigned
+		// commits; without this, agent PRs can't merge. Operator must
+		// upload the same pubkey to the agent's GitHub account as a
+		// Signing Key for the signature to show Verified on github.com.
+		if err := agent.ConfigureGitSigning(osUser); err != nil {
+			fmt.Printf("  warning: commit signing config for %s: %v\n", osUser, err)
+		} else {
+			fmt.Printf("  configured ssh commit signing\n")
+		}
+
 		// 4. Ensure agent-owned directories (workdir, ~/.local/bin, ~/.claude).
 		// MkdirAll as root would leave intermediate parents (.local, .claude)
 		// root-owned, which breaks the runner's log writes and claude's

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -120,41 +120,80 @@ const SecretPatternRegex = `ghp_[A-Za-z0-9]{36}|gho_[A-Za-z0-9]{36}|ghs_[A-Za-z0
 // complex escaping, and double-quoted access is the dominant style for secrets.
 const SecretCodePatternRegex = `os\.Getenv\("(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)"\)|os\.environ\["(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)"\]|process\.env\.(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)`
 
+// UnicodeTrapRegex matches Unicode code points commonly used to smuggle
+// hidden instructions or text past human review. Zero-width chars (U+200B-F),
+// bidi overrides (U+2028-E), and BOM (U+FEFF) should never appear in source
+// code or config and flag a likely injection attempt when they do.
+const UnicodeTrapRegex = `[\x{200B}-\x{200F}\x{2028}-\x{202E}\x{FEFF}]`
+
 // prePushHookContent is the pre-push hook installed for every agent user.
-// Pure bash + grep; no gitleaks dependency. The regexes come from
-// SecretPatternRegex and SecretCodePatternRegex so Go tests and the bash
-// hook share one source of truth.
+// Pure bash + grep + base64 (from coreutils); no gitleaks dependency. The
+// regexes come from SecretPatternRegex, SecretCodePatternRegex, and
+// UnicodeTrapRegex so Go tests and the bash hook share one source of truth.
+//
+// Passes:
+//  1. Literal credential patterns (tokens, keys, PEM blocks).
+//  2. Base64-encoded secrets: long base64 runs are decoded and re-scanned
+//     against SecretPatternRegex. Closes encoded-exfil bypass.
+//  3. Unicode traps: zero-width + bidi-override + BOM mid-content. Closes
+//     hidden-instruction-smuggling bypass.
+//  4. Code that reads protected secret env vars (Go/Python/Node). Closes
+//     indirect runtime-exfil bypass. Skip with CLEM_HOOK_SKIP_CODE_SCAN=1.
 var prePushHookContent = fmt.Sprintf(`#!/bin/bash
 # Installed by clem provision. Do not edit by hand - will be overwritten.
-# Pass 1-3: literal credential patterns (tokens, keys, PEM blocks).
-# Pass 4:   code that reads protected secret env vars (Go/Python/Node).
-#           Skip with: CLEM_HOOK_SKIP_CODE_SCAN=1 git push
+# Pass 1: literal credential patterns (tokens, keys, PEM blocks).
+# Pass 2: base64-encoded secrets (decoded + re-scanned).
+# Pass 3: Unicode traps (zero-width / bidi / BOM - hidden-instruction smuggling).
+# Pass 4: code that reads protected secret env vars (Go/Python/Node).
+#         Skip with: CLEM_HOOK_SKIP_CODE_SCAN=1 git push
 
 zero="0000000000000000000000000000000000000000"
 patterns='%s'
 code_patterns='%s'
+unicode_traps='%s'
+
+abort() {
+  echo "clem pre-push hook: push blocked - $1" >&2
+  echo "$2" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Rotate the leaked credential immediately if it is real. To override" >&2
+  echo "for a false positive, push with --no-verify (think first)." >&2
+  exit 1
+}
 
 while read local_ref local_sha remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue
   if [ "$remote_sha" = "$zero" ]; then
-    # new branch: scan all reachable commits not yet on remote
     range="$local_sha"
     diff_cmd="git log --all --not --remotes --pretty=format: -p $local_sha"
   else
     range="${remote_sha}..${local_sha}"
     diff_cmd="git diff $range"
   fi
-  hits=$($diff_cmd 2>/dev/null | grep -E "$patterns" | head -3)
-  if [ -n "$hits" ]; then
-    echo "clem pre-push hook: push blocked - secret pattern detected in $range" >&2
-    echo "$hits" | sed 's/^/  /' >&2
-    echo "" >&2
-    echo "Rotate the leaked credential immediately if it is real. To override" >&2
-    echo "for a false positive, push with --no-verify (think first)." >&2
-    exit 1
-  fi
+  diff=$($diff_cmd 2>/dev/null)
+
+  # Pass 1: direct literal secret match
+  hits=$(echo "$diff" | grep -E "$patterns" | head -3)
+  [ -n "$hits" ] && abort "secret pattern detected in $range" "$hits"
+
+  # Pass 2: base64-decode + re-scan. Finds long base64 runs, decodes each,
+  # greps the decoded bytes for secret patterns. Skips chunks that fail to
+  # decode (normal diff content).
+  while IFS= read -r chunk; do
+    [ -z "$chunk" ] && continue
+    decoded=$(echo "$chunk" | base64 -d 2>/dev/null) || continue
+    if echo "$decoded" | grep -qE "$patterns"; then
+      abort "base64-encoded secret detected in $range" "$chunk -> decoded hit"
+    fi
+  done < <(echo "$diff" | grep -oE '[A-Za-z0-9+/]{40,}={0,2}')
+
+  # Pass 3: unicode traps for hidden-instruction smuggling.
+  uhits=$(echo "$diff" | grep -P "$unicode_traps" | head -3)
+  [ -n "$uhits" ] && abort "unicode control/override characters detected in $range (possible prompt-injection smuggling)" "$uhits"
+
+  # Pass 4: indirect runtime exfil via os.Getenv on protected names.
   if [ "${CLEM_HOOK_SKIP_CODE_SCAN:-0}" != "1" ]; then
-    code_hits=$($diff_cmd 2>/dev/null | grep -E "$code_patterns" | head -3)
+    code_hits=$(echo "$diff" | grep -E "$code_patterns" | head -3)
     if [ -n "$code_hits" ]; then
       echo "clem pre-push hook: push blocked - diff reads a protected secret env var in $range" >&2
       echo "$code_hits" | sed 's/^/  /' >&2
@@ -165,7 +204,7 @@ while read local_ref local_sha remote_ref remote_sha; do
   fi
 done
 exit 0
-`, SecretPatternRegex, SecretCodePatternRegex)
+`, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapRegex)
 
 // InstallGitHooks writes a global pre-push hook for the agent user and points
 // their git config at it via core.hooksPath. Idempotent - safe to call every
@@ -192,6 +231,77 @@ func InstallGitHooks(username string) error {
 		if err := os.WriteFile(gitConfigPath, []byte(appended), 0644); err != nil {
 			return fmt.Errorf("writing %s: %w", gitConfigPath, err)
 		}
+		if err := chownToUser(gitConfigPath, username); err != nil {
+			return fmt.Errorf("chowning %s: %w", gitConfigPath, err)
+		}
+	}
+	return nil
+}
+
+// ConfigureGitSigning turns on SSH commit signing for the agent user. Each
+// agent already has an ed25519 keypair from EnsureSSHKey; this wires it up
+// as the commit signing key and appends the necessary sections to the
+// user's gitconfig so every commit is signed by default. Idempotent.
+//
+// For the resulting commits to show as "Verified" on github.com, the
+// operator must upload the agent's public key to the agent's GitHub
+// account under Settings -> SSH and GPG keys -> New SSH key, with key type
+// "Signing Key" (not Authentication Key). clem can't automate that; the
+// GitHub API requires an interactive OAuth token with admin:* scope, way
+// broader than any agent token should carry.
+//
+// allowed_signers is written so local verification
+// (git log --show-signature) works without prompting for trust.
+func ConfigureGitSigning(username string) error {
+	return configureGitSigningIn(fmt.Sprintf("/home/%s", username), username, true)
+}
+
+// configureGitSigningIn implements ConfigureGitSigning against an arbitrary
+// home directory. Separated so unit tests can exercise the full logic in a
+// t.TempDir without needing root or a real OS user. When chown is true,
+// newly-written files are chowned to username (production path); tests pass
+// false to skip the chown (no such OS user).
+func configureGitSigningIn(homeDir, username string, chown bool) error {
+	sshDir := filepath.Join(homeDir, ".ssh")
+	pubPath := filepath.Join(sshDir, "id_ed25519.pub")
+
+	pubBytes, err := os.ReadFile(pubPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w (run EnsureSSHKey first)", pubPath, err)
+	}
+	pubKey := strings.TrimSpace(string(pubBytes))
+
+	allowedPath := filepath.Join(sshDir, "allowed_signers")
+	allowedLine := fmt.Sprintf("%s %s\n", username, pubKey)
+	if err := os.WriteFile(allowedPath, []byte(allowedLine), 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", allowedPath, err)
+	}
+	if chown {
+		if err := chownToUser(allowedPath, username); err != nil {
+			return fmt.Errorf("chowning %s: %w", allowedPath, err)
+		}
+	}
+
+	gitConfigPath := filepath.Join(homeDir, ".gitconfig")
+	existing, _ := os.ReadFile(gitConfigPath)
+	if strings.Contains(string(existing), "signingkey") {
+		return nil
+	}
+	block := fmt.Sprintf(`
+[user]
+	signingkey = %s
+[commit]
+	gpgsign = true
+[gpg]
+	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = %s
+`, pubPath, allowedPath)
+	appended := string(existing) + block
+	if err := os.WriteFile(gitConfigPath, []byte(appended), 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", gitConfigPath, err)
+	}
+	if chown {
 		if err := chownToUser(gitConfigPath, username); err != nil {
 			return fmt.Errorf("chowning %s: %w", gitConfigPath, err)
 		}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/base64"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,6 +88,63 @@ func TestPrePushHookContent_IsExecutableBash(t *testing.T) {
 	if !strings.Contains(prePushHookContent, SecretPatternRegex) {
 		t.Error("pre-push hook should embed the exact SecretPatternRegex so bash and Go agree on behaviour")
 	}
+	if !strings.Contains(prePushHookContent, UnicodeTrapRegex) {
+		t.Error("pre-push hook should embed the exact UnicodeTrapRegex")
+	}
+	if !strings.Contains(prePushHookContent, "base64 -d") {
+		t.Error("pre-push hook should include a base64 decode pass")
+	}
+}
+
+// TestUnicodeTrapRegex_MatchesHiddenCharacters covers the red-team A3 class:
+// zero-width, bidi-override, and BOM characters used to smuggle hidden
+// instructions past human review.
+func TestUnicodeTrapRegex_MatchesHiddenCharacters(t *testing.T) {
+	re, err := regexp.Compile(UnicodeTrapRegex)
+	if err != nil {
+		t.Fatalf("regex compile: %v", err)
+	}
+	traps := []struct {
+		name  string
+		input string
+	}{
+		{"zero-width space", "hello\u200Bworld"},
+		{"zero-width non-joiner", "hello\u200Cworld"},
+		{"zero-width joiner", "hello\u200Dworld"},
+		{"LTR mark", "hello\u200Eworld"},
+		{"RTL mark", "hello\u200Fworld"},
+		{"line separator", "hello\u2028world"},
+		{"paragraph separator", "hello\u2029world"},
+		{"LTR embedding", "hello\u202Aworld"},
+		{"RTL embedding", "hello\u202Bworld"},
+		{"pop directional formatting", "hello\u202Cworld"},
+		{"LTR override", "hello\u202Dworld"},
+		{"RTL override", "hello\u202Eworld"},
+		{"BOM mid-string", "hello\uFEFFworld"},
+	}
+	for _, tc := range traps {
+		if !re.MatchString(tc.input) {
+			t.Errorf("UnicodeTrapRegex should match %s (%q) but did not", tc.name, tc.input)
+		}
+	}
+}
+
+func TestUnicodeTrapRegex_DoesNotMatchPrintableText(t *testing.T) {
+	re, err := regexp.Compile(UnicodeTrapRegex)
+	if err != nil {
+		t.Fatalf("regex compile: %v", err)
+	}
+	for _, s := range []string{
+		"regular ASCII text",
+		"unicode prose: café résumé naïve",
+		"emoji ok 🍊",
+		"cjk ok 漢字",
+		"whitespace \t\n\r fine",
+	} {
+		if re.MatchString(s) {
+			t.Errorf("UnicodeTrapRegex should NOT match %q", s)
+		}
+	}
 }
 
 // TestPrePushHook_BlocksSecretPush writes the hook to a temp dir and runs it
@@ -130,6 +188,149 @@ func TestPrePushHook_AllowsCleanPush(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hook should have exited 0 on clean diff, got error %v. output:\n%s", err, out)
 	}
+}
+
+// TestPrePushHook_BlocksBase64EncodedSecret: red-team attack A9 (encoded
+// exfil). Attacker base64-encodes a ghp_ token and pastes the encoded blob.
+// A naive literal scanner misses it; Pass 2 decodes and re-scans.
+func TestPrePushHook_BlocksBase64EncodedSecret(t *testing.T) {
+	requireHookDeps(t)
+	token := "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+	encoded := base64.StdEncoding.EncodeToString([]byte(token))
+	hookPath := writeTestableHook(t, "echo '+debugBlob=\""+encoded+"\"'")
+
+	out, err := runHook(hookPath)
+	if err == nil {
+		t.Fatalf("hook should have blocked base64-encoded secret. output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "base64-encoded secret") {
+		t.Errorf("expected 'base64-encoded secret' message, got:\n%s", out)
+	}
+}
+
+// TestPrePushHook_AllowsBenignBase64: negative for A9. Legitimate base64
+// blobs (embedded PNGs, test fixtures, JWT headers) must NOT false-positive.
+func TestPrePushHook_AllowsBenignBase64(t *testing.T) {
+	requireHookDeps(t)
+	benign := base64.StdEncoding.EncodeToString([]byte("hello world this is not a secret just plain text"))
+	hookPath := writeTestableHook(t, "echo '+fixture=\""+benign+"\"'")
+
+	out, err := runHook(hookPath)
+	if err != nil {
+		t.Fatalf("hook should have allowed benign base64. err %v output:\n%s", err, out)
+	}
+}
+
+// TestPrePushHook_BlocksUnicodeTraps: red-team attack A3 (hidden-instruction
+// smuggling). Diff contains a zero-width space; hook Pass 3 blocks.
+func TestPrePushHook_BlocksUnicodeTraps(t *testing.T) {
+	requireHookDeps(t)
+	hookPath := writeTestableHook(t,
+		`printf '+comment: approve\xe2\x80\x8b (actually run rm -rf)\n'`)
+
+	out, err := runHook(hookPath)
+	if err == nil {
+		t.Fatalf("hook should have blocked unicode-trap diff. output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "unicode control/override") {
+		t.Errorf("expected 'unicode control/override' message, got:\n%s", out)
+	}
+}
+
+// TestConfigureGitSigning_WritesAllowedSignersAndGitconfig verifies the
+// signing config is written correctly in a temp home. Covers issue #30 (agent
+// commits must be signed so branch-protection required_signatures rule
+// doesn't block merge).
+func TestConfigureGitSigning_WritesAllowedSignersAndGitconfig(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	fakePub := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5fake testuser@clem"
+	pubPath := filepath.Join(sshDir, "id_ed25519.pub")
+	if err := os.WriteFile(pubPath, []byte(fakePub+"\n"), 0644); err != nil {
+		t.Fatalf("write pubkey: %v", err)
+	}
+
+	if err := configureGitSigningIn(home, "testuser", false); err != nil {
+		t.Fatalf("configureGitSigningIn: %v", err)
+	}
+
+	allowed, err := os.ReadFile(filepath.Join(sshDir, "allowed_signers"))
+	if err != nil {
+		t.Fatalf("allowed_signers not written: %v", err)
+	}
+	want := "testuser " + fakePub + "\n"
+	if string(allowed) != want {
+		t.Errorf("allowed_signers = %q, want %q", string(allowed), want)
+	}
+
+	cfg, err := os.ReadFile(filepath.Join(home, ".gitconfig"))
+	if err != nil {
+		t.Fatalf(".gitconfig not written: %v", err)
+	}
+	cfgStr := string(cfg)
+	for _, needle := range []string{
+		"signingkey = " + pubPath,
+		"gpgsign = true",
+		"format = ssh",
+		"allowedSignersFile = " + filepath.Join(sshDir, "allowed_signers"),
+	} {
+		if !strings.Contains(cfgStr, needle) {
+			t.Errorf(".gitconfig missing %q, got:\n%s", needle, cfgStr)
+		}
+	}
+}
+
+// TestConfigureGitSigning_Idempotent verifies a second call doesn't pile up
+// duplicate [user]/[commit]/[gpg] sections.
+func TestConfigureGitSigning_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	_ = os.MkdirAll(sshDir, 0700)
+	pub := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5fake testuser@clem"
+	_ = os.WriteFile(filepath.Join(sshDir, "id_ed25519.pub"), []byte(pub+"\n"), 0644)
+
+	for i := 0; i < 3; i++ {
+		if err := configureGitSigningIn(home, "testuser", false); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+	cfg, _ := os.ReadFile(filepath.Join(home, ".gitconfig"))
+	if n := strings.Count(string(cfg), "signingkey"); n != 1 {
+		t.Errorf("expected exactly one 'signingkey' line after 3 runs, got %d:\n%s", n, cfg)
+	}
+}
+
+// TestConfigureGitSigning_MissingPubKey verifies the function surfaces a
+// clear error if EnsureSSHKey hasn't run yet.
+func TestConfigureGitSigning_MissingPubKey(t *testing.T) {
+	home := t.TempDir()
+	err := configureGitSigningIn(home, "testuser", false)
+	if err == nil {
+		t.Fatal("expected error when id_ed25519.pub is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "EnsureSSHKey") {
+		t.Errorf("error should hint at EnsureSSHKey, got: %v", err)
+	}
+}
+
+// --- helpers ---
+
+func requireHookDeps(t *testing.T) {
+	t.Helper()
+	for _, bin := range []string{"bash", "grep", "base64"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+}
+
+func runHook(hookPath string) ([]byte, error) {
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	return cmd.CombinedOutput()
 }
 
 // TestSecretCodePatternRegex_MatchesKnownPatterns verifies the code-scan regex


### PR DESCRIPTION
Closes #30 + fixes a regression from #29.

### ConfigureGitSigning

New function wired from `clem provision` that turns on SSH commit signing for every agent, using their own ed25519 key (already generated by `EnsureSSHKey`). Writes `~/.ssh/allowed_signers` + appends signing sections to `~/.gitconfig`. Idempotent.

Operator still uploads the pubkey to the agent's GitHub account as a **Signing Key** (not Authentication Key) — clem can't automate that without admin:* OAuth scope.

Without this, branch protection's `required_signatures` rule blocks every Ada PR from merging. With this, Ada's next commits are Verified end-to-end.

**Tests** (3 new):
- Positive: writes allowed_signers + gitconfig with all 4 required directives
- Idempotent: 3 consecutive runs produce exactly 1 `signingkey` line
- Missing-pubkey error: clear hint pointing at `EnsureSSHKey`

### Restore base64 + unicode passes

#29 branched from main before #21 landed. Its version of `prePushHookContent` was the old 1-pass hook, so when #29 merged it overwrote #21's base64-decode pass + unicode-trap pass. Red-team A3 + A9 were silently re-opened.

This PR re-integrates both, keeping #29's code-scan pass intact:
- Pass 1: literal credential patterns (kept)
- Pass 2: base64 decode + re-scan (restored, closes A9)
- Pass 3: Unicode traps (restored, closes A3)
- Pass 4: code reads of secret env vars (kept, from #29)

### Tests summary

All 18 tests in `internal/agent/` pass. `SECURITY_MATRIX.md` stays accurate — every defense it claims is backed by at least one passing test.

### Not in this PR

Ada's one-off rebase of any pre-signing unsigned commits. Her next iteration's normal loop will rebase + re-sign naturally.