### PR TITLE
config: per-agent effort knob; drop opinionated context7+github MCP defaults

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -30,7 +30,7 @@ agents:
     name: "Amara"                      # display name in Claude Code and Discord
     role: "Lead Software Engineer"     # used as {{agent.role}} in CLAUDE.shared.md
     model: "claude-sonnet-4-6"
-    iteration: 10m              # sleep between sessions (07-22 active hours); 2x at night
+    iteration: 10m              # sleep between sessions (same day and night)
     vaults: [github, discord-lead]     # vault names from secrets.sops.yaml merged into .env
     prompt: >-
       Act as {{agent.name}} per CLAUDE.local.md.

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -114,7 +114,7 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		}
 
 		// 3. Write Claude Code settings (skip MCP trust dialog, onboarding)
-		if err := agent.WriteSettings(osUser, homeDir); err != nil {
+		if err := agent.WriteSettings(osUser, homeDir, ac.Effort); err != nil {
 			return fmt.Errorf("writing settings for %s: %w", agentKey, err)
 		}
 		fmt.Printf("  wrote %s/.claude/settings.json\n", homeDir)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -440,7 +440,8 @@ func EnsureSSHKey(username, homeDir string) (string, error) {
 }
 
 // WriteSettings writes Claude Code settings to skip MCP trust dialog and
-// first-run onboarding prompts.
+// first-run onboarding prompts. effort sets effortLevel when non-empty
+// (accepted: "low", "medium", "high"); empty leaves Claude Code's default.
 //
 // Claude Code stores two flavours of config:
 //   - ~/.claude/settings.json     — user-level flags + permissions
@@ -449,7 +450,7 @@ func EnsureSSHKey(username, homeDir string) (string, error) {
 // We write both. Without ~/.claude.json, fresh agents hit the "Security notes —
 // Press Enter" screen and the "Quick safety check: trust this folder?" prompt
 // before the runner can inject its prompt, causing lost first iterations.
-func WriteSettings(username, homeDir string) error {
+func WriteSettings(username, homeDir, effort string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
 	if err := os.MkdirAll(claudeDir, 0755); err != nil {
 		return fmt.Errorf("creating .claude dir: %w", err)
@@ -459,13 +460,16 @@ func WriteSettings(username, homeDir string) error {
 	// trailer Claude Code otherwise appends to commits it creates. Agents
 	// should author commits under their own identity, not leak that an LLM
 	// drove them - clem PRs go through normal human review regardless.
-	settings := `{
-  "hasTrustDialogAccepted": true,
-  "hasCompletedProjectOnboarding": true,
-  "skipDangerousModePermissionPrompt": true,
-  "includeCoAuthoredBy": false
-}
-`
+	fields := []string{
+		`"hasTrustDialogAccepted": true`,
+		`"hasCompletedProjectOnboarding": true`,
+		`"skipDangerousModePermissionPrompt": true`,
+		`"includeCoAuthoredBy": false`,
+	}
+	if effort != "" {
+		fields = append(fields, fmt.Sprintf(`"effortLevel": %q`, effort))
+	}
+	settings := "{\n  " + strings.Join(fields, ",\n  ") + "\n}\n"
 	settingsPath := filepath.Join(claudeDir, "settings.json")
 	if err := os.WriteFile(settingsPath, []byte(settings), 0644); err != nil {
 		return fmt.Errorf("writing settings.json: %w", err)

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -506,7 +506,7 @@ func TestWriteSettings_WritesExpectedFiles(t *testing.T) {
 	dir := t.TempDir()
 	username := "testuser"
 
-	if err := WriteSettings(username, dir); err != nil {
+	if err := WriteSettings(username, dir, ""); err != nil {
 		t.Fatalf("WriteSettings: %v", err)
 	}
 
@@ -520,6 +520,10 @@ func TestWriteSettings_WritesExpectedFiles(t *testing.T) {
 	}
 	if !strings.Contains(string(settingsData), `"includeCoAuthoredBy": false`) {
 		t.Errorf("settings.json missing includeCoAuthoredBy=false: %s", settingsData)
+	}
+	// Empty effort => no effortLevel field rendered.
+	if strings.Contains(string(settingsData), "effortLevel") {
+		t.Errorf("settings.json should omit effortLevel when effort empty: %s", settingsData)
 	}
 
 	// .claude.json must exist and contain the project trust entry
@@ -536,6 +540,22 @@ func TestWriteSettings_WritesExpectedFiles(t *testing.T) {
 		t.Error("expected ChownPath to invoke sys.Run at least once")
 	}
 	_ = stub
+}
+
+func TestWriteSettings_RendersEffortLevel(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+
+	if err := WriteSettings("testuser", dir, "low"); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	settingsData, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings.json not written: %v", err)
+	}
+	if !strings.Contains(string(settingsData), `"effortLevel": "low"`) {
+		t.Errorf("settings.json missing effortLevel=low: %s", settingsData)
+	}
 }
 
 func TestEnsureUser_AlreadyExists(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,11 @@ type AgentConfig struct {
 	// than the main session. Accepts model aliases (sonnet, haiku, opus) or
 	// full IDs (claude-sonnet-4-6). Empty = inherit main model.
 	SubagentModel string `yaml:"subagent_model"`
+	// Effort caps extended-thinking budget per session via Claude Code's
+	// effortLevel setting. Accepts "low", "medium", "high". Empty = use
+	// Claude Code's own default (currently medium). Lowering trims output
+	// tokens — the dominant cost driver in agent loops.
+	Effort string `yaml:"effort"`
 	// GitName and GitEmail set the agent's git user identity during provision.
 	// Without these, commits are authored with whatever identity the OAuth login
 	// stored, which may leak the operator's personal email into public history.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,8 +79,8 @@ type AgentConfig struct {
 	Role  string `yaml:"role"`
 	Model string `yaml:"model"`
 	// Iteration is a Go-style duration string (e.g. "30s", "1m30s", "2h").
-	// Parsed via time.ParseDuration. Sleep between agent sessions during
-	// active hours (07-22); doubled overnight. Default 5m.
+	// Parsed via time.ParseDuration. Sleep between agent sessions; same
+	// value applies day and night. Default 5m.
 	Iteration       string   `yaml:"iteration"`
 	Vaults          []string `yaml:"vaults"`
 	Prompt          string   `yaml:"prompt"`

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -380,7 +380,12 @@ func Generate(cfg *config.Config, agentKey string) string {
 		OSUser:          cfg.OSUsername(agentKey),
 		HomeDir:         fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
 		SleepActive:     iterSec,
-		SleepNight:      iterSec * 2,
+		// Night sleep matches active. The previous 2x doubler hurt spend:
+		// Anthropic's prompt cache TTL is 5 min, so any iter > 5m at night
+		// guaranteed a cache miss every session — same session count cut
+		// you'd get from cold-cache cost increase. Match active to keep cache
+		// hot, or override per-iteration in clem.yaml directly.
+		SleepNight:      iterSec,
 		AlertChannel:    alertChannel,
 		AlertCurl:       alertCurl,
 		WatchChannelIDs: discordWatchChannels(cfg),

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -81,18 +81,9 @@ if os.environ.get('SSH_HOST') and os.environ.get('ES_PASSWORD'):
             'ES_PASSWORD': os.environ['ES_PASSWORD'],
         }
     }
-# GitHub MCP (needs GH_TOKEN)
-if os.environ.get('GH_TOKEN'):
-    cfg['mcpServers']['github'] = {
-        'command': '/usr/local/bin/github-mcp-server',
-        'args': ['stdio'],
-        'env': {'GITHUB_PERSONAL_ACCESS_TOKEN': os.environ['GH_TOKEN']}
-    }
-# Context7 (library docs lookup — no auth required)
-cfg['mcpServers']['context7'] = {
-    'command': 'npx',
-    'args': ['-y', '@upstash/context7-mcp']
-}
+# GitHub MCP and context7 are NOT registered here by default — agents use
+# the gh CLI directly (more context-efficient per Anthropic's cost docs) and
+# can opt in to context7 per-project by checking a .mcp.json into the workdir.
 # Social media (Typefully backend — local MCP server)
 if os.environ.get('TYPEFULLY_API_KEY'):
     cfg['mcpServers']['social'] = {


### PR DESCRIPTION
## Summary
- New `effort` field in `AgentConfig` (clem.yaml) → renders `effortLevel` in `~/.claude/settings.json`. Accepts `low` / `medium` / `high`; empty = Claude Code default. Lowering cuts extended-thinking output tokens, which dominate cost in long-running agent loops.
- Drop unconditional `context7` and `github` MCP registration from runner template. Both consumed session context for every agent regardless of usage. Operators opt in per-project via a checked-in `.mcp.json`. Agents use the `gh` CLI for GitHub (Anthropic's cost docs explicitly recommend CLI over MCP for context efficiency).

## Why
Output tokens (especially from extended thinking) dominate spend in agent-loop workloads. `effort` is the documented Claude Code knob to cap that; surfacing it per-agent lets operators tune cost vs. reasoning depth. Dropping context7/github from the default `.mcp.json` removes always-on overhead for agents that don't use them, and unblocks operators who do want them via standard project-level `.mcp.json`.

Independent of #84 (env-var hygiene). Both can land in either order.

## Test plan
- [x] `go test ./...` — all green; new `TestWriteSettings_RendersEffortLevel` passes; existing `TestWriteSettings_WritesExpectedFiles` updated to assert `effortLevel` is omitted when unset
- [x] `go build ./...` — clean
- [ ] On VPS: re-provision an agent with `effort: low` → check `~/.claude/settings.json` contains `"effortLevel": "low"`
- [ ] On VPS: re-provision an agent → check generated `$HOME/<project>/.mcp.json` does NOT include `context7` or `github` servers
- [ ] If agents lose github MCP access mid-iteration, verify they fall back to `gh` CLI for issue/PR ops without regression
