### PR TITLE
feat(samples): add anthropic variant; publish 3 images on release

### DIFF
--- a/.github/workflows/publish-samples.yml
+++ b/.github/workflows/publish-samples.yml
@@ -18,6 +18,15 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - sample: anthropic
+            tag_suffix: ""
+          - sample: ollama-nemotron-4b
+            tag_suffix: "-ollama"
+          - sample: slack-nemotron-4b
+            tag_suffix: "-slack"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +50,9 @@ jobs:
           context: .
           file: samples/Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            SAMPLE=${{ matrix.sample }}
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}${{ matrix.tag_suffix }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}${{ matrix.tag_suffix }}:latest

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,8 +4,9 @@ Self-contained Dockerised setup for trying clem without touching your host.
 
 Samples today:
 
-- [`ollama-nemotron-4b/`](ollama-nemotron-4b/) - **Discord** coordination + local [NVIDIA Nemotron 3 Nano 4B](https://ollama.com/library/nemotron-3-nano) via Ollama. 2.8 GB, fits an 8 GB MacBook Air, emits proper tool_use blocks.
-- [`slack-nemotron-4b/`](slack-nemotron-4b/) - **Slack** coordination, same local model. Uses [korotovsky/slack-mcp-server](https://github.com/korotovsky/slack-mcp-server).
+- [`anthropic/`](anthropic/) - **Discord** coordination + [Anthropic Claude API](https://www.anthropic.com/). Bring your own API key; no local GPU needed. Published as `ghcr.io/jahwag/clem-sample:latest`.
+- [`ollama-nemotron-4b/`](ollama-nemotron-4b/) - **Discord** coordination + local [NVIDIA Nemotron 3 Nano 4B](https://ollama.com/library/nemotron-3-nano) via Ollama. 2.8 GB, fits an 8 GB MacBook Air, emits proper tool_use blocks. Published as `ghcr.io/jahwag/clem-sample:latest-ollama`.
+- [`slack-nemotron-4b/`](slack-nemotron-4b/) - **Slack** coordination, same local model. Uses [korotovsky/slack-mcp-server](https://github.com/korotovsky/slack-mcp-server). Published as `ghcr.io/jahwag/clem-sample:latest-slack`.
 
 ## Quick start (prebuilt image)
 

--- a/samples/anthropic/README.md
+++ b/samples/anthropic/README.md
@@ -1,0 +1,53 @@
+# clem sample — Anthropic
+
+Single-agent setup using Anthropic's Claude API directly. No local GPU or model
+download needed — just an API key.
+
+## Prerequisites
+
+- An [Anthropic API key](https://console.anthropic.com/)
+- A Discord bot token and server (see [Discord setup](../../docs/discord.md) if present, or the main README)
+- A GitHub personal access token (for the agent to push code)
+
+## Quick start (prebuilt image)
+
+```bash
+podman run -d --name clem-sample --systemd=always \
+  -e DISCORD_SERVER_ID=... \
+  -e DISCORD_GENERAL_CHANNEL=... \
+  -e DISCORD_TASKS_CHANNEL=... \
+  -e DISCORD_ALERTS_CHANNEL=... \
+  -e DISCORD_LESSONS_CHANNEL=... \
+  -p 7681:7681 \
+  ghcr.io/jahwag/clem-sample:latest
+```
+
+Then provision the agent:
+
+```bash
+podman exec -it clem-sample bash
+clem vault init
+clem vault set anthropic ANTHROPIC_API_KEY=sk-ant-...
+clem vault set github    GH_TOKEN=ghp_...
+clem vault set discord-lead DISCORD_TOKEN=...
+sudo clem provision
+```
+
+## Build from source
+
+From the repo root:
+
+```bash
+docker build -f samples/Dockerfile --build-arg SAMPLE=anthropic -t clem-anthropic .
+```
+
+## Runtime modes
+
+- **Tour** — interactive shell; explore `clem init` / `clem vault` without real credentials.
+- **Runtime** — `--systemd=always` (podman) or `--privileged` (docker); `clem provision`
+  creates OS users and starts services.
+
+## Model
+
+Defaults to `claude-sonnet-4-6`. Change the `model:` field in `clem.yaml` or override at
+build time with `--build-arg SAMPLE=anthropic` and a customised `samples/anthropic/clem.yaml`.

--- a/samples/anthropic/clem.yaml
+++ b/samples/anthropic/clem.yaml
@@ -1,0 +1,37 @@
+# Sample clem.yaml — Anthropic Claude via the official API.
+# Bring your own API key; no local GPU or model download required.
+#
+# Prerequisites:
+#   clem vault init
+#   clem vault set anthropic ANTHROPIC_API_KEY=sk-ant-...
+#   clem vault set github    GH_TOKEN=ghp_...
+#   clem vault set discord-lead DISCORD_TOKEN=...
+
+project: sample
+
+coordination:
+  backend: discord
+  server_id: "${DISCORD_SERVER_ID}"
+  channels:
+    general: "${DISCORD_GENERAL_CHANNEL}"
+    tasks:   "${DISCORD_TASKS_CHANNEL}"
+    alerts:  "${DISCORD_ALERTS_CHANNEL}"
+    lessons: "${DISCORD_LESSONS_CHANNEL}"
+
+agents:
+  lead:
+    name: "Clementine"
+    role: "Lead Software Engineer"
+    runtime: claude-code
+    model: "claude-sonnet-4-6"
+    provider: anthropic
+    iteration: 30s
+    web_terminal_port: 7681
+    web_terminal_bind: 0.0.0.0       # safe inside container; host firewall / podman port map is the guard
+    vaults: [anthropic, github, discord-lead]
+    prompt: >-
+      You are the {{agent.name}} Discord bot. Messages authored by {{agent.name}} in
+      #general are your own previous posts — do not respond to yourself.
+      Every iteration: read the last 5 messages in #general via mcp__discord-bot__read_messages.
+      If a message from a different user addresses you or mentions {{agent.name}}, reply via
+      mcp__discord-bot__send_message. Otherwise do nothing. Then run bash: kill $PPID


### PR DESCRIPTION
Closes #41.

## What

Add `samples/anthropic/` — a Discord + Anthropic Claude API sample requiring no local GPU. The `samples/Dockerfile` already defaults to `SAMPLE=anthropic`; the missing directory was the sole cause of the publish workflow failure on v0.2.0.

Update `publish-samples.yml` to use a build matrix so all three variants are published on each release tag:

| Tag | Sample |
|-----|--------|
| `:latest`, `:vX.Y.Z` | `anthropic` (default) |
| `:latest-ollama`, `:vX.Y.Z-ollama` | `ollama-nemotron-4b` |
| `:latest-slack`, `:vX.Y.Z-slack` | `slack-nemotron-4b` |

## Changes

| File | Change |
|------|--------|
| `samples/anthropic/clem.yaml` | New — Discord + Anthropic API agent config |
| `samples/anthropic/README.md` | New — quick-start instructions for the variant |
| `samples/README.md` | Add anthropic entry; note which GHCR tag each variant publishes to |
| `.github/workflows/publish-samples.yml` | Replace single build step with 3-way matrix |