### PR TITLE
fix(samples): boot systemd instead of bash in detached mode

### DIFF
--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -74,7 +74,7 @@ ARG SAMPLE=anthropic
 WORKDIR /srv/team
 COPY samples/${SAMPLE}/clem.yaml ./clem.yaml
 
-# Default: interactive shell. To boot systemd instead (so `clem provision`
-# can start services), run with `--entrypoint /sbin/init --privileged`.
-# See samples/<sample>/README.md for full instructions.
-CMD ["/bin/bash"]
+# Boot systemd so `clem provision` can install and start services.
+# Run with: podman run -d --systemd=always <image>
+# For an interactive shell instead: docker run -it --entrypoint /bin/bash <image>
+CMD ["/sbin/init"]


### PR DESCRIPTION
Closes #42.

## What

`CMD ["/bin/bash"]` exits immediately when the container runs without a TTY (detached mode). This makes `podman run -d --systemd=always clem-sample` unusable — the container stops at once and subsequent `podman exec` fails.

Changed `CMD` to `/sbin/init` so systemd boots and keeps the container alive. The `--systemd=always` flag on podman works correctly with an init-based CMD.

## Changes

| File | Change |
|------|--------|
| `samples/Dockerfile` | `CMD ["/sbin/init"]` replacing `CMD ["/bin/bash"]`; updated comment to reflect detached-first workflow |

## Verification

```
podman run -d --name t --systemd=always ghcr.io/jahwag/clem-sample:latest
podman exec t systemctl is-system-running --wait
podman exec t clem --help
```

All three should succeed after this change.