### PR TITLE
fix(update): guard http.NewRequest error in fetchLatestRelease (#62)

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -92,7 +92,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 func fetchLatestRelease() (*ghRelease, error) {
 	client := &http.Client{Timeout: 15 * time.Second}
-	req, _ := http.NewRequest("GET", latestReleaseURL, nil)
+	req, err := http.NewRequest("GET", latestReleaseURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build release request: %w", err)
+	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

\`fetchLatestRelease\` discarded the error from \`http.NewRequest\` and then unconditionally dereferenced \`req.Header\`. Any future change that made \`latestReleaseURL\` configurable (or introduced a context) would cause a nil-pointer panic instead of a clean error.

## Fix

Bind the error, wrap it as \`build release request: %w\`, and bail out before touching the request. No behaviour change on the current happy path (the URL is a valid constant).

Fixes #62

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`