### PR TITLE
fix: clem status TMUX check + ttyd restart-with-agent

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -39,7 +39,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 		systemdState := agent.SystemdState(svcName)
 		tmuxAlive := "no"
-		if agent.TmuxAlive(agentKey) {
+		if agent.TmuxAlive(osUser, agentKey) {
 			tmuxAlive = "yes"
 		}
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -593,9 +593,17 @@ func SystemdState(serviceName string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// TmuxAlive returns true if a tmux session with the given name exists.
-func TmuxAlive(sessionName string) bool {
-	_, err := sys.Run("tmux", "has-session", "-t", sessionName)
+// TmuxAlive returns true if a tmux session with the given name exists in the
+// agent user's tmux server. Tmux servers are per-UID, so checking from the
+// invoking shell (typically root running `clem status`) sees an empty server
+// and reports every agent as down. Always invoke under sudo -u <osUser>.
+func TmuxAlive(osUser, sessionName string) bool {
+	if osUser == "" {
+		// Backwards-compat path for callers that still query their own server.
+		_, err := sys.Run("tmux", "has-session", "-t", sessionName)
+		return err == nil
+	}
+	_, err := sys.Run("sudo", "-n", "-u", osUser, "tmux", "has-session", "-t", sessionName)
 	return err == nil
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -801,3 +801,55 @@ func TestRegisterSSHSigningKey_APIError(t *testing.T) {
 		t.Errorf("expected status code 403 in error, got: %v", err)
 	}
 }
+
+func TestTmuxAlive_UsesSudoForAgentUser(t *testing.T) {
+	stub := withStub(t)
+
+	if !TmuxAlive("cdev-worker", "worker") {
+		t.Fatal("expected alive when stub returns no error")
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected exactly one Run call, got %d: %v", len(stub.calls), stub.calls)
+	}
+	got := stub.calls[0]
+	want := []string{"sudo", "-n", "-u", "cdev-worker", "tmux", "has-session", "-t", "worker"}
+	if !equalSlice(got, want) {
+		t.Errorf("invocation mismatch:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestTmuxAlive_ReportsDownWhenSudoTmuxFails(t *testing.T) {
+	stub := withStub(t)
+	stub.failOn = "sudo"
+
+	if TmuxAlive("cdev-worker", "worker") {
+		t.Fatal("expected dead when sudo tmux returns error")
+	}
+}
+
+func TestTmuxAlive_EmptyOSUserFallsBackToCallerOwnServer(t *testing.T) {
+	// Backwards-compat path: an empty user means "check our own tmux server"
+	// which is what older callers (and tests) relied on. Keep that working
+	// so the new signature is additive, not breaking.
+	stub := withStub(t)
+
+	TmuxAlive("", "worker")
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected one Run call, got %d", len(stub.calls))
+	}
+	if stub.calls[0][0] != "tmux" {
+		t.Errorf("expected fallback to call tmux directly, got: %v", stub.calls[0])
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -255,6 +255,11 @@ done
 const serviceTemplate = `[Unit]
 Description=Clem agent: {{.AgentName}} ({{.Project}})
 After=network.target
+# Pull the web-terminal sidecar up alongside the agent. The ttyd unit's
+# BindsTo+PartOf already propagate stops back, but neither propagates a fresh
+# start, so without a Wants here a "systemctl start" of the agent leaves the
+# terminal dead until provision re-enables it.
+Wants=clem-ttyd-{{.Project}}-{{.AgentKey}}.service
 
 [Service]
 Type=forking

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -245,3 +245,22 @@ func TestGenerate_DiscordWatchSkippedForNonDiscordBackend(t *testing.T) {
 		t.Fatalf("expected slack channel id NOT to appear in discord watcher block, got:\n%s", out)
 	}
 }
+
+func TestGenerateService_PullsTtydUp(t *testing.T) {
+	cfg := baseCfg("worker", config.AgentConfig{
+		Name:      "Worker",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+
+	out := GenerateService(cfg, "worker")
+
+	// Wants= ensures starting clem-test-worker also pulls the ttyd sidecar.
+	// Without this, BindsTo+PartOf only propagate stops back, leaving the
+	// web terminal dead until the next provision.
+	want := "Wants=clem-ttyd-test-worker.service"
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected %q in service unit, got:\n%s", want, out)
+	}
+}


### PR DESCRIPTION
## Summary

Two reliability fixes; same root cause (systemd / tooling side-effects only flowing one direction).

### 1. `clem status` always shows TMUX = `no`

`TmuxAlive` ran `tmux has-session` as the invoking shell's user (typically root). Tmux servers are per-UID, so root sees an empty server and reports every agent as down even when their tmux session is alive under the agent user.

**Fix:** `TmuxAlive(osUser, sessionName)` invokes via `sudo -n -u <osUser>`. Empty `osUser` preserves the original behavior so any other callers (current or future) keep working; `cmd/status.go` is updated to pass the resolved user.

### 2. ttyd stays dead after `systemctl start clem-<project>-<agent>`

The ttyd web-terminal unit uses `BindsTo` + `PartOf` on the agent service, which propagates **stops** back to ttyd but does not propagate a **fresh start**. After a manual `systemctl start` (or any shutdown that didn't restart the bound unit), ttyd stayed dead until the next `clem provision` re-enabled it.

**Fix:** add `Wants=clem-ttyd-<project>-<agent>.service` to the agent service so a start pulls the sidecar with it. Stops still propagate via the existing `BindsTo`+`PartOf` on the ttyd unit.

## How we hit these

Daisy ran `clem status` from `~/consultant-dev-team` (correct cwd) and saw `TMUX no` for both Athena and Amara even though `sudo -u cdev-worker tmux ls` showed the worker session alive. Same browser session also couldn't reach `localhost:7682` — ttyd had been stopped at 19:23 and never came back through restarts.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `TestTmuxAlive_UsesSudoForAgentUser` — exact `sudo -n -u <user> tmux has-session -t <session>` invocation
- [x] `TestTmuxAlive_ReportsDownWhenSudoTmuxFails` — error path returns false
- [x] `TestTmuxAlive_EmptyOSUserFallsBackToCallerOwnServer` — backwards-compat path
- [x] `TestGenerateService_PullsTtydUp` — snapshot for the `Wants=` line
- [ ] Manual smoke on cdev: `clem status` shows `yes`; `systemctl restart clem-cdev-worker` brings ttyd up