### PR TITLE
feat(provision): register SSH signing key on GitHub during provision

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -74,6 +74,7 @@ func runProvision(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  provider: %s\n", ac.Provider)
 		}
 
+		var ghToken string
 		secrets, err := vault.DecryptForAgent(agentKey, ac.Vaults)
 		if err != nil {
 			fmt.Printf("  warning: could not decrypt secrets for %s: %v\n", agentKey, err)
@@ -106,7 +107,8 @@ func runProvision(cmd *cobra.Command, args []string) error {
 				fmt.Printf("  wrote wrangler config for %s\n", osUser)
 			}
 
-			if secrets["GH_TOKEN"] != "" && ac.GitEmail == "" {
+			ghToken = secrets["GH_TOKEN"]
+			if ghToken != "" && ac.GitEmail == "" {
 				fmt.Printf("  warning: agent %s has GH_TOKEN but no git_email in clem.yaml — commits may leak operator identity\n", agentKey)
 			}
 		}
@@ -140,6 +142,14 @@ func runProvision(cmd *cobra.Command, args []string) error {
 				fmt.Printf("  warning: git config for %s: %v\n", osUser, err)
 			} else {
 				fmt.Printf("  configured git signing + identity for %s\n", osUser)
+			}
+
+			// 3b1. Register the signing key on GitHub so commits show as verified.
+			// Requires write:public_key scope on the agent's GH_TOKEN.
+			if err := agent.RegisterSSHSigningKey(pubKey, ghToken); err != nil {
+				fmt.Printf("  warning: register SSH signing key for %s: %v\n", osUser, err)
+			} else if ghToken != "" {
+				fmt.Printf("  registered SSH signing key on GitHub for %s\n", osUser)
 			}
 		}
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +32,54 @@ func (OSExecutor) Run(name string, args ...string) ([]byte, error) {
 
 // sys is the active Executor. Replaced in tests to avoid root/binary requirements.
 var sys Executor = OSExecutor{}
+
+// ghHTTPClient performs GitHub API calls. Replaced in tests to avoid real network calls.
+var ghHTTPClient = &http.Client{}
+
+// RegisterSSHSigningKey registers pubKey on the agent's GitHub account as a
+// signing key via POST /user/ssh_signing_keys. Requires a GH_TOKEN with the
+// write:public_key scope. Idempotent: returns nil if the key is already registered.
+func RegisterSSHSigningKey(pubKey, ghToken string) error {
+	if ghToken == "" {
+		return fmt.Errorf("GH_TOKEN required to register SSH signing key; grant write:public_key scope to the agent PAT")
+	}
+
+	type payload struct {
+		Title string `json:"title"`
+		Key   string `json:"key"`
+	}
+	body, err := json.Marshal(payload{Title: "clem-signing", Key: pubKey})
+	if err != nil {
+		return fmt.Errorf("marshaling signing key payload: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.github.com/user/ssh_signing_keys", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating signing key request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+ghToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := ghHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("registering SSH signing key: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusCreated {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnprocessableEntity &&
+		strings.Contains(string(respBody), "key is already in use") {
+		return nil
+	}
+
+	return fmt.Errorf("GitHub /user/ssh_signing_keys returned %d: %s", resp.StatusCode, respBody)
+}
 
 // EnsureUser creates the OS user if it doesn't already exist.
 func EnsureUser(username string) error {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -716,5 +718,86 @@ func TestInstallGitHooks_WritesHookAndConfig(t *testing.T) {
 	}
 	if !strings.Contains(string(gitConfigData), "hooksPath") {
 		t.Errorf(".gitconfig missing hooksPath: %s", gitConfigData)
+	}
+}
+
+func withGHHTTPClient(t *testing.T, handler http.Handler) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	orig := ghHTTPClient
+	ghHTTPClient = srv.Client()
+	// Redirect all requests to the test server by rewriting the URL host.
+	// The test handler receives the full path so it can assert on it.
+	ghHTTPClient.Transport = &rewriteTransport{base: srv.Client().Transport, host: srv.URL}
+	t.Cleanup(func() { ghHTTPClient = orig })
+}
+
+type rewriteTransport struct {
+	base http.RoundTripper
+	host string
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(rt.host, "http://")
+	return rt.base.RoundTrip(req)
+}
+
+func TestRegisterSSHSigningKey_NoToken(t *testing.T) {
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "")
+	if err == nil {
+		t.Fatal("expected error when ghToken is empty")
+	}
+	if !strings.Contains(err.Error(), "GH_TOKEN required") {
+		t.Errorf("expected 'GH_TOKEN required' in error, got: %v", err)
+	}
+}
+
+func TestRegisterSSHSigningKey_Success(t *testing.T) {
+	withGHHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "ssh_signing_keys") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer fake-token" {
+			t.Errorf("unexpected Authorization: %s", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token")
+	if err != nil {
+		t.Fatalf("expected no error on 201, got: %v", err)
+	}
+}
+
+func TestRegisterSSHSigningKey_AlreadyRegistered(t *testing.T) {
+	withGHHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message":"key is already in use"}`)) //nolint:errcheck
+	}))
+
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token")
+	if err != nil {
+		t.Fatalf("expected nil error when key already registered, got: %v", err)
+	}
+}
+
+func TestRegisterSSHSigningKey_APIError(t *testing.T) {
+	withGHHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"Must have admin rights to Repository."}`)) //nolint:errcheck
+	}))
+
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token")
+	if err == nil {
+		t.Fatal("expected error on non-201/non-422 response")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected status code 403 in error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #31.

## What

`clem provision` already generates an Ed25519 keypair (`~/.ssh/id_ed25519`) and configures git to sign commits with it (landed in #35). The missing piece from #31 is step 3: registering the public key on the agent's GitHub account so commits show as **verified**.

This PR adds `RegisterSSHSigningKey(pubKey, ghToken string) error` which calls `POST /user/ssh_signing_keys` and is invoked during provision after `ConfigureGit`.

## Scope note

Issue #31 proposed a separate signing key at `~/.ssh/<name>-signing` distinct from the auth key. Since #35 already landed with a single `id_ed25519` used for both auth and SSH signing, this PR reuses that key for the GitHub registration rather than introducing a second keypair. If a separate signing key is wanted, that can be a follow-up issue.

## Changes

| File | Change |
|------|--------|
| `internal/agent/manager.go` | Add `RegisterSSHSigningKey` + `ghHTTPClient` seam; import `bytes`, `io`, `net/http` |
| `cmd/provision.go` | Capture `ghToken` from secrets; call `RegisterSSHSigningKey` after `ConfigureGit` |
| `internal/agent/manager_test.go` | 4 tests: no-token error, 201 success, 422 already-registered (idempotent), other API error |

## Behaviour

- **Idempotent**: 422 with `"key is already in use"` → returns nil. Safe to re-provision.
- **Graceful degradation**: API failure prints a warning and continues; provision does not abort. Operator must grant `write:public_key` scope to the agent PAT for registration to succeed.
- No new dependencies.

## Verification

After provisioning an agent with a GH_TOKEN that has `write:public_key` scope:

```
# should appear in the agent's GitHub signing keys
curl -H "Authorization: Bearer $GH_TOKEN" \
  https://api.github.com/user/ssh_signing_keys
```

Commits made by the agent should then show the green **Verified** badge on GitHub.