### PR TITLE
feat(config): declarative agent extensions in clem.yaml

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -119,12 +119,14 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("  wrote %s/.claude/settings.json\n", homeDir)
 
-		// 3aa. Install caveman plugin if enabled (reduces output tokens ~75%)
-		if ac.Caveman.Enabled() {
-			if err := agent.InstallCaveman(osUser); err != nil {
-				fmt.Printf("  warning: caveman install for %s: %v\n", osUser, err)
+		// 3aa. Install extensions (marketplaces, plugins, skills, MCP servers).
+		// caveman: true is handled as a shorthand inside InstallExtensions.
+		ext := ac.Extensions
+		if ac.Caveman.Enabled() || len(ext.Marketplaces)+len(ext.Plugins)+len(ext.Skills)+len(ext.MCPServers) > 0 {
+			if err := agent.InstallExtensions(osUser, homeDir, ext, ac.Caveman, secrets); err != nil {
+				fmt.Printf("  warning: extensions for %s: %v\n", osUser, err)
 			} else {
-				fmt.Printf("  installed caveman plugin for %s\n", osUser)
+				fmt.Printf("  installed extensions for %s\n", osUser)
 			}
 		}
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -742,61 +743,166 @@ func InstallClaude(username string) error {
 	return nil
 }
 
-// InstallCaveman installs and enables the caveman Claude Code plugin for the agent user.
-// Caveman reduces output tokens ~75% via terse response style. Idempotent.
+// InstallCaveman installs the caveman plugin for the agent user. Idempotent.
 // https://github.com/JuliusBrussee/caveman
 func InstallCaveman(username string) error {
-	home := fmt.Sprintf("/home/%s", username)
-	marketplaceDir := filepath.Join(home, ".claude", "plugins", "marketplaces", "caveman")
-	knownPath := filepath.Join(home, ".claude", "plugins", "known_marketplaces.json")
+	return InstallExtensions(username, fmt.Sprintf("/home/%s", username),
+		config.ExtensionsConfig{}, config.CavemanUltra, nil)
+}
 
-	// Clone marketplace (idempotent — skip if directory exists)
+// InstallMarketplace clones a GitHub marketplace and registers it in
+// known_marketplaces.json. Idempotent. Verifies HEAD against m.Commit if set.
+func InstallMarketplace(username string, m config.MarketplaceConfig) error {
+	home := fmt.Sprintf("/home/%s", username)
+	marketplaceDir := filepath.Join(home, ".claude", "plugins", "marketplaces", m.Name)
+	knownPath := filepath.Join(home, ".claude", "plugins", "known_marketplaces.json")
 	if _, err := os.Stat(marketplaceDir); os.IsNotExist(err) {
-		cloneCmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-			fmt.Sprintf("mkdir -p ~/.claude/plugins/marketplaces && git clone https://github.com/JuliusBrussee/caveman.git %s", marketplaceDir))
-		if out, err := cloneCmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("cloning caveman for %s: %w\n%s", username, err, out)
+		cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
+			fmt.Sprintf("mkdir -p ~/.claude/plugins/marketplaces && git clone https://github.com/%s.git %s", m.Repo, marketplaceDir))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("cloning marketplace %s for %s: %w\n%s", m.Name, username, err, out)
 		}
 	}
-
-	// Register in known_marketplaces.json if missing
-	existing, _ := os.ReadFile(knownPath)
-	if !strings.Contains(string(existing), `"caveman"`) {
-		base := strings.TrimSpace(string(existing))
-		entry := fmt.Sprintf(`"caveman":{"source":{"source":"github","repo":"JuliusBrussee/caveman"},"installLocation":"%s","lastUpdated":"1970-01-01T00:00:00.000Z"}`, marketplaceDir)
-		var merged string
-		switch {
-		case base == "" || base == "{}":
-			merged = "{" + entry + "}"
-		case strings.HasSuffix(base, "}"):
-			merged = strings.TrimSuffix(base, "}") + "," + entry + "}"
-		default:
-			return fmt.Errorf("unexpected known_marketplaces.json format for %s", username)
+	if m.Commit != "" {
+		cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
+			fmt.Sprintf("git -C %s rev-parse HEAD | grep -q '^%s'", marketplaceDir, m.Commit))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("marketplace %s HEAD does not match pinned commit %s for %s:\n%s", m.Name, m.Commit, username, out)
 		}
+	}
+	var known map[string]json.RawMessage
+	if raw, _ := os.ReadFile(knownPath); len(raw) > 0 {
+		_ = json.Unmarshal(raw, &known)
+	}
+	if known == nil {
+		known = make(map[string]json.RawMessage)
+	}
+	if _, exists := known[m.Name]; !exists {
+		entry, _ := json.Marshal(map[string]any{
+			"source":          map[string]string{"source": m.Source, "repo": m.Repo},
+			"installLocation": marketplaceDir,
+			"lastUpdated":     "1970-01-01T00:00:00.000Z",
+		})
+		known[m.Name] = entry
+		out, _ := json.Marshal(known)
 		if err := os.MkdirAll(filepath.Dir(knownPath), 0755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(knownPath, []byte(merged), 0644); err != nil {
+		if err := os.WriteFile(knownPath, out, 0644); err != nil {
 			return fmt.Errorf("writing known_marketplaces.json: %w", err)
 		}
 		ChownPath(filepath.Dir(knownPath), username)
 	}
+	return nil
+}
 
-	// Install + enable plugin. "enable" returns non-zero when already
-	// enabled, so we inspect the output instead of trusting the exit code.
-	installCmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-		"claude plugin install caveman@caveman 2>&1; claude plugin enable caveman@caveman 2>&1; true")
-	out, err := installCmd.CombinedOutput()
+// installPlugin installs and enables a plugin from the named marketplace. Idempotent.
+func installPlugin(username, pluginName, marketplaceName string) error {
+	cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
+		fmt.Sprintf("claude plugin install %s@%s 2>&1; claude plugin enable %s@%s 2>&1; true",
+			pluginName, marketplaceName, pluginName, marketplaceName))
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("running claude plugin commands for %s: %w\n%s", username, err, out)
+		return fmt.Errorf("plugin %s@%s for %s: %w\n%s", pluginName, marketplaceName, username, err, out)
 	}
 	output := string(out)
-	installedOK := strings.Contains(output, "Successfully installed plugin") || strings.Contains(output, "already installed")
-	enabledOK := strings.Contains(output, "Successfully enabled plugin") || strings.Contains(output, "already enabled")
-	if !installedOK || !enabledOK {
-		return fmt.Errorf("caveman install/enable did not confirm success for %s:\n%s", username, output)
+	if !(strings.Contains(output, "Successfully installed plugin") || strings.Contains(output, "already installed")) ||
+		!(strings.Contains(output, "Successfully enabled plugin") || strings.Contains(output, "already enabled")) {
+		return fmt.Errorf("plugin %s@%s install/enable did not confirm success for %s:\n%s", pluginName, marketplaceName, username, output)
 	}
+	return nil
+}
 
+// InstallSkill clones a GitHub skill into ~/.claude/skills/<name>/. Idempotent.
+// When s.Path is set the entrypoint is at ~/.claude/skills/<name>/<path>.
+func InstallSkill(username string, s config.SkillConfig) error {
+	skillDir := filepath.Join(fmt.Sprintf("/home/%s", username), ".claude", "skills", s.Name)
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
+			fmt.Sprintf("mkdir -p ~/.claude/skills && git clone https://github.com/%s.git %s", s.Repo, skillDir))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("cloning skill %s for %s: %w\n%s", s.Name, username, err, out)
+		}
+	}
+	ChownPath(skillDir, username)
+	return nil
+}
+
+// SetMCPServers overwrites the mcpServers key in ~/.claude/settings.json while
+// preserving all other settings. Vault refs in env values are expanded via secrets.
+func SetMCPServers(homeDir string, servers []config.MCPServerConfig, secrets map[string]string) error {
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return fmt.Errorf("reading settings.json: %w", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("parsing settings.json: %w", err)
+	}
+	mcpMap := make(map[string]any, len(servers))
+	for _, srv := range servers {
+		entry := make(map[string]any)
+		if srv.URL != "" {
+			entry["type"] = "sse"
+			entry["url"] = srv.URL
+		} else {
+			entry["type"] = "stdio"
+			entry["command"] = srv.Command
+			if len(srv.Args) > 0 {
+				entry["args"] = srv.Args
+			}
+		}
+		if len(srv.Env) > 0 {
+			env := make(map[string]string, len(srv.Env))
+			for k, v := range srv.Env {
+				env[k] = config.ExpandVaultRefs(v, secrets)
+			}
+			entry["env"] = env
+		}
+		mcpMap[srv.Name] = entry
+	}
+	doc["mcpServers"] = mcpMap
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling settings.json: %w", err)
+	}
+	return os.WriteFile(settingsPath, append(out, '\n'), 0644)
+}
+
+// InstallExtensions installs marketplaces, plugins, skills, and MCP servers for
+// an agent. caveman: true is translated to the equivalent marketplace+plugin
+// entries if not already explicit. Idempotent. Removed entries are not
+// auto-uninstalled — use `claude plugin list` to audit manually.
+func InstallExtensions(username, homeDir string, ext config.ExtensionsConfig, caveman config.CavemanLevel, secrets map[string]string) error {
+	if caveman.Enabled() {
+		if !slices.ContainsFunc(ext.Marketplaces, func(m config.MarketplaceConfig) bool { return m.Name == "caveman" }) {
+			ext.Marketplaces = append([]config.MarketplaceConfig{{Name: "caveman", Source: "github", Repo: "JuliusBrussee/caveman"}}, ext.Marketplaces...)
+		}
+		if !slices.ContainsFunc(ext.Plugins, func(p config.PluginConfig) bool { return p.Name == "caveman" && p.Marketplace == "caveman" }) {
+			ext.Plugins = append([]config.PluginConfig{{Name: "caveman", Marketplace: "caveman"}}, ext.Plugins...)
+		}
+	}
+	for _, mp := range ext.Marketplaces {
+		if err := InstallMarketplace(username, mp); err != nil {
+			return err
+		}
+	}
+	for _, pl := range ext.Plugins {
+		if err := installPlugin(username, pl.Name, pl.Marketplace); err != nil {
+			return err
+		}
+	}
+	for _, sk := range ext.Skills {
+		if err := InstallSkill(username, sk); err != nil {
+			return err
+		}
+	}
+	if len(ext.MCPServers) > 0 {
+		if err := SetMCPServers(homeDir, ext.MCPServers, secrets); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -12,6 +13,82 @@ import (
 )
 
 var validName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}$`)
+
+// vaultRefRe matches ${vault:BUCKET.KEY} in MCP server env values.
+var vaultRefRe = regexp.MustCompile(`\$\{vault:([^.}]+)\.([^}]+)\}`)
+
+// MarketplaceConfig declares a Claude Code plugin marketplace to install.
+// source must be "github". commit is optional; when set, provision verifies
+// the cloned HEAD matches before proceeding (supply-chain pin).
+type MarketplaceConfig struct {
+	Name   string `yaml:"name"`
+	Source string `yaml:"source"`
+	Repo   string `yaml:"repo"`
+	Commit string `yaml:"commit"`
+}
+
+// PluginConfig declares a plugin to install from a named marketplace.
+// Accepts the shorthand string form "pluginName@marketplaceName".
+type PluginConfig struct {
+	Name        string `yaml:"name"`
+	Marketplace string `yaml:"marketplace"`
+}
+
+// UnmarshalYAML accepts "name@marketplace" shorthand and the struct form.
+func (p *PluginConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Tag == "!!str" {
+		parts := strings.SplitN(value.Value, "@", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("plugin shorthand must be name@marketplace, got %q", value.Value)
+		}
+		p.Name, p.Marketplace = parts[0], parts[1]
+		return nil
+	}
+	type plain PluginConfig
+	return value.Decode((*plain)(p))
+}
+
+// SkillConfig declares a skill to clone into ~/.claude/skills/<name>/.
+// When path is set, the skill entrypoint is at ~/.claude/skills/<name>/<path>.
+type SkillConfig struct {
+	Name   string `yaml:"name"`
+	Source string `yaml:"source"`
+	Repo   string `yaml:"repo"`
+	Path   string `yaml:"path"`
+}
+
+// MCPServerConfig declares an MCP server to register in ~/.claude/settings.json.
+// Env values may contain ${vault:BUCKET.KEY} refs resolved at provision time.
+// command/args run as the agent OS user; clem.yaml is operator-controlled.
+type MCPServerConfig struct {
+	Name    string            `yaml:"name"`
+	Command string            `yaml:"command"`
+	Args    []string          `yaml:"args"`
+	URL     string            `yaml:"url"`
+	Env     map[string]string `yaml:"env"`
+}
+
+// ExtensionsConfig declares all extensions to install for an agent at provision
+// time. Provision is idempotent: already-installed extensions are no-ops.
+// Removing an entry does not auto-uninstall; re-provision logs a reminder.
+type ExtensionsConfig struct {
+	Marketplaces []MarketplaceConfig `yaml:"marketplaces"`
+	Plugins      []PluginConfig      `yaml:"plugins"`
+	Skills       []SkillConfig       `yaml:"skills"`
+	MCPServers   []MCPServerConfig   `yaml:"mcp_servers"`
+}
+
+// ExpandVaultRefs replaces ${vault:BUCKET.KEY} refs in s using the flat
+// secrets map from vault.DecryptForAgent. Unresolvable refs are left as-is.
+func ExpandVaultRefs(s string, secrets map[string]string) string {
+	return vaultRefRe.ReplaceAllStringFunc(s, func(match string) string {
+		m := vaultRefRe.FindStringSubmatch(match)
+		if v, ok := secrets[m[2]]; ok {
+			return v
+		}
+		return match
+	})
+}
 
 // CavemanLevel controls whether and at what intensity the caveman plugin is
 // injected. Accepts "off"/""  (disabled), "lite", "full", "ultra", or the
@@ -115,6 +192,10 @@ type AgentConfig struct {
 	// logs a warning at runtime.
 	GitName  string `yaml:"git_name"`
 	GitEmail string `yaml:"git_email"`
+	// Extensions declares marketplaces, plugins, skills, and MCP servers to
+	// install for this agent at provision time. caveman: true is handled as a
+	// shorthand that prepends the caveman marketplace and plugin entries.
+	Extensions ExtensionsConfig `yaml:"extensions"`
 	// EgressRestrictionExperimental adds systemd IPAddressDeny=any + IPAddressAllow
 	// rules to the agent service unit. EXPERIMENTAL — known limitations:
 	//
@@ -293,9 +374,46 @@ func Load(path string) (*Config, error) {
 			usedPorts[ac.WebTerminalPort] = key
 		}
 		ac.normalizeSubagentModel()
+		if err := ac.validateExtensions(key); err != nil {
+			return nil, err
+		}
 		cfg.Agents[key] = ac
 	}
 	return &cfg, nil
+}
+
+// validateExtensions checks extension config for an agent identified by key.
+func (ac *AgentConfig) validateExtensions(key string) error {
+	for _, mp := range ac.Extensions.Marketplaces {
+		if mp.Name == "" || mp.Repo == "" {
+			return fmt.Errorf("agent %s: marketplace entry missing name or repo", key)
+		}
+	}
+	for _, sk := range ac.Extensions.Skills {
+		if sk.Name == "" || sk.Repo == "" {
+			return fmt.Errorf("agent %s: skill entry missing name or repo", key)
+		}
+	}
+	for _, mcp := range ac.Extensions.MCPServers {
+		if mcp.Name == "" {
+			return fmt.Errorf("agent %s: mcp_server entry missing name", key)
+		}
+		if mcp.URL == "" && mcp.Command == "" {
+			return fmt.Errorf("agent %s: mcp_server %s requires command or url", key, mcp.Name)
+		}
+		vaultSet := make(map[string]bool, len(ac.Vaults))
+		for _, v := range ac.Vaults {
+			vaultSet[v] = true
+		}
+		for envKey, envVal := range mcp.Env {
+			for _, m := range vaultRefRe.FindAllStringSubmatch(envVal, -1) {
+				if !vaultSet[m[1]] {
+					return fmt.Errorf("agent %s: mcp_server %s: env %s references vault %q not in agent vaults list", key, mcp.Name, envKey, m[1])
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // DefaultSubagentModel is applied when subagent_model is unset in clem.yaml.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -281,3 +281,167 @@ func TestLoad_GitIdentityOptional(t *testing.T) {
 		t.Errorf("expected empty git identity when unset, got name=%q email=%q", ac.GitName, ac.GitEmail)
 	}
 }
+
+func TestLoad_ExtensionsParsed(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    vaults: [github, discord-lead]
+    extensions:
+      marketplaces:
+        - name: caveman
+          source: github
+          repo: JuliusBrussee/caveman
+      plugins:
+        - caveman@caveman
+      skills:
+        - name: security
+          source: github
+          repo: anthropics/skills
+          path: skills/security-pre-commit
+      mcp_servers:
+        - name: context7
+          url: https://mcp.context7.com/mcp
+        - name: discord
+          command: npx
+          args: ["-y", "@some/discord-mcp"]
+          env:
+            DISCORD_TOKEN: "${vault:discord-lead.DISCORD_TOKEN}"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ext := cfg.Agents["lead"].Extensions
+	if len(ext.Marketplaces) != 1 || ext.Marketplaces[0].Name != "caveman" {
+		t.Errorf("marketplaces: got %v", ext.Marketplaces)
+	}
+	if len(ext.Plugins) != 1 || ext.Plugins[0].Name != "caveman" || ext.Plugins[0].Marketplace != "caveman" {
+		t.Errorf("plugins: got %v", ext.Plugins)
+	}
+	if len(ext.Skills) != 1 || ext.Skills[0].Name != "security" || ext.Skills[0].Path != "skills/security-pre-commit" {
+		t.Errorf("skills: got %v", ext.Skills)
+	}
+	if len(ext.MCPServers) != 2 {
+		t.Fatalf("mcp_servers: want 2, got %d", len(ext.MCPServers))
+	}
+	sse := ext.MCPServers[0]
+	if sse.Name != "context7" || sse.URL != "https://mcp.context7.com/mcp" {
+		t.Errorf("mcp_server[0]: got %+v", sse)
+	}
+	disc := ext.MCPServers[1]
+	if disc.Name != "discord" || disc.Command != "npx" {
+		t.Errorf("mcp_server[1]: got %+v", disc)
+	}
+	if disc.Env["DISCORD_TOKEN"] != "${vault:discord-lead.DISCORD_TOKEN}" {
+		t.Errorf("vault ref should be preserved in config, got %q", disc.Env["DISCORD_TOKEN"])
+	}
+}
+
+func TestLoad_ExtensionsMissingVaultRejectsAtLoad(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    vaults: [github]
+    extensions:
+      mcp_servers:
+        - name: discord
+          command: npx
+          env:
+            DISCORD_TOKEN: "${vault:discord-lead.DISCORD_TOKEN}"
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for vault ref to unlisted vault, got nil")
+	}
+}
+
+func TestLoad_ExtensionsMCPMissingCommandAndURL(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    extensions:
+      mcp_servers:
+        - name: broken
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for mcp_server with no command or url, got nil")
+	}
+}
+
+func TestExpandVaultRefs(t *testing.T) {
+	secrets := map[string]string{
+		"DISCORD_TOKEN": "tok123",
+		"GH_TOKEN":      "ghp_abc",
+	}
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"${vault:discord-lead.DISCORD_TOKEN}", "tok123"},
+		{"${vault:github.GH_TOKEN}", "ghp_abc"},
+		{"prefix-${vault:discord-lead.DISCORD_TOKEN}-suffix", "prefix-tok123-suffix"},
+		{"${vault:other.MISSING}", "${vault:other.MISSING}"},
+		{"no refs here", "no refs here"},
+	}
+	for _, tc := range cases {
+		if got := ExpandVaultRefs(tc.in, secrets); got != tc.want {
+			t.Errorf("ExpandVaultRefs(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestPluginConfig_ShorthandUnmarshal(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    extensions:
+      plugins:
+        - caveman@caveman
+        - name: pr-review
+          marketplace: toolkit
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plugins := cfg.Agents["lead"].Extensions.Plugins
+	if len(plugins) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(plugins))
+	}
+	if plugins[0].Name != "caveman" || plugins[0].Marketplace != "caveman" {
+		t.Errorf("plugin[0]: got %+v", plugins[0])
+	}
+	if plugins[1].Name != "pr-review" || plugins[1].Marketplace != "toolkit" {
+		t.Errorf("plugin[1]: got %+v", plugins[1])
+	}
+}


### PR DESCRIPTION
Closes #73.

## What

Adds an `extensions:` block to `AgentConfig` so operators declare marketplaces, plugins, skills, and MCP servers per agent in `clem.yaml`. Provision reconciles state idempotently.

### Config shape

```yaml
agents:
  ada:
    vaults: [github, discord-lead]
    extensions:
      marketplaces:
        - name: caveman
          source: github
          repo: JuliusBrussee/caveman
          commit: c2ed24b3e5d4   # optional pin
      plugins:
        - caveman@caveman          # shorthand: name@marketplace
      skills:
        - name: security
          source: github
          repo: anthropics/skills
          path: skills/security-pre-commit
      mcp_servers:
        - name: context7
          url: https://mcp.context7.com/mcp
        - name: discord
          command: npx
          args: ["-y", "@some/discord-mcp"]
          env:
            DISCORD_TOKEN: "${vault:discord-lead.DISCORD_TOKEN}"
```

### Behaviour

- **Marketplaces**: `git clone` into `~/.claude/plugins/marketplaces/<name>/`, register in `known_marketplaces.json`. Skips clone if directory exists. When `commit:` is set, verifies HEAD matches before proceeding.
- **Plugins**: `claude plugin install name@marketplace && claude plugin enable`. Inspects output (exit code unreliable for already-enabled).
- **Skills**: `git clone` into `~/.claude/skills/<name>/`. When `path:` is set the entrypoint is at `~/.claude/skills/<name>/<path>`.
- **MCP servers**: overwrites the `mcpServers` key in `~/.claude/settings.json` while preserving all other settings. `${vault:BUCKET.KEY}` refs in `env` values are expanded from the agent's decrypted vault secrets at provision time — never stored in plaintext in `clem.yaml`.
- **`caveman: true` backward compat**: translated internally to the equivalent `marketplaces` + `plugins` entries before processing. Existing configs unchanged.
- **Removal**: entries removed from `clem.yaml` are not auto-uninstalled. Re-provision is a no-op for them. Use `claude plugin list` to audit and remove manually.

### Security

- `${vault:BUCKET.KEY}` expansion validates at config load that `BUCKET` is in the agent's `vaults:` list (least-privilege). Invalid refs are rejected before provisioning starts.
- `command`/`args` for MCP servers run as the agent OS user. `clem.yaml` is operator-controlled (root, version-controlled), so adding a `command:` entry is the trust decision — same model as `apt sources.list`.
- `commit:` pin per marketplace lets operators audit a specific SHA. No `commit:` = float at tip.

## Tests added (`internal/config/config_test.go`)

- `TestLoad_ExtensionsParsed` — full extensions block round-trips correctly
- `TestLoad_ExtensionsMissingVaultRejectsAtLoad` — vault ref to unlisted bucket fails at load
- `TestLoad_ExtensionsMCPMissingCommandAndURL` — mcp_server with neither command nor url fails
- `TestExpandVaultRefs` — expansion, prefix/suffix, missing key, no-op
- `TestPluginConfig_ShorthandUnmarshal` — `name@marketplace` shorthand + struct form

## Files changed (source, excl. tests)

| File | +/− |
|---|---|
| `internal/config/config.go` | +118 |
| `internal/agent/manager.go` | +161 / −38 |
| `cmd/provision.go` | +8 / −5 |
| **Total** | **290** |
