### PR TITLE
ci: switch CodeQL to advanced setup (analyze fork PRs)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+# CodeQL advanced setup. Replaces GitHub-managed default setup so that PRs
+# from forks (e.g. external contributors) also get analyzed — default setup
+# silently skips fork PRs, which left PR #63 missing the required
+# `code_scanning` ruleset check and unmergeable.
+#
+# Languages mirror the prior default-setup config (`go`, `actions`).
+# Triggers cover push to main, all PRs (incl. forks), and a weekly schedule
+# so periodic re-analysis still runs even on quiet weeks.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 06:13 UTC. Offset from :00 to avoid GitHub scheduler hot spots.
+    - cron: '13 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-and-quality covers the default-setup query suite plus
+          # additional maintainability checks. Drop to "security-extended"
+          # if results get noisy.
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Replaces GitHub-managed default setup CodeQL with an explicit workflow file
- Fixes the gap that left PR #63 unmergeable: default setup silently skips fork PRs, so the `code_scanning` ruleset check never appeared. Advanced setup runs on all PRs incl. forks
- Mirrors prior default-setup config — languages `go` + `actions`, query suite `security-and-quality`, weekly schedule preserved (Mondays 06:13 UTC)

## Why now
External contributor opened PR #63 from `SAY-5/clem`. All other checks (test, lint, e2e, codeowners-coverage) ran fine; only CodeQL skipped because of the default-setup restriction. PR is unmergeable until CodeQL produces a result.

## Manual step before merging
Default setup must be disabled or the advanced workflow will fail on first run with "default setup is configured for this repository".

Either:
- **UI**: Settings → Code security → CodeQL analysis → switch to advanced
- **API**:
  ```bash
  gh api -X PATCH /repos/jahwag/clem/code-scanning/default-setup -f state=not-configured
  ```

Run the manual step **then** merge this PR.

## Trade-offs
- Fork PRs run CodeQL with a restricted GITHUB_TOKEN (no SARIF upload to the security tab; findings appear as PR comments only). Fine for the merge gate.
- Internal PRs (and pushes to main) keep full Security tab integration as before.

## Test plan
- [ ] Disable default setup (manual)
- [ ] Merge this PR
- [ ] Verify the next push to main triggers a CodeQL workflow run
- [ ] Re-run PR #63 (e.g. push an empty commit on the fork) and confirm CodeQL check appears