### PR TITLE
feat(provision): permissions.deny denylist for destructive ops (T1989)

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -454,11 +454,47 @@ func WriteSettings(username, homeDir string) error {
 	// trailer Claude Code otherwise appends to commits it creates. Agents
 	// should author commits under their own identity, not leak that an LLM
 	// drove them - clem PRs go through normal human review regardless.
+	//
+	// permissions.deny enforces an irreversible-op denylist at the harness
+	// layer (T1989). Lesson: PocketOS 2026-04-25 — Claude Opus 4.6 in Cursor
+	// violated explicit "never destructive" system-prompt rules; treat any
+	// "NEVER do X" prompt as advisory, require infra-layer enforcement.
+	// Patterns target the highest-blast-radius verbs only; agents' own
+	// $HOME and /tmp are unrestricted so legitimate test/cleanup work runs.
 	settings := `{
   "hasTrustDialogAccepted": true,
   "hasCompletedProjectOnboarding": true,
   "skipDangerousModePermissionPrompt": true,
-  "includeCoAuthoredBy": false
+  "includeCoAuthoredBy": false,
+  "permissions": {
+    "deny": [
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git push * --force *)",
+      "Bash(git push * -f *)",
+      "Bash(rm -rf /)",
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf /opt*)",
+      "Bash(rm -rf /var*)",
+      "Bash(rm -rf /etc*)",
+      "Bash(rm -rf /usr*)",
+      "Bash(rm -rf /boot*)",
+      "Bash(rm -rf /lib*)",
+      "Bash(rm -rf /root*)",
+      "Bash(wrangler delete *)",
+      "Bash(wrangler pages delete *)",
+      "Bash(wrangler pages project delete *)",
+      "Bash(wrangler d1 delete *)",
+      "Bash(wrangler r2 bucket delete *)",
+      "Bash(wrangler kv:namespace delete *)",
+      "Bash(wrangler kv namespace delete *)",
+      "Bash(wrangler queues delete *)",
+      "Bash(wrangler workflows delete *)",
+      "Bash(docker volume rm *)",
+      "Bash(docker volume prune *)",
+      "Bash(docker system prune * --volumes*)"
+    ]
+  }
 }
 `
 	settingsPath := filepath.Join(claudeDir, "settings.json")

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -521,6 +521,26 @@ func TestWriteSettings_WritesExpectedFiles(t *testing.T) {
 		t.Errorf("settings.json missing includeCoAuthoredBy=false: %s", settingsData)
 	}
 
+	// permissions.deny block guards against destructive ops (T1989).
+	// Spot-check a few canonical patterns from each blast-radius bucket.
+	for _, want := range []string{
+		`"permissions"`,
+		`"deny"`,
+		"Bash(git push --force *)",
+		"Bash(rm -rf /opt*)",
+		"Bash(wrangler delete *)",
+		"Bash(docker volume rm *)",
+	} {
+		if !strings.Contains(string(settingsData), want) {
+			t.Errorf("settings.json missing %q: %s", want, settingsData)
+		}
+	}
+	// settings.json must remain valid JSON after the deny-list addition.
+	var parsed map[string]any
+	if err := json.Unmarshal(settingsData, &parsed); err != nil {
+		t.Fatalf("settings.json is not valid JSON: %v\n%s", err, settingsData)
+	}
+
 	// .claude.json must exist and contain the project trust entry
 	appStateData, err := os.ReadFile(filepath.Join(dir, ".claude.json"))
 	if err != nil {


### PR DESCRIPTION
## Summary

T1989 default-fire (24h-silence trim shape, agreed in #general 2026-04-28 09:20Z + #lessons 04-27 16:27Z).

Adds a `permissions.deny` block to `~/.claude/settings.json` (written by clem provisioning) so destructive verbs are denied at the harness layer, not just the system-prompt layer.

**Lesson source — PocketOS 2026-04-25:** Cursor's marketed "Destructive Guardrails" + Cursor's explicit system-prompt rule "NEVER run destructive/irreversible commands unless the user explicitly requests them" were both bypassed by Cursor's own Claude Opus 4.6 agent. Treat any "NEVER do X" prompt as advisory; require infra-layer enforcement.

## Scope (trim default per 24h-silence)

Highest-blast-radius verbs only:

- `git push --force` / `-f` (any flag position)
- `rm -rf /` and roots that don't belong to an agent: `/opt /var /etc /usr /boot /lib /root`
- `wrangler` destructive verbs (`pages|d1|r2|kv|queues|workflows delete`)
- `docker volume rm`, `docker volume prune`, `docker system prune --volumes`

**Carve-outs:** agents' own `\$HOME` and `/tmp` are unrestricted, so test-fixture cleanup, scratch-dir, and worktree work continue to run. `git reset --hard origin/main` not denied (used routinely by agents to align worktrees) — flagged in the lesson but excluded from the trim default.

**MCP delete-verbs not denied** (the 04-27 draft listed `mcp__github__delete_file` etc; pulled per "drop MCP delete-verb ban as too broad" — these have legitimate jahwag-driven uses).

## Test

- `internal/agent/manager_test.go` extends `TestWriteSettings_WritesExpectedFiles` to assert each blast-radius bucket appears + `settings.json` parses as valid JSON post-edit.
- \`go test ./internal/agent/\` ✓
- \`go vet ./...\` ✓
- \`go build ./...\` ✓

## Rollout

Effective on **next agent host (re)provisioning**. Existing hosts retain their current `settings.json` until reprovisioned (per `arch_clem_vault.md` — agents cannot reprovision themselves).

## Refs

- T1989 task thread: 1498360040900526080
- Memory: \`feedback_pocketos_destructive_agent.md\`

🤖 Athena