### PR TITLE
fix(watchdog): suppress alert when restart brings service back

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -61,14 +61,34 @@ check_agent() {
 
     local fail_count_file="$COOLDOWN_DIR/${agent_key}.fails"
 
-    # Case 1: systemd service dead — restart, only alert after 3 consecutive failures
+    # Case 1: systemd service dead — restart, then re-check. Only alert when
+    # the restart did NOT bring the service back. Silences noise from
+    # transient non-active states (e.g. ExecStop kill-session exit 1 during
+    # a clean restart) that historically fired spurious "failed 3 times"
+    # alerts even though auto-recovery had succeeded.
     if [ "$systemd_state" != "active" ]; then
         echo "$(date -Iseconds) $agent_key: systemd=$systemd_state — restarting"
         systemctl restart "$service"
+
+        # systemctl restart returns after the job completes, but the forked
+        # tmux daemon needs a beat to register its session.
+        sleep 3
+        local post_state post_tmux
+        post_state=$(systemctl show -p ActiveState --value "$service" 2>/dev/null)
+        post_tmux="no"
+        tmux has-session -t "$agent_key" 2>/dev/null && post_tmux="yes"
+
+        if [ "$post_state" = "active" ] && [ "$post_tmux" = "yes" ]; then
+            # Restart succeeded — reset counter, suppress alert.
+            echo 0 > "$fail_count_file"
+            date +%s > "$cooldown_file"
+            return
+        fi
+
         local fails=$(( $(cat "$fail_count_file" 2>/dev/null || echo 0) + 1 ))
         echo "$fails" > "$fail_count_file"
         if (( fails >= 3 )); then
-            send_alert "🔴 clem/$PROJECT: $agent_key failed $fails times consecutively (systemd=$systemd_state)"
+            send_alert "🔴 clem/$PROJECT: $agent_key failed $fails times consecutively (systemd=$post_state tmux=$post_tmux)"
             echo 0 > "$fail_count_file"
         fi
         date +%s > "$cooldown_file"

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -1,0 +1,55 @@
+package watchdog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jahwag/clem/internal/config"
+)
+
+func baseCfg() *config.Config {
+	return &config.Config{
+		Project: "test",
+		Coordination: config.Coordination{
+			Backend: "discord",
+			Channels: map[string]string{
+				"alerts":  "111",
+				"tasks":   "222",
+				"general": "333",
+			},
+		},
+		Agents: map[string]config.AgentConfig{
+			"lead": {Name: "Lead", Model: "claude-opus-4-7", Iteration: "1m", Prompt: "x"},
+		},
+	}
+}
+
+func TestGenerateScript_PostRestartRecheckSuppressesAlert(t *testing.T) {
+	s := GenerateScript(baseCfg())
+	for _, want := range []string{
+		`systemctl restart "$service"`,
+		`post_state=$(systemctl show -p ActiveState --value "$service" 2>/dev/null)`,
+		`tmux has-session -t "$agent_key"`,
+		`if [ "$post_state" = "active" ] && [ "$post_tmux" = "yes" ]; then`,
+		`echo 0 > "$fail_count_file"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("generated script missing post-restart re-check line: %q\n---\n%s", want, s)
+		}
+	}
+
+	// Alert message must include both post-restart signals so on-call can tell
+	// whether systemd was still failed or tmux never came back.
+	if !strings.Contains(s, `(systemd=$post_state tmux=$post_tmux)`) {
+		t.Errorf("alert should report post_state + post_tmux, got:\n%s", s)
+	}
+
+	// Pre-fix behaviour: counter incremented before any post-restart check.
+	// Guard against regression by requiring that the increment only appears
+	// AFTER the post_state check returns.
+	preCheck := strings.Index(s, `post_state=$(systemctl show`)
+	inc := strings.Index(s, `fails=$(( $(cat "$fail_count_file"`)
+	if preCheck == -1 || inc == -1 || inc < preCheck {
+		t.Errorf("fail-count increment must follow post_state check (preCheck=%d inc=%d)", preCheck, inc)
+	}
+}


### PR DESCRIPTION
## Problem

The clem watchdog's Case 1 path (`check_agent` in `internal/watchdog/watchdog.go`) incremented the fail counter **before** verifying that `systemctl restart` had actually brought the service back.

Under `Type=forking` + `RemainAfterExit=yes`, a clean restart passes through a transient non-active state (e.g. `ExecStop`'s `tmux kill-session -t <key>` returns 1 when the session is already gone, so systemd marks the unit `failed` for the instant between Stop and Start). Each tick that caught the unit in that window fired a restart and bumped the counter even though the follow-up `ExecStart` succeeded.

Three such ticks in a row triggered:

```
🔴 clem/$PROJECT: $agent_key failed 3 times consecutively (systemd=failed)
```

while the agent was in fact healthy. Observed on our VPS 2026-04-24: six alerts between 10:58Z and 12:21Z, all self-recovered within ~7 min. No data impact — pure alert noise that trained the operator to mute the channel.

## Fix

Re-read `ActiveState` + `tmux has-session` 3s after the restart. If both are green, reset the counter and suppress the alert. Only increment and eventually alert when the re-check still shows the service down.

Alert message now reports both post-restart signals:

```
🔴 clem/$PROJECT: $agent_key failed N times consecutively (systemd=$post_state tmux=$post_tmux)
```

so on-call can distinguish a systemd-side failure (e.g. `ExecStart` failing) from a tmux-side one (e.g. runner.sh crashed immediately after fork).

## Test

New `TestGenerateScript_PostRestartRecheckSuppressesAlert` asserts:
- the re-check block is present,
- the alert message carries both signals,
- the fail-count increment sits **after** the re-check (regression guard).

Also `bash -n` on the rendered script: clean.

```
$ go test -race ./internal/watchdog/...
ok  github.com/jahwag/clem/internal/watchdog  1.015s
$ go test -race ./...
ok (all packages)
```

## Scope

Watchdog-side only. The agent-side runner and the systemd unit are unchanged. `clem provision` will regenerate `/usr/local/bin/clem-watchdog-<project>.sh` on next run; no operator action required beyond that.