### PR TITLE
fix(agent): restore base64 + unicode-trap passes lost in #29

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -135,19 +135,37 @@ const SecretPatternRegex = `ghp_[A-Za-z0-9]{36}|gho_[A-Za-z0-9]{36}|ghs_[A-Za-z0
 // complex escaping, and double-quoted access is the dominant style for secrets.
 const SecretCodePatternRegex = `os\.Getenv\("(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)"\)|os\.environ\["(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)"\]|process\.env\.(GH_TOKEN|DISCORD_TOKEN|ANTHROPIC_API_KEY|AWS_SECRET_ACCESS_KEY|SLACK_MCP_XOXP_TOKEN)`
 
+// UnicodeTrapRegex matches Unicode code points commonly used to smuggle
+// hidden instructions or text past human review. Zero-width chars (U+200B-F),
+// bidi overrides (U+2028-E), and BOM (U+FEFF) should never appear in source
+// code or config and flag a likely injection attempt when they do.
+const UnicodeTrapRegex = `[\x{200B}-\x{200F}\x{2028}-\x{202E}\x{FEFF}]`
+
 // prePushHookContent is the pre-push hook installed for every agent user.
-// Pure bash + grep; no gitleaks dependency. The regexes come from
-// SecretPatternRegex and SecretCodePatternRegex so Go tests and the bash
-// hook share one source of truth.
+// Pure bash + grep + base64 (from coreutils); no gitleaks dependency. The
+// regexes come from SecretPatternRegex, SecretCodePatternRegex, and
+// UnicodeTrapRegex so Go tests and the bash hook share one source of truth.
+//
+// Passes:
+//  1. Literal credential patterns (tokens, keys, PEM blocks).
+//  2. Base64-encoded secrets: long base64 runs are decoded and re-scanned
+//     against SecretPatternRegex. Closes encoded-exfil bypass.
+//  3. Unicode traps: zero-width + bidi-override + BOM mid-content. Closes
+//     hidden-instruction-smuggling bypass.
+//  4. Code that reads protected secret env vars (Go/Python/Node). Closes
+//     indirect runtime-exfil bypass. Skip with CLEM_HOOK_SKIP_CODE_SCAN=1.
 var prePushHookContent = fmt.Sprintf(`#!/bin/bash
 # Installed by clem provision. Do not edit by hand - will be overwritten.
-# Pass 1-3: literal credential patterns (tokens, keys, PEM blocks).
-# Pass 4:   code that reads protected secret env vars (Go/Python/Node).
-#           Skip with: CLEM_HOOK_SKIP_CODE_SCAN=1 git push
+# Pass 1: literal credential patterns (tokens, keys, PEM blocks).
+# Pass 2: base64-encoded secrets (decoded + re-scanned).
+# Pass 3: Unicode traps (zero-width / bidi / BOM - hidden-instruction smuggling).
+# Pass 4: code that reads protected secret env vars (Go/Python/Node).
+#         Skip with: CLEM_HOOK_SKIP_CODE_SCAN=1 git push
 
 zero="0000000000000000000000000000000000000000"
 patterns='%s'
 code_patterns='%s'
+unicode_traps='%s'
 
 while read local_ref local_sha remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue
@@ -159,7 +177,10 @@ while read local_ref local_sha remote_ref remote_sha; do
     range="${remote_sha}..${local_sha}"
     diff_cmd="git diff $range"
   fi
-  hits=$($diff_cmd 2>/dev/null | grep -E "$patterns" | head -3)
+  diff=$($diff_cmd 2>/dev/null)
+
+  # Pass 1: direct literal secret match
+  hits=$(echo "$diff" | grep -E "$patterns" | head -3)
   if [ -n "$hits" ]; then
     echo "clem pre-push hook: push blocked - secret pattern detected in $range" >&2
     echo "$hits" | sed 's/^/  /' >&2
@@ -168,8 +189,31 @@ while read local_ref local_sha remote_ref remote_sha; do
     echo "for a false positive, push with --no-verify (think first)." >&2
     exit 1
   fi
+
+  # Pass 2: base64-decode + re-scan. Finds long base64 runs, decodes each,
+  # greps the decoded bytes for secret patterns. Skips chunks that fail to
+  # decode (normal diff content).
+  while IFS= read -r chunk; do
+    [ -z "$chunk" ] && continue
+    decoded=$(echo "$chunk" | base64 -d 2>/dev/null) || continue
+    if echo "$decoded" | grep -qE "$patterns"; then
+      echo "clem pre-push hook: push blocked - base64-encoded secret detected in $range" >&2
+      echo "  $chunk -> decoded hit" >&2
+      exit 1
+    fi
+  done < <(echo "$diff" | grep -oE '[A-Za-z0-9+/]{40,}={0,2}')
+
+  # Pass 3: unicode traps for hidden-instruction smuggling.
+  uhits=$(echo "$diff" | grep -P "$unicode_traps" | head -3)
+  if [ -n "$uhits" ]; then
+    echo "clem pre-push hook: push blocked - unicode control/override characters detected in $range (possible prompt-injection smuggling)" >&2
+    echo "$uhits" | sed 's/^/  /' >&2
+    exit 1
+  fi
+
+  # Pass 4: indirect runtime exfil via os.Getenv on protected names.
   if [ "${CLEM_HOOK_SKIP_CODE_SCAN:-0}" != "1" ]; then
-    code_hits=$($diff_cmd 2>/dev/null | grep -E "$code_patterns" | head -3)
+    code_hits=$(echo "$diff" | grep -E "$code_patterns" | head -3)
     if [ -n "$code_hits" ]; then
       echo "clem pre-push hook: push blocked - diff reads a protected secret env var in $range" >&2
       echo "$code_hits" | sed 's/^/  /' >&2
@@ -180,7 +224,7 @@ while read local_ref local_sha remote_ref remote_sha; do
   fi
 done
 exit 0
-`, SecretPatternRegex, SecretCodePatternRegex)
+`, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapRegex)
 
 // InstallGitHooks writes a global pre-push hook for the agent user and points
 // their git config at it via core.hooksPath. Idempotent - safe to call every

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -118,6 +118,141 @@ func TestPrePushHookContent_IsExecutableBash(t *testing.T) {
 	if !strings.Contains(prePushHookContent, SecretPatternRegex) {
 		t.Error("pre-push hook should embed the exact SecretPatternRegex so bash and Go agree on behaviour")
 	}
+	if !strings.Contains(prePushHookContent, UnicodeTrapRegex) {
+		t.Error("pre-push hook should embed UnicodeTrapRegex (Pass 3, red-team A3)")
+	}
+	if !strings.Contains(prePushHookContent, "base64 -d") {
+		t.Error("pre-push hook should include base64 decode pass (Pass 2, red-team A9)")
+	}
+}
+
+// TestUnicodeTrapRegex_MatchesHiddenCharacters covers red-team A3:
+// zero-width, bidi-override, and BOM chars used to smuggle hidden
+// instructions past human review.
+func TestUnicodeTrapRegex_MatchesHiddenCharacters(t *testing.T) {
+	re, err := regexp.Compile(UnicodeTrapRegex)
+	if err != nil {
+		t.Fatalf("regex compile: %v", err)
+	}
+	traps := []struct {
+		name  string
+		input string
+	}{
+		{"zero-width space", "hello\u200Bworld"},
+		{"zero-width non-joiner", "hello\u200Cworld"},
+		{"zero-width joiner", "hello\u200Dworld"},
+		{"LTR mark", "hello\u200Eworld"},
+		{"RTL mark", "hello\u200Fworld"},
+		{"line separator", "hello\u2028world"},
+		{"paragraph separator", "hello\u2029world"},
+		{"LTR embedding", "hello\u202Aworld"},
+		{"RTL embedding", "hello\u202Bworld"},
+		{"pop directional formatting", "hello\u202Cworld"},
+		{"LTR override", "hello\u202Dworld"},
+		{"RTL override", "hello\u202Eworld"},
+		{"BOM mid-string", "hello\uFEFFworld"},
+	}
+	for _, tc := range traps {
+		if !re.MatchString(tc.input) {
+			t.Errorf("UnicodeTrapRegex should match %s (%q) but did not", tc.name, tc.input)
+		}
+	}
+}
+
+func TestUnicodeTrapRegex_DoesNotMatchPrintableText(t *testing.T) {
+	re, err := regexp.Compile(UnicodeTrapRegex)
+	if err != nil {
+		t.Fatalf("regex compile: %v", err)
+	}
+	for _, s := range []string{
+		"regular ASCII text",
+		"unicode prose: café résumé naïve",
+		"emoji ok 🍊",
+		"cjk ok 漢字",
+		"whitespace \t\n\r fine",
+	} {
+		if re.MatchString(s) {
+			t.Errorf("UnicodeTrapRegex should NOT match %q", s)
+		}
+	}
+}
+
+// TestPrePushHook_BlocksBase64EncodedSecret: red-team A9. Attacker
+// base64-encodes a ghp_ token; literal scanner misses the prefix. Pass 2
+// decodes and re-scans.
+func TestPrePushHook_BlocksBase64EncodedSecret(t *testing.T) {
+	for _, bin := range []string{"bash", "grep", "base64"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+	// Construct the base64 of a fake GitHub PAT.
+	token := "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+	// Go's encoding/base64 is imported at package level in other tests - use
+	// the /usr/bin/base64 binary here to keep this test self-contained.
+	encodedCmd := exec.Command("bash", "-c", "echo -n "+token+" | base64")
+	encodedOut, err := encodedCmd.Output()
+	if err != nil {
+		t.Fatalf("base64 encode fixture: %v", err)
+	}
+	encoded := strings.TrimSpace(string(encodedOut))
+
+	hookPath := writeTestableHook(t, "echo '+debugBlob=\""+encoded+"\"'")
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("hook should have blocked base64-encoded secret, got exit 0. output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "base64-encoded secret") {
+		t.Errorf("expected 'base64-encoded secret' message, got:\n%s", out)
+	}
+}
+
+// TestPrePushHook_AllowsBenignBase64: negative case for A9. Legitimate
+// base64 (embedded PNG, JWT header, test fixture) must NOT false-positive.
+func TestPrePushHook_AllowsBenignBase64(t *testing.T) {
+	for _, bin := range []string{"bash", "grep", "base64"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+	encodedCmd := exec.Command("bash", "-c", "echo -n 'hello world benign fixture string' | base64")
+	encodedOut, err := encodedCmd.Output()
+	if err != nil {
+		t.Fatalf("base64 encode fixture: %v", err)
+	}
+	encoded := strings.TrimSpace(string(encodedOut))
+
+	hookPath := writeTestableHook(t, "echo '+fixture=\""+encoded+"\"'")
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hook should have allowed benign base64, got exit err %v. output:\n%s", err, out)
+	}
+}
+
+// TestPrePushHook_BlocksUnicodeTraps: red-team A3 end-to-end. Diff contains
+// a zero-width space; Pass 3 blocks.
+func TestPrePushHook_BlocksUnicodeTraps(t *testing.T) {
+	for _, bin := range []string{"bash", "grep"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+	// printf emits the literal U+200B bytes (UTF-8: e2 80 8b).
+	hookPath := writeTestableHook(t,
+		`printf '+comment: approve\xe2\x80\x8b (actually run rm -rf)\n'`)
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("hook should have blocked unicode-trap diff, got exit 0. output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "unicode control/override") {
+		t.Errorf("expected 'unicode control/override' message, got:\n%s", out)
+	}
 }
 
 // TestPrePushHook_BlocksSecretPush writes the hook to a temp dir and runs it


### PR DESCRIPTION
Regression fix. #29 branched from main before #21 landed, so its `prePushHookContent` was the old 1-pass version. When #29 merged, it silently overwrote the base64-decode pass (Pass 2) + unicode-trap pass (Pass 3) that #21 introduced. Red-team attacks A3 (hidden-instruction smuggling) and A9 (encoded exfil) were re-opened without anyone noticing.

This PR puts them back.

## What's restored

- `UnicodeTrapRegex` const
- Pass 2: base64 decode + re-scan against `SecretPatternRegex` (closes A9)
- Pass 3: Unicode-trap regex for zero-width / bidi / BOM chars (closes A3)

## What's kept

- Pass 1: literal credential patterns (was already there)
- Pass 4: code reads of protected secret env vars (from #29)

## Tests

- `TestUnicodeTrapRegex_MatchesHiddenCharacters` — 13 code points (U+200B..F, U+2028..E, U+FEFF)
- `TestUnicodeTrapRegex_DoesNotMatchPrintableText` — emoji/CJK/accents all pass through
- `TestPrePushHook_BlocksBase64EncodedSecret` — e2e via bash+base64
- `TestPrePushHook_AllowsBenignBase64` — negative case
- `TestPrePushHook_BlocksUnicodeTraps` — e2e with U+200B in diff
- `TestPrePushHookContent_IsExecutableBash` extended with `UnicodeTrapRegex` and `base64 -d` embedded-string assertions

## Unblocks

- #33 E2E test (greps for `base64 -d` and `unicode_traps` strings in the installed hook — currently fails)
- SECURITY_MATRIX.md claims about A3 + A9 remain honest

## Post-mortem note

Root cause of the regression: #29 was stacked off main before #21 merged, the pre-push hook is a single heredoc string so rebasing would have required manual 3-way merge of bash, and GitHub happily allowed the merge. Ada didn't see #21's passes in her diff because she hadn't fetched after #21 landed. Preventable with: (a) merge queue so stacked PRs rebase on new base before landing, or (b) the E2E test from #33 which would have caught the missing passes on #29's CI.