### PR TITLE
docs: add asciinema demo script and embed infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@
   <a href="https://github.com/jahwag/clem/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs welcome"></a>
 </p>
 
+<!-- Demo cast: record with docs/demo.sh, upload to asciinema.org, replace CAST_ID with the numeric ID from the upload URL.
+<p align="center">
+  <a href="https://asciinema.org/a/CAST_ID">
+    <img src="https://asciinema.org/a/CAST_ID.svg" alt="clem provision demo" width="700">
+  </a>
+</p>
+-->
+
 <p align="center">
   <a href="https://myclementine.ai"><b>myclementine.ai</b></a> &middot;
   <a href="https://github.com/jahwag/clem#quickstart">Quickstart</a> &middot;
@@ -380,6 +388,17 @@ Safe. `useradd` is idempotent; systemd units are overwritten; `.env` is regenera
 ## Community
 
 Questions, ideas, showing off your team - join the [ClaudeSync / Clem Discord](https://discord.gg/pR4qeMH4u4).
+
+## Regenerating the demo cast
+
+When clem's provision flow changes, re-record and re-upload:
+
+```bash
+# On a fresh Linux host or inside samples/Dockerfile (--privileged, /bin/bash entrypoint):
+asciinema rec demo.cast -- bash docs/demo.sh
+asciinema upload demo.cast
+# Replace CAST_ID in README.md and docs/index.html with the numeric ID from the upload URL.
+```
 
 ## License
 

--- a/docs/demo.sh
+++ b/docs/demo.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# clem end-to-end provision demo, designed for asciinema recording.
+#
+# Requirements: clem, age, sops, yq on PATH; sudo access.
+# Works on a bare Linux host or inside samples/Dockerfile (--privileged, /bin/bash entrypoint).
+#
+# Record:
+#   asciinema rec demo.cast -- bash docs/demo.sh
+#   asciinema upload demo.cast          # copy the cast ID into README.md + docs/index.html
+#
+# Tokens are placeholders: provisioning completes cleanly; agents need real tokens to run.
+# Regenerate after clem changes: re-run on a fresh host and re-upload.
+
+set -euo pipefail
+
+DEMO_DIR=$(mktemp -d /tmp/clem-demo-XXXX)
+trap 'rm -rf "$DEMO_DIR"' EXIT
+
+run() {
+    printf '\033[1;32m$\033[0m %s\n' "$*"
+    sleep 0.4
+    eval "$*"
+    sleep 1
+}
+
+clear
+printf '# clem — docker-compose for Claude Code agents\n'
+printf '# Provisioning a two-agent team from scratch\n\n'
+sleep 2
+
+cd "$DEMO_DIR"
+
+run "clem init"
+run "clem vault init"
+
+# Placeholder tokens — provisioning flow completes; agents fail at runtime (expected for demo)
+run "clem vault set github GH_TOKEN=ghp_fake"
+run "clem vault set discord-lead DISCORD_TOKEN=discord_fake"
+
+run "sudo clem provision"
+run "clem status"
+
+printf '\n# Agents provisioned. Start them: sudo clem up\n'

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,6 +125,21 @@
     </div>
   </section>
 
+  <!-- Demo cast: record with docs/demo.sh, upload to asciinema.org, replace CAST_ID below.
+  <section class="max-w-4xl mx-auto mb-16 text-center">
+    <link rel="stylesheet" type="text/css" href="https://asciinema.org/assets/asciinema-player.css">
+    <script src="https://asciinema.org/js/asciinema-player.min.js"></script>
+    <div id="demo-player" class="mx-auto rounded-xl overflow-hidden" style="max-width:720px"></div>
+    <script>
+      AsciinemaPlayer.create(
+        'https://asciinema.org/a/CAST_ID.cast',
+        document.getElementById('demo-player'),
+        { cols: 120, rows: 30, autoPlay: true, loop: true, theme: 'monokai' }
+      );
+    </script>
+  </section>
+  -->
+
   <section id="install" class="max-w-3xl mx-auto mb-24">
     <div class="terminal rounded-xl overflow-hidden">
       <div class="terminal-chrome px-4 py-3 flex items-center justify-between">


### PR DESCRIPTION
Closes #40.

## What

- `docs/demo.sh`: idempotent script recording the full provision flow (init → vault → provision → status) with placeholder tokens. Executable. Designed for `asciinema rec demo.cast -- bash docs/demo.sh`.
- `README.md`: commented-out asciinema embed block under the badge row; regeneration instructions section at the bottom.
- `docs/index.html`: commented-out asciinema-player section between the hero and install snippet.

## What's not in this PR

The actual cast recording and upload require a provisioned host or `samples/Dockerfile` container — per the issue constraint ("Must run in a fresh environment so viewers trust nothing is hand-waved"). `asciinema` is not available in the CI environment.

To complete the deliverable: run `docs/demo.sh` in a fresh container or VM, upload the cast, then uncomment the embed blocks in `README.md` and `docs/index.html` and replace `CAST_ID` with the numeric ID from the asciinema.org upload URL.

## Test

```bash
bash -n docs/demo.sh   # syntax check passes
```
