### PR TITLE
feat(agent): configure git commit signing via SSH key

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -130,7 +130,16 @@ func runProvision(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  ssh pubkey: %s\n", pubKey)
 		}
 
-		// 3b. Install client-side pre-push hook that scans for secret patterns.
+		// 3b. Configure git commit signing via the agent's SSH key.
+		if pubKey != "" {
+			if err := agent.ConfigureGit(osUser, homeDir, pubKey); err != nil {
+				fmt.Printf("  warning: git signing config for %s: %v\n", osUser, err)
+			} else {
+				fmt.Printf("  configured git commit signing for %s\n", osUser)
+			}
+		}
+
+		// 3c. Install client-side pre-push hook that scans for secret patterns.
 		// Defense-in-depth alongside the existing .gitignore_global + GitHub
 		// Push Protection. Refuses any push whose diff contains credentials.
 		if err := agent.InstallGitHooks(osUser, homeDir); err != nil {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -182,6 +182,45 @@ done
 exit 0
 `, SecretPatternRegex, SecretCodePatternRegex)
 
+// ConfigureGit writes SSH commit-signing configuration to the agent's
+// ~/.gitconfig and creates ~/.ssh/allowed_signers so git can verify signatures
+// locally. Idempotent — safe to call every provision.
+// pubKey is the agent's ed25519 public key (returned by EnsureSSHKey).
+func ConfigureGit(username, homeDir, pubKey string) error {
+	sshDir := filepath.Join(homeDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		return fmt.Errorf("creating .ssh dir: %w", err)
+	}
+
+	commitEmail := username + "@clem"
+	allowedSignersPath := filepath.Join(sshDir, "allowed_signers")
+	if err := os.WriteFile(allowedSignersPath, []byte(commitEmail+" "+pubKey+"\n"), 0644); err != nil {
+		return fmt.Errorf("writing allowed_signers: %w", err)
+	}
+	if err := chownToUser(allowedSignersPath, username); err != nil {
+		return fmt.Errorf("chowning allowed_signers: %w", err)
+	}
+
+	gitConfigPath := filepath.Join(homeDir, ".gitconfig")
+	existing, _ := os.ReadFile(gitConfigPath)
+	if !strings.Contains(string(existing), "gpgsign") {
+		signingKey := filepath.Join(sshDir, "id_ed25519.pub")
+		block := fmt.Sprintf(
+			"\n[user]\n\tsigningkey = %s\n[commit]\n\tgpgsign = true\n[gpg]\n\tformat = ssh\n[gpg \"ssh\"]\n\tallowedSignersFile = %s\n",
+			signingKey,
+			allowedSignersPath,
+		)
+		appended := string(existing) + block
+		if err := os.WriteFile(gitConfigPath, []byte(appended), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", gitConfigPath, err)
+		}
+		if err := chownToUser(gitConfigPath, username); err != nil {
+			return fmt.Errorf("chowning %s: %w", gitConfigPath, err)
+		}
+	}
+	return nil
+}
+
 // InstallGitHooks writes a global pre-push hook for the agent user and points
 // their git config at it via core.hooksPath. Idempotent - safe to call every
 // provision. The hook rejects pushes whose diff contains credential patterns,

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -452,6 +452,59 @@ func TestWriteEnvFile_WritesSecretsAndGitignore(t *testing.T) {
 	}
 }
 
+func TestConfigureGit_WritesSigningConfig(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	username := "testuser"
+	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
+
+	if err := ConfigureGit(username, dir, pubKey); err != nil {
+		t.Fatalf("ConfigureGit: %v", err)
+	}
+
+	asData, err := os.ReadFile(filepath.Join(dir, ".ssh", "allowed_signers"))
+	if err != nil {
+		t.Fatalf("allowed_signers not written: %v", err)
+	}
+	asStr := string(asData)
+	if !strings.Contains(asStr, username+"@clem") {
+		t.Errorf("allowed_signers missing commit email: %s", asStr)
+	}
+	if !strings.Contains(asStr, pubKey) {
+		t.Errorf("allowed_signers missing pubkey: %s", asStr)
+	}
+
+	gcData, err := os.ReadFile(filepath.Join(dir, ".gitconfig"))
+	if err != nil {
+		t.Fatalf(".gitconfig not written: %v", err)
+	}
+	gcStr := string(gcData)
+	for _, want := range []string{"gpgsign = true", "format = ssh", "allowedSignersFile", "signingkey"} {
+		if !strings.Contains(gcStr, want) {
+			t.Errorf(".gitconfig missing %q: %s", want, gcStr)
+		}
+	}
+}
+
+func TestConfigureGit_Idempotent(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
+
+	if err := ConfigureGit("testuser", dir, pubKey); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := ConfigureGit("testuser", dir, pubKey); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	gcData, _ := os.ReadFile(filepath.Join(dir, ".gitconfig"))
+	count := strings.Count(string(gcData), "gpgsign")
+	if count != 1 {
+		t.Errorf("expected gpgsign once in .gitconfig, got %d: %s", count, gcData)
+	}
+}
+
 func TestInstallGitHooks_WritesHookAndConfig(t *testing.T) {
 	withStub(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #30.

## What

Adds `ConfigureGit(username, homeDir, pubKey string) error` to `internal/agent/manager.go` and wires it into `cmd/provision.go` after `EnsureSSHKey`.

**`ConfigureGit` does two things:**

1. Writes `~/.ssh/allowed_signers` containing `<username>@clem <pubkey>` so git can verify signatures locally.
2. Appends a signing block to `~/.gitconfig` (idempotent — skipped if `gpgsign` already present):

```
[user]
    signingkey = /home/<user>/.ssh/id_ed25519.pub
[commit]
    gpgsign = true
[gpg]
    format = ssh
[gpg "ssh"]
    allowedSignersFile = /home/<user>/.ssh/allowed_signers
```

**Operator note:** GitHub verifies the signature against a key uploaded to the agent's GitHub account as a *Signing Key* (not Authentication Key). That upload step is manual — out of scope per the issue.

## Tests

- `TestConfigureGit_WritesSigningConfig` — asserts `allowed_signers` contains commit email + pubkey, and `.gitconfig` contains all four signing stanzas.
- `TestConfigureGit_Idempotent` — calls twice, asserts `gpgsign` appears exactly once in `.gitconfig`.

Both run without root via the `stubExec` seam introduced in #34.

## Test plan

- [x] `go test -race -v ./internal/agent/` — 23 tests pass, no root required
- [x] `go build ./...` — clean