### PR TITLE
fix(provision): per-agent SSH signing key title on GitHub

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -145,8 +145,11 @@ func runProvision(cmd *cobra.Command, args []string) error {
 			}
 
 			// 3b1. Register the signing key on GitHub so commits show as verified.
-			// Requires write:public_key scope on the agent's GH_TOKEN.
-			if err := agent.RegisterSSHSigningKey(pubKey, ghToken); err != nil {
+			// Requires write:ssh_signing_key scope on the agent's GH_TOKEN.
+			// Title includes the OS user so multiple agents sharing a GitHub
+			// account are distinguishable in https://github.com/settings/ssh/signing.
+			signingTitle := fmt.Sprintf("clem-%s", osUser)
+			if err := agent.RegisterSSHSigningKey(pubKey, ghToken, signingTitle); err != nil {
 				fmt.Printf("  warning: register SSH signing key for %s: %v\n", osUser, err)
 			} else if ghToken != "" {
 				fmt.Printf("  registered SSH signing key on GitHub for %s\n", osUser)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -38,17 +38,22 @@ var ghHTTPClient = &http.Client{}
 
 // RegisterSSHSigningKey registers pubKey on the agent's GitHub account as a
 // signing key via POST /user/ssh_signing_keys. Requires a GH_TOKEN with the
-// write:public_key scope. Idempotent: returns nil if the key is already registered.
-func RegisterSSHSigningKey(pubKey, ghToken string) error {
+// write:ssh_signing_key (admin:ssh_signing_key) scope. Idempotent: returns nil
+// if the key is already registered. The title argument lets callers
+// distinguish keys per agent in the GitHub UI (e.g. "clem-cdev-lead").
+func RegisterSSHSigningKey(pubKey, ghToken, title string) error {
 	if ghToken == "" {
-		return fmt.Errorf("GH_TOKEN required to register SSH signing key; grant write:public_key scope to the agent PAT")
+		return fmt.Errorf("GH_TOKEN required to register SSH signing key; grant write:ssh_signing_key scope to the agent PAT")
+	}
+	if title == "" {
+		title = "clem-signing"
 	}
 
 	type payload struct {
 		Title string `json:"title"`
 		Key   string `json:"key"`
 	}
-	body, err := json.Marshal(payload{Title: "clem-signing", Key: pubKey})
+	body, err := json.Marshal(payload{Title: title, Key: pubKey})
 	if err != nil {
 		return fmt.Errorf("marshaling signing key payload: %w", err)
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -746,7 +747,7 @@ func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error)
 }
 
 func TestRegisterSSHSigningKey_NoToken(t *testing.T) {
-	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "")
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "", "clem-test")
 	if err == nil {
 		t.Fatal("expected error when ghToken is empty")
 	}
@@ -766,10 +767,29 @@ func TestRegisterSSHSigningKey_Success(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer fake-token" {
 			t.Errorf("unexpected Authorization: %s", r.Header.Get("Authorization"))
 		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"title":"clem-cdev-lead"`) {
+			t.Errorf("expected title 'clem-cdev-lead' in payload, got: %s", body)
+		}
 		w.WriteHeader(http.StatusCreated)
 	}))
 
-	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token")
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token", "clem-cdev-lead")
+	if err != nil {
+		t.Fatalf("expected no error on 201, got: %v", err)
+	}
+}
+
+func TestRegisterSSHSigningKey_DefaultTitleWhenEmpty(t *testing.T) {
+	withGHHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"title":"clem-signing"`) {
+			t.Errorf("expected default title 'clem-signing' when caller passes empty, got: %s", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token", "")
 	if err != nil {
 		t.Fatalf("expected no error on 201, got: %v", err)
 	}
@@ -781,7 +801,7 @@ func TestRegisterSSHSigningKey_AlreadyRegistered(t *testing.T) {
 		w.Write([]byte(`{"message":"key is already in use"}`)) //nolint:errcheck
 	}))
 
-	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token")
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token", "clem-test")
 	if err != nil {
 		t.Fatalf("expected nil error when key already registered, got: %v", err)
 	}
@@ -793,7 +813,7 @@ func TestRegisterSSHSigningKey_APIError(t *testing.T) {
 		w.Write([]byte(`{"message":"Must have admin rights to Repository."}`)) //nolint:errcheck
 	}))
 
-	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token")
+	err := RegisterSSHSigningKey("ssh-ed25519 AAAA testuser@clem", "fake-token", "clem-test")
 	if err == nil {
 		t.Fatal("expected error on non-201/non-422 response")
 	}


### PR DESCRIPTION
## Why

When multiple agents share a single GitHub account (common when one operator owns one PAT used by lead+worker agents), all signing keys upload with the hardcoded title `clem-signing`. https://github.com/settings/ssh/signing then shows N rows with identical names — impossible to tell which key belongs to which agent.

## What

`RegisterSSHSigningKey` gains a `title` argument. `provision.go` passes `fmt.Sprintf("clem-%s", osUser)` so each agent's key gets a distinct title (e.g. `clem-<project>-lead`, `clem-<project>-worker`).

Empty title falls back to `clem-signing` for backwards compat.

Also corrected scope name in the error message and comment: GitHub's signing-key endpoint requires `write:ssh_signing_key` (child of `admin:ssh_signing_key`), not `write:public_key` (the latter is for authentication keys, not signing keys).

## Tests

- New `TestRegisterSSHSigningKey_DefaultTitleWhenEmpty` — covers fallback path
- Existing `TestRegisterSSHSigningKey_Success` extended to assert title is in payload body
- All other tests updated to pass the title arg
