### PR TITLE
feat(provision): set per-agent git user.name + user.email

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -105,6 +105,10 @@ func runProvision(cmd *cobra.Command, args []string) error {
 			} else if secrets["WRANGLER_OAUTH_TOKEN"] != "" {
 				fmt.Printf("  wrote wrangler config for %s\n", osUser)
 			}
+
+			if secrets["GH_TOKEN"] != "" && ac.GitEmail == "" {
+				fmt.Printf("  warning: agent %s has GH_TOKEN but no git_email in clem.yaml — commits may leak operator identity\n", agentKey)
+			}
 		}
 
 		// 3. Write Claude Code settings (skip MCP trust dialog, onboarding)
@@ -130,12 +134,12 @@ func runProvision(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  ssh pubkey: %s\n", pubKey)
 		}
 
-		// 3b. Configure git commit signing via the agent's SSH key.
+		// 3b. Configure git commit signing and user identity via the agent's SSH key.
 		if pubKey != "" {
-			if err := agent.ConfigureGit(osUser, homeDir, pubKey); err != nil {
-				fmt.Printf("  warning: git signing config for %s: %v\n", osUser, err)
+			if err := agent.ConfigureGit(osUser, homeDir, pubKey, ac.GitName, ac.GitEmail); err != nil {
+				fmt.Printf("  warning: git config for %s: %v\n", osUser, err)
 			} else {
-				fmt.Printf("  configured git commit signing for %s\n", osUser)
+				fmt.Printf("  configured git signing + identity for %s\n", osUser)
 			}
 		}
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -226,11 +226,12 @@ done
 exit 0
 `, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapRegex)
 
-// ConfigureGit writes SSH commit-signing configuration to the agent's
-// ~/.gitconfig and creates ~/.ssh/allowed_signers so git can verify signatures
-// locally. Idempotent — safe to call every provision.
-// pubKey is the agent's ed25519 public key (returned by EnsureSSHKey).
-func ConfigureGit(username, homeDir, pubKey string) error {
+// ConfigureGit writes SSH commit-signing configuration and optionally the git
+// user identity to the agent's ~/.gitconfig. Idempotent — safe to call every
+// provision. pubKey is the agent's ed25519 public key (returned by EnsureSSHKey).
+// gitName and gitEmail, when non-empty, set git user.name / user.email; existing
+// values are preserved (operator-set identity is never overwritten).
+func ConfigureGit(username, homeDir, pubKey, gitName, gitEmail string) error {
 	sshDir := filepath.Join(homeDir, ".ssh")
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
 		return fmt.Errorf("creating .ssh dir: %w", err)
@@ -247,22 +248,34 @@ func ConfigureGit(username, homeDir, pubKey string) error {
 
 	gitConfigPath := filepath.Join(homeDir, ".gitconfig")
 	existing, _ := os.ReadFile(gitConfigPath)
-	if !strings.Contains(string(existing), "gpgsign") {
+	content := string(existing)
+
+	var extra string
+	if !strings.Contains(content, "gpgsign") {
 		signingKey := filepath.Join(sshDir, "id_ed25519.pub")
-		block := fmt.Sprintf(
-			"\n[user]\n\tsigningkey = %s\n[commit]\n\tgpgsign = true\n[gpg]\n\tformat = ssh\n[gpg \"ssh\"]\n\tallowedSignersFile = %s\n",
-			signingKey,
-			allowedSignersPath,
+		extra += fmt.Sprintf(
+			"\n[user]\n\tsigningkey = %s\n[commit]\n\tgpgsign = true\n[gpg]\n\tformat = ssh\n[gpg \"ssh\"]\n\tallowedSignersFile = %s",
+			signingKey, allowedSignersPath,
 		)
-		appended := string(existing) + block
-		if err := os.WriteFile(gitConfigPath, []byte(appended), 0644); err != nil {
-			return fmt.Errorf("writing %s: %w", gitConfigPath, err)
-		}
-		if err := chownToUser(gitConfigPath, username); err != nil {
-			return fmt.Errorf("chowning %s: %w", gitConfigPath, err)
-		}
 	}
-	return nil
+	var identityLines []string
+	if gitName != "" && !strings.Contains(content, "\tname = ") {
+		identityLines = append(identityLines, "\tname = "+gitName)
+	}
+	if gitEmail != "" && !strings.Contains(content, "\temail = ") {
+		identityLines = append(identityLines, "\temail = "+gitEmail)
+	}
+	if len(identityLines) > 0 {
+		extra += "\n[user]\n" + strings.Join(identityLines, "\n")
+	}
+	if extra == "" {
+		return nil
+	}
+
+	if err := os.WriteFile(gitConfigPath, []byte(content+extra+"\n"), 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", gitConfigPath, err)
+	}
+	return chownToUser(gitConfigPath, username)
 }
 
 // InstallGitHooks writes a global pre-push hook for the agent user and points

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -593,7 +593,7 @@ func TestConfigureGit_WritesSigningConfig(t *testing.T) {
 	username := "testuser"
 	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
 
-	if err := ConfigureGit(username, dir, pubKey); err != nil {
+	if err := ConfigureGit(username, dir, pubKey, "", ""); err != nil {
 		t.Fatalf("ConfigureGit: %v", err)
 	}
 
@@ -621,22 +621,75 @@ func TestConfigureGit_WritesSigningConfig(t *testing.T) {
 	}
 }
 
+func TestConfigureGit_WritesUserIdentity(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
+
+	if err := ConfigureGit("testuser", dir, pubKey, "clauderesearch", "212849679+clauderesearch@users.noreply.github.com"); err != nil {
+		t.Fatalf("ConfigureGit: %v", err)
+	}
+
+	gcData, err := os.ReadFile(filepath.Join(dir, ".gitconfig"))
+	if err != nil {
+		t.Fatalf(".gitconfig not written: %v", err)
+	}
+	gcStr := string(gcData)
+	if !strings.Contains(gcStr, "\tname = clauderesearch") {
+		t.Errorf(".gitconfig missing name: %s", gcStr)
+	}
+	if !strings.Contains(gcStr, "\temail = 212849679+clauderesearch@users.noreply.github.com") {
+		t.Errorf(".gitconfig missing email: %s", gcStr)
+	}
+}
+
+func TestConfigureGit_PreservesExistingIdentity(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
+
+	// pre-existing operator-set identity
+	existing := "[user]\n\tname = operator\n\temail = operator@example.com\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitconfig"), []byte(existing), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ConfigureGit("testuser", dir, pubKey, "clauderesearch", "bot@example.com"); err != nil {
+		t.Fatalf("ConfigureGit: %v", err)
+	}
+
+	gcData, _ := os.ReadFile(filepath.Join(dir, ".gitconfig"))
+	gcStr := string(gcData)
+	if strings.Contains(gcStr, "clauderesearch") {
+		t.Errorf("ConfigureGit overwrote operator name: %s", gcStr)
+	}
+	if strings.Contains(gcStr, "bot@example.com") {
+		t.Errorf("ConfigureGit overwrote operator email: %s", gcStr)
+	}
+}
+
 func TestConfigureGit_Idempotent(t *testing.T) {
 	withStub(t)
 	dir := t.TempDir()
 	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
 
-	if err := ConfigureGit("testuser", dir, pubKey); err != nil {
+	if err := ConfigureGit("testuser", dir, pubKey, "ada", "ada@clem.local"); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
-	if err := ConfigureGit("testuser", dir, pubKey); err != nil {
+	if err := ConfigureGit("testuser", dir, pubKey, "ada", "ada@clem.local"); err != nil {
 		t.Fatalf("second call: %v", err)
 	}
 
 	gcData, _ := os.ReadFile(filepath.Join(dir, ".gitconfig"))
-	count := strings.Count(string(gcData), "gpgsign")
-	if count != 1 {
-		t.Errorf("expected gpgsign once in .gitconfig, got %d: %s", count, gcData)
+	gcStr := string(gcData)
+	if count := strings.Count(gcStr, "gpgsign"); count != 1 {
+		t.Errorf("expected gpgsign once in .gitconfig, got %d: %s", count, gcStr)
+	}
+	if count := strings.Count(gcStr, "\tname = ada"); count != 1 {
+		t.Errorf("expected name once in .gitconfig, got %d: %s", count, gcStr)
+	}
+	if count := strings.Count(gcStr, "\temail = ada@clem.local"); count != 1 {
+		t.Errorf("expected email once in .gitconfig, got %d: %s", count, gcStr)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,13 @@ type AgentConfig struct {
 	// than the main session. Accepts model aliases (sonnet, haiku, opus) or
 	// full IDs (claude-sonnet-4-6). Empty = inherit main model.
 	SubagentModel string `yaml:"subagent_model"`
+	// GitName and GitEmail set the agent's git user identity during provision.
+	// Without these, commits are authored with whatever identity the OAuth login
+	// stored, which may leak the operator's personal email into public history.
+	// If GitEmail is unset and the agent's vault contains GH_TOKEN, provision
+	// logs a warning at runtime.
+	GitName  string `yaml:"git_name"`
+	GitEmail string `yaml:"git_email"`
 }
 
 // RuntimeKind returns the normalized runtime name for this agent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -242,3 +242,42 @@ agents:
 		t.Errorf("SubagentModel = %q, want %q (bedrock is Anthropic-backed)", got, DefaultSubagentModel)
 	}
 }
+
+func TestLoad_GitIdentityParsed(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Ada"
+    model: "claude-sonnet-4-6"
+    git_name: "clauderesearch"
+    git_email: "212849679+clauderesearch@users.noreply.github.com"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ac := cfg.Agents["lead"]
+	if ac.GitName != "clauderesearch" {
+		t.Errorf("GitName = %q, want %q", ac.GitName, "clauderesearch")
+	}
+	if ac.GitEmail != "212849679+clauderesearch@users.noreply.github.com" {
+		t.Errorf("GitEmail = %q, want %q", ac.GitEmail, "212849679+clauderesearch@users.noreply.github.com")
+	}
+}
+
+func TestLoad_GitIdentityOptional(t *testing.T) {
+	path := writeYAML(t, minYAML(""))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ac := cfg.Agents["lead"]
+	if ac.GitName != "" || ac.GitEmail != "" {
+		t.Errorf("expected empty git identity when unset, got name=%q email=%q", ac.GitName, ac.GitEmail)
+	}
+}


### PR DESCRIPTION
Closes #38.

## What

Extends `ConfigureGit` (added in #35) to accept `git_name` and `git_email` from the per-agent `clem.yaml` config and write them to `~/.gitconfig` during `clem provision`.

New fields:

```yaml
agents:
  lead:
    git_name: clauderesearch
    git_email: 212849679+clauderesearch@users.noreply.github.com
```

## Behaviour

- Both fields are optional. Provision succeeds without them.
- **Idempotent**: existing `name =` / `email =` entries in `~/.gitconfig` are never overwritten, so operator-configured identity is preserved on re-provision.
- **Warning**: if an agent's vault contains `GH_TOKEN` but `git_email` is unset, provision logs a warning so the leak is surfaced loudly before reaching public history.

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `GitName`, `GitEmail` to `AgentConfig` |
| `internal/agent/manager.go` | Extend `ConfigureGit` signature; write identity block when fields are set and not already present |
| `cmd/provision.go` | Pass `ac.GitName`, `ac.GitEmail` to `ConfigureGit`; warn on GH_TOKEN + missing email |
| `internal/config/config_test.go` | Tests: fields parse correctly; optional when unset |
| `internal/agent/manager_test.go` | Tests: identity written; existing identity preserved; idempotent |