### PR TITLE
feat: discord gateway watcher pushes notifications via tmux

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/jahwag/clem/internal/config"
@@ -30,9 +31,16 @@ tail -500 "$LOGFILE" > "$LOGFILE.tmp" 2>/dev/null && mv "$LOGFILE.tmp" "$LOGFILE
 python3 -c "
 import json, os
 cfg = {'mcpServers': {}}
-# Discord bot
+# Discord bot. When channel IDs are configured the MCP server also runs a
+# gateway watcher that pushes one debounced notification per burst into this
+# agent's tmux session — see mcp-discord's CLEM_TMUX_TARGET docs.
 if os.environ.get('DISCORD_TOKEN'):
-    cfg['mcpServers']['discord-bot'] = {'command': '/usr/local/bin/mcp-discord', 'env': {'DISCORD_TOKEN': os.environ['DISCORD_TOKEN']}}
+    _discord_env = {'DISCORD_TOKEN': os.environ['DISCORD_TOKEN']}
+    _watch = '{{.WatchChannelIDs}}'
+    if _watch:
+        _discord_env['DISCORD_WATCH_CHANNELS'] = _watch
+        _discord_env['CLEM_TMUX_TARGET'] = '{{.AgentKey}}'
+    cfg['mcpServers']['discord-bot'] = {'command': '/usr/local/bin/mcp-discord', 'env': _discord_env}
 # Slack (korotovsky/slack-mcp-server). Read access is free; write access
 # (conversations_add_message) requires SLACK_MCP_ADD_MESSAGE_TOOL — enabled
 # here by default so agents can actually post, matching the Discord default.
@@ -179,11 +187,16 @@ if os.environ.get('ANTHROPIC_MODEL'):
         'models': {os.environ['ANTHROPIC_MODEL']: {}},
     }
 if os.environ.get('DISCORD_TOKEN'):
+    _discord_env = {'DISCORD_TOKEN': os.environ['DISCORD_TOKEN']}
+    _watch = '{{.WatchChannelIDs}}'
+    if _watch:
+        _discord_env['DISCORD_WATCH_CHANNELS'] = _watch
+        _discord_env['CLEM_TMUX_TARGET'] = '{{.AgentKey}}'
     cfg['mcp']['discord-bot'] = {
         'type': 'local',
         'command': ['/usr/local/bin/mcp-discord'],
         'enabled': True,
-        'environment': {'DISCORD_TOKEN': os.environ['DISCORD_TOKEN']},
+        'environment': _discord_env,
     }
 if os.environ.get('SLACK_MCP_XOXP_TOKEN'):
     slack_cmd = ['/usr/local/bin/slack-mcp-server', '--transport', 'stdio']
@@ -317,6 +330,10 @@ type RunnerParams struct {
 	AlertChannel      string
 	AlertCurl         string
 	EgressDirectives  string
+	// WatchChannelIDs is the comma-separated list of Discord channel IDs the
+	// MCP server's gateway watcher should observe. Empty disables the watcher
+	// even when DISCORD_TOKEN is set, preserving the original tool-only mode.
+	WatchChannelIDs   string
 }
 
 // Generate renders the runner.sh content for an agent. Dispatches on the
@@ -350,18 +367,19 @@ func Generate(cfg *config.Config, agentKey string) string {
 		subagentExport = fmt.Sprintf("export CLAUDE_CODE_SUBAGENT_MODEL=%q", ac.SubagentModel)
 	}
 	p := RunnerParams{
-		Project:        cfg.Project,
-		AgentKey:       agentKey,
-		AgentName:      ac.Name,
-		Model:          ac.Model,
-		SubagentExport: subagentExport,
-		Prompt:         strings.ReplaceAll(promptText, "'", `'\''`),
-		OSUser:         cfg.OSUsername(agentKey),
-		HomeDir:        fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
-		SleepActive:    iterSec,
-		SleepNight:     iterSec * 2,
-		AlertChannel:   alertChannel,
-		AlertCurl:      alertCurl,
+		Project:         cfg.Project,
+		AgentKey:        agentKey,
+		AgentName:       ac.Name,
+		Model:           ac.Model,
+		SubagentExport:  subagentExport,
+		Prompt:          strings.ReplaceAll(promptText, "'", `'\''`),
+		OSUser:          cfg.OSUsername(agentKey),
+		HomeDir:         fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
+		SleepActive:     iterSec,
+		SleepNight:      iterSec * 2,
+		AlertChannel:    alertChannel,
+		AlertCurl:       alertCurl,
+		WatchChannelIDs: discordWatchChannels(cfg),
 	}
 	switch ac.RuntimeKind() {
 	case "opencode":
@@ -426,6 +444,30 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.AlertCurl}}", p.AlertCurl,
 		"{{.SubagentExport}}", p.SubagentExport,
 		"{{.EgressDirectives}}", p.EgressDirectives,
+		"{{.WatchChannelIDs}}", p.WatchChannelIDs,
 	)
 	return r.Replace(tmpl)
+}
+
+// discordWatchChannels returns a deterministic comma-separated list of
+// configured Discord channel IDs for the gateway watcher to observe.
+// Sorted by channel name (the map key) so renders are stable across
+// Go map-iteration orderings, which keeps generated runner.sh diffs
+// minimal between provisions.
+func discordWatchChannels(cfg *config.Config) string {
+	if cfg == nil || cfg.Coordination.Backend != "discord" {
+		return ""
+	}
+	names := make([]string, 0, len(cfg.Coordination.Channels))
+	for name := range cfg.Coordination.Channels {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	ids := make([]string, 0, len(names))
+	for _, name := range names {
+		if id := strings.TrimSpace(cfg.Coordination.Channels[name]); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return strings.Join(ids, ",")
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -164,3 +164,84 @@ func TestGenerateService_EgressRestrictionDisabled(t *testing.T) {
 		t.Fatalf("expected no IPAddressDeny when egress_restriction unset, got:\n%s", out)
 	}
 }
+
+func TestGenerate_DiscordWatchChannelsWired(t *testing.T) {
+	cfg := baseCfg("worker", config.AgentConfig{
+		Name:      "Worker",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+
+	out := Generate(cfg, "worker")
+
+	// Channels are sorted by name (alerts, general, tasks) -> 111,333,222.
+	wantList := "111,333,222"
+	if !strings.Contains(out, "DISCORD_WATCH_CHANNELS") {
+		t.Fatalf("expected DISCORD_WATCH_CHANNELS substitution, got:\n%s", out)
+	}
+	if !strings.Contains(out, wantList) {
+		t.Fatalf("expected channel list %q in runner, got:\n%s", wantList, out)
+	}
+	if !strings.Contains(out, "CLEM_TMUX_TARGET") {
+		t.Fatalf("expected CLEM_TMUX_TARGET substitution, got:\n%s", out)
+	}
+	// Tmux target = agent key, since clem starts the tmux session under that name.
+	if !strings.Contains(out, "'CLEM_TMUX_TARGET'] = 'worker'") {
+		t.Fatalf("expected tmux target = 'worker', got:\n%s", out)
+	}
+}
+
+func TestGenerate_DiscordWatchEmptyWhenNoChannels(t *testing.T) {
+	cfg := &config.Config{
+		Project: "test",
+		Coordination: config.Coordination{
+			Backend:  "discord",
+			Channels: map[string]string{},
+		},
+		Agents: map[string]config.AgentConfig{
+			"worker": {
+				Name:      "Worker",
+				Model:     "claude-opus-4-7",
+				Iteration: "1m",
+				Prompt:    "do the thing",
+			},
+		},
+	}
+
+	out := Generate(cfg, "worker")
+
+	// _watch resolves to '' so the wrapper if-block stays inert: tokens may be set
+	// but neither DISCORD_WATCH_CHANNELS nor CLEM_TMUX_TARGET should be assigned.
+	if strings.Contains(out, "_discord_env['DISCORD_WATCH_CHANNELS']") &&
+		!strings.Contains(out, "_watch = ''") {
+		t.Fatalf("expected empty _watch when no channels configured, got:\n%s", out)
+	}
+}
+
+func TestGenerate_DiscordWatchSkippedForNonDiscordBackend(t *testing.T) {
+	cfg := &config.Config{
+		Project: "test",
+		Coordination: config.Coordination{
+			Backend: "slack",
+			Channels: map[string]string{
+				"general": "C1234",
+			},
+		},
+		Agents: map[string]config.AgentConfig{
+			"worker": {
+				Name:      "Worker",
+				Model:     "claude-opus-4-7",
+				Iteration: "1m",
+				Prompt:    "do the thing",
+			},
+		},
+	}
+
+	out := Generate(cfg, "worker")
+
+	// Slack channel IDs must not leak into the Discord-watch env block.
+	if strings.Contains(out, "C1234") {
+		t.Fatalf("expected slack channel id NOT to appear in discord watcher block, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Wire the `mcp-discord` fork's new gateway watcher into clem-provisioned runners
- Pass `DISCORD_WATCH_CHANNELS` (sorted, comma-joined IDs from `coordination.channels`) and `CLEM_TMUX_TARGET` (the agent key, which is also the tmux session name) to the discord-bot MCP server when the backend is discord and channels are configured
- Watcher pushes one debounced `[discord] N new: #ch(@user)` line per burst into the agent's tmux pane, so the running Claude session can react mid-task instead of waiting for the next iteration's poll

## Why
Long-running tasks could not see new Discord messages until the agent finished its current operation and looped back to `read_messages`. The fork now subscribes to the gateway and uses the same `tmux send-keys` primitive clem already uses to inject the initial agent prompt.

## Behavior
- DISCORD_TOKEN-without-channels deployments unchanged (watcher inert because `_watch == ''`)
- Slack backend unaffected (Discord watcher block does not run when `coordination.backend != "discord"`)
- Channel list is sorted by name to keep generated runner.sh diffs minimal across provisions

## Test plan
- [x] `go test ./...` — full suite green
- [x] `TestGenerate_DiscordWatchChannelsWired` — happy path, sorted IDs + tmux target wired
- [x] `TestGenerate_DiscordWatchEmptyWhenNoChannels` — empty channel map = inert watcher
- [x] `TestGenerate_DiscordWatchSkippedForNonDiscordBackend` — slack channel IDs do not leak into Discord block
- [ ] Manual smoke on _: jahwag posts in #general, watch agent's tmux pane via web terminal — pending