### PR TITLE
runner: disable claude.ai connector MCPs in agent sessions

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -24,6 +24,12 @@ log() { echo "$(date -Iseconds) $1" | tee -a "$LOGFILE"; }
 
 tail -500 "$LOGFILE" > "$LOGFILE.tmp" 2>/dev/null && mv "$LOGFILE.tmp" "$LOGFILE" 2>/dev/null
 
+# Disable claude.ai connector MCPs (Figma/Gmail/Drive/M365/...) — agents are
+# headless workers, never need human-account connectors, and the bundled tool
+# lists eat ~1-2k tokens per session. Exported BEFORE sourcing .env so
+# operators can re-enable per-host by setting the var in $HOME/.env.
+export ENABLE_CLAUDEAI_MCP_SERVERS=false
+
 # Load secrets (written by clem provision, never committed)
 [ -f "$HOME/.env" ] && source "$HOME/.env"
 {{.SubagentExport}}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -29,6 +29,8 @@ tail -500 "$LOGFILE" > "$LOGFILE.tmp" 2>/dev/null && mv "$LOGFILE.tmp" "$LOGFILE
 # lists eat ~1-2k tokens per session. Exported BEFORE sourcing .env so
 # operators can re-enable per-host by setting the var in $HOME/.env.
 export ENABLE_CLAUDEAI_MCP_SERVERS=false
+# Skip IDE extension auto-install probe — agents run in headless tmux, no IDE.
+export CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1
 
 # Load secrets (written by clem provision, never committed)
 [ -f "$HOME/.env" ] && source "$HOME/.env"

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -132,6 +132,29 @@ func TestGenerate_PreservesUserKillPPID(t *testing.T) {
 	}
 }
 
+func TestGenerate_DisablesClaudeAIConnectorMCPs(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+
+	out := Generate(cfg, "lead")
+
+	want := "export ENABLE_CLAUDEAI_MCP_SERVERS=false"
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected runner to contain %q, got:\n%s", want, out)
+	}
+
+	// Must export BEFORE sourcing .env so operators can override per-host.
+	exportIdx := strings.Index(out, want)
+	sourceIdx := strings.Index(out, `source "$HOME/.env"`)
+	if exportIdx < 0 || sourceIdx < 0 || exportIdx > sourceIdx {
+		t.Fatalf("expected export to precede .env source (export=%d, source=%d), got:\n%s", exportIdx, sourceIdx, out)
+	}
+}
+
 func TestGenerateService_EgressRestrictionEnabled(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:              "Lead",

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -142,16 +142,19 @@ func TestGenerate_DisablesClaudeAIConnectorMCPs(t *testing.T) {
 
 	out := Generate(cfg, "lead")
 
-	want := "export ENABLE_CLAUDEAI_MCP_SERVERS=false"
-	if !strings.Contains(out, want) {
-		t.Fatalf("expected runner to contain %q, got:\n%s", want, out)
-	}
-
-	// Must export BEFORE sourcing .env so operators can override per-host.
-	exportIdx := strings.Index(out, want)
-	sourceIdx := strings.Index(out, `source "$HOME/.env"`)
-	if exportIdx < 0 || sourceIdx < 0 || exportIdx > sourceIdx {
-		t.Fatalf("expected export to precede .env source (export=%d, source=%d), got:\n%s", exportIdx, sourceIdx, out)
+	for _, want := range []string{
+		"export ENABLE_CLAUDEAI_MCP_SERVERS=false",
+		"export CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected runner to contain %q, got:\n%s", want, out)
+		}
+		// Must export BEFORE sourcing .env so operators can override per-host.
+		exportIdx := strings.Index(out, want)
+		sourceIdx := strings.Index(out, `source "$HOME/.env"`)
+		if exportIdx < 0 || sourceIdx < 0 || exportIdx > sourceIdx {
+			t.Errorf("expected %q to precede .env source (export=%d, source=%d)", want, exportIdx, sourceIdx)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Set `ENABLE_CLAUDEAI_MCP_SERVERS=false` in claude runner template — kills claude.ai connector MCPs (Figma, Gmail, Drive, Calendar, M365, Discord, S&P, Consultant Jobs, ...) that come from the operator's claude.ai account session and leak into every clem agent
- Saves ~1-2k context tokens per session per agent (tool catalogs were the bulk)
- Exported BEFORE sourcing `\$HOME/.env` so operators can re-enable per-host by setting the var in `.env`
- Opencode runner unaffected (opencode bypasses Anthropic's connector layer)

Setting documented at https://code.claude.com/docs/en/mcp

## Follow-up (separate PR / issue)
Other documented token/feature knobs worth considering for headless agents:
- `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1` — agents are tmux-only, no IDE
- `spinnerTipsEnabled: false` (managed-settings) — no human watching spinner
- `awaySummaryEnabled: false` — agent doesn't go AFK
- `terminalProgressBarEnabled: false`, `showTurnDuration: false` — UI noise

## Test plan
- [x] `go test ./internal/runner/...` — new `TestGenerate_DisablesClaudeAIConnectorMCPs` passes; asserts export precedes `.env` source
- [x] `go test ./...` — all green
- [x] `go build ./...` — clean
- [ ] On VPS: pull, rebuild clem, re-provision an agent, check `/mcp` in agent's tmux session shows no `claude_ai_*` servers