### PR TITLE
feat(release): publish multi-arch sample image to GHCR on tag

### DIFF
--- a/.github/workflows/publish-samples.yml
+++ b/.github/workflows/publish-samples.yml
@@ -1,0 +1,47 @@
+name: publish-samples
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/jahwag/clem-sample
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: samples/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # --- build stage ---------------------------------------------------
-FROM docker.io/library/golang:1.22-bookworm AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/clem .
 # --- runtime stage -------------------------------------------------
 FROM docker.io/library/ubuntu:24.04
 
+ARG TARGETARCH
 ARG SOPS_VERSION=3.12.2
 ARG YQ_VERSION=4.52.5
 
@@ -36,12 +37,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/apt/*
 
 # sops (binary release)
-RUN curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+RUN curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${TARGETARCH}" \
         -o /usr/local/bin/sops \
     && chmod +x /usr/local/bin/sops
 
 # yq (binary release — needed by clem vault decrypt merge)
-RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH}" \
         -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
 
@@ -51,13 +52,14 @@ RUN pip3 install --break-system-packages --ignore-installed \
 
 # ttyd (read-only web terminal — optional, enabled when web_terminal_port set)
 ARG TTYD_VERSION=1.7.7
-RUN curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
+RUN TTYD_ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "aarch64" || echo "x86_64") \
+    && curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" \
         -o /usr/local/bin/ttyd \
     && chmod +x /usr/local/bin/ttyd
 
 # Slack MCP server (korotovsky/slack-mcp-server — Go binary, MIT)
 ARG SLACK_MCP_VERSION=v1.2.3
-RUN curl -fsSL "https://github.com/korotovsky/slack-mcp-server/releases/download/${SLACK_MCP_VERSION}/slack-mcp-server-linux-amd64" \
+RUN curl -fsSL "https://github.com/korotovsky/slack-mcp-server/releases/download/${SLACK_MCP_VERSION}/slack-mcp-server-linux-${TARGETARCH}" \
         -o /usr/local/bin/slack-mcp-server \
     && chmod +x /usr/local/bin/slack-mcp-server
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -7,9 +7,22 @@ Samples today:
 - [`ollama-nemotron-4b/`](ollama-nemotron-4b/) - **Discord** coordination + local [NVIDIA Nemotron 3 Nano 4B](https://ollama.com/library/nemotron-3-nano) via Ollama. 2.8 GB, fits an 8 GB MacBook Air, emits proper tool_use blocks.
 - [`slack-nemotron-4b/`](slack-nemotron-4b/) - **Slack** coordination, same local model. Uses [korotovsky/slack-mcp-server](https://github.com/korotovsky/slack-mcp-server).
 
+## Quick start (prebuilt image)
+
+No clone required. Pull and run the latest published image:
+
+```bash
+docker run --rm -it --privileged \
+  -e DISCORD_TOKEN=... -e DISCORD_SERVER_ID=... \
+  -p 7681:7681 \
+  ghcr.io/jahwag/clem-sample:latest
+```
+
+Images are published to GHCR on every release tag for `linux/amd64` and `linux/arm64`.
+
 ## Build
 
-From the repo root:
+From the repo root (to customise the sample):
 
 ```bash
 docker build -f samples/Dockerfile --build-arg SAMPLE=ollama-nemotron-4b -t clem-nemotron .


### PR DESCRIPTION
Closes #13.

## What

Adds `.github/workflows/publish-samples.yml`: triggers on `v*` tags and `workflow_dispatch`, builds `samples/Dockerfile` for `linux/amd64,linux/arm64`, pushes:
- `ghcr.io/jahwag/clem-sample:<tag>`
- `ghcr.io/jahwag/clem-sample:latest`

Permissions: `packages: write`, `contents: read` — uses `GITHUB_TOKEN` only, no new secrets.

## Dockerfile multi-arch fixes

The existing Dockerfile hardcoded `amd64`/`x86_64` in four binary downloads. Added `ARG TARGETARCH` in the runtime stage and made each download arch-aware:

| Binary | Before | After |
|--------|--------|-------|
| sops | `linux.amd64` | `linux.${TARGETARCH}` |
| yq | `yq_linux_amd64` | `yq_linux_${TARGETARCH}` |
| ttyd | `ttyd.x86_64` | `ttyd.$(amd64→x86_64, arm64→aarch64)` |
| slack-mcp-server | `linux-amd64` | `linux-${TARGETARCH}` |

Builder stage uses `--platform=$BUILDPLATFORM` so cross-compilation happens on the native runner.

## README

Added "Quick start (prebuilt image)" section with zero-clone `docker run` command above the existing build instructions.

## Test plan

- [ ] `workflow_dispatch` run on this branch produces `ghcr.io/jahwag/clem-sample` tags for both amd64 and arm64
- [ ] `docker manifest inspect ghcr.io/jahwag/clem-sample:latest` shows two platform entries
- [ ] Existing `docker build -f samples/Dockerfile ...` still works (TARGETARCH defaults to host arch when not set by BuildKit)