### PR TITLE
feat(watchdog): alert on OOM-kill events

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -120,7 +120,31 @@ check_agent() {
     [ -f "$fail_count_file" ] && echo 0 > "$fail_count_file"
 }
 
+check_oom() {
+    local marker="$COOLDOWN_DIR/oom.last"
+    local since
+    if [ -f "$marker" ]; then
+        since="@$(cat "$marker")"
+    else
+        since="5 minutes ago"
+    fi
+    date +%s > "$marker"
+
+    local hits
+    hits=$(journalctl --since "$since" --no-pager 2>/dev/null \
+        | grep -E "killed by the OOM killer" \
+        | grep -oE "clem-[a-zA-Z0-9_-]+\.service" \
+        | sort | uniq -c | awk '{printf "%s x%s\n", $2, $1}')
+    if [ -n "$hits" ]; then
+        local mem
+        mem=$(free -h | awk '/^Mem:/ {printf "%s/%s", $3, $2} /^Swap:/ {printf " swap=%s/%s", $3, $2}')
+        send_alert "🔥 clem/$PROJECT OOM-kill detected (last 5min): $hits — RAM $mem"
+    fi
+}
+
 {{.AgentChecks}}
+
+check_oom
 `
 
 const watchdogServiceTemplate = `[Unit]

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -53,3 +53,27 @@ func TestGenerateScript_PostRestartRecheckSuppressesAlert(t *testing.T) {
 		t.Errorf("fail-count increment must follow post_state check (preCheck=%d inc=%d)", preCheck, inc)
 	}
 }
+
+func TestGenerateScript_OOMCheckPresent(t *testing.T) {
+	s := GenerateScript(baseCfg())
+	for _, want := range []string{
+		`check_oom()`,
+		`journalctl --since "$since" --no-pager`,
+		`killed by the OOM killer`,
+		`clem-[a-zA-Z0-9_-]+\.service`,
+		`OOM-kill detected`,
+		`free -h`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("generated script missing OOM-check fragment: %q", want)
+		}
+	}
+
+	// check_oom must be invoked after the per-agent loop so a kill
+	// in the same tick still alerts before the next iteration.
+	defIdx := strings.Index(s, "check_oom()")
+	callIdx := strings.LastIndex(s, "check_oom")
+	if defIdx == -1 || callIdx == -1 || callIdx <= defIdx {
+		t.Errorf("check_oom must be defined and then invoked (def=%d call=%d)", defIdx, callIdx)
+	}
+}


### PR DESCRIPTION
## Why

138 OOM-kills observed on cdev in 7 days with zero signal to the operator. Worker service got silently restarted and lost mid-task work each time. Watchdog already runs every 5min and posts Discord alerts — natural place to add OOM detection.

## What

\`check_oom()\` added to \`clem-watchdog-<project>.sh\`. Each tick:
- Reads marker file \`oom.last\` to get since-timestamp (seeds at \"5 minutes ago\" on first run)
- Scans \`journalctl --since\` for \`killed by the OOM killer\` lines
- Attributes hits to \`clem-*.service\` units, dedups via \`sort | uniq -c\`
- Includes \`free -h\` RAM/swap snapshot in alert
- Posts to existing #alerts channel

Sample alert:
\`\`\`
🔥 clem/cdev OOM-kill detected (last 5min): clem-cdev-worker.service x4 — RAM 14Gi/16Gi swap=0/0
\`\`\`

## Tests

Added \`TestGenerateScript_OOMCheckPresent\` — verifies fragment shape + that \`check_oom\` is defined before being invoked.

## Latency

≤5min (timer cadence). Acceptable for human-in-the-loop. Real-time would need \`OnFailure=\` units per agent service which is more wiring for marginal gain.