### PR TITLE
fix(runner): lock CLAUDE.md via systemd ReadOnlyPaths

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -201,7 +201,10 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  wrote %s\n", runnerPath)
 
 		// 5. Install systemd service
-		svcContent := runner.GenerateService(cfg, agentKey)
+		svcContent, err := runner.GenerateService(cfg, agentKey)
+		if err != nil {
+			return fmt.Errorf("generating service for %s: %w", agentKey, err)
+		}
 		if err := agent.InstallService(cfg, agentKey, svcContent); err != nil {
 			return fmt.Errorf("installing service for %s: %w", agentKey, err)
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,12 +2,23 @@ package runner
 
 import (
 	"fmt"
+	"os/user"
 	"sort"
 	"strings"
 
 	"github.com/jahwag/clem/internal/config"
 	"github.com/jahwag/clem/internal/coordination"
 )
+
+// userHomeLookup returns the home directory for the named OS user.
+// Replaced in tests via package-level assignment.
+var userHomeLookup = func(username string) (string, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return "", fmt.Errorf("user %q not found: %w", username, err)
+	}
+	return u.HomeDir, nil
+}
 
 const runnerTemplate = `#!/bin/bash
 set -m
@@ -267,7 +278,7 @@ ExecStart=/usr/bin/tmux new-session -d -s {{.AgentKey}} {{.HomeDir}}/.local/bin/
 ExecStop=/usr/bin/tmux kill-session -t {{.AgentKey}}
 RemainAfterExit=yes
 Restart=no
-{{.EgressDirectives}}
+{{.HardeningDirectives}}{{.EgressDirectives}}
 [Install]
 WantedBy=multi-user.target
 `
@@ -333,7 +344,8 @@ type RunnerParams struct {
 	TtydBind          string
 	AlertChannel      string
 	AlertCurl         string
-	EgressDirectives  string
+	EgressDirectives    string
+	HardeningDirectives string
 	// WatchChannelIDs is the comma-separated list of Discord channel IDs the
 	// MCP server's gateway watcher should observe. Empty disables the watcher
 	// even when DISCORD_TOKEN is set, preserving the original tool-only mode.
@@ -398,22 +410,41 @@ func Generate(cfg *config.Config, agentKey string) string {
 	}
 }
 
+// buildHardeningDirectives returns the systemd filesystem hardening block for
+// an agent service. homeDir must come from os/user.Lookup — not %h, which
+// resolves to the service manager's home (root) in system units (systemd #12389).
+func buildHardeningDirectives(homeDir, project string) string {
+	return fmt.Sprintf(
+		"NoNewPrivileges=yes\nProtectSystem=strict\nProtectHome=read-only\nPrivateTmp=yes\n"+
+			"ReadOnlyPaths=%s/CLAUDE.md %s/CLAUDE.local.md\n"+
+			"ReadWritePaths=%s/.claude %s/.local/state %s/%s\n",
+		homeDir, homeDir, homeDir, homeDir, homeDir, project,
+	)
+}
+
 // GenerateService renders the systemd service unit content for an agent.
-func GenerateService(cfg *config.Config, agentKey string) string {
+// Returns an error if the agent OS user does not exist on the host.
+func GenerateService(cfg *config.Config, agentKey string) (string, error) {
 	ac := cfg.Agents[agentKey]
+	osUser := cfg.OSUsername(agentKey)
+	homeDir, err := userHomeLookup(osUser)
+	if err != nil {
+		return "", fmt.Errorf("generating service for agent %s: %w", agentKey, err)
+	}
 	egress := ""
 	if ac.EgressRestrictionExperimental {
 		egress = egressDirectives
 	}
 	p := RunnerParams{
-		Project:          cfg.Project,
-		AgentKey:         agentKey,
-		AgentName:        ac.Name,
-		OSUser:           cfg.OSUsername(agentKey),
-		HomeDir:          fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
-		EgressDirectives: egress,
+		Project:             cfg.Project,
+		AgentKey:            agentKey,
+		AgentName:           ac.Name,
+		OSUser:              osUser,
+		HomeDir:             homeDir,
+		EgressDirectives:    egress,
+		HardeningDirectives: buildHardeningDirectives(homeDir, cfg.Project),
 	}
-	return renderTemplate(serviceTemplate, p)
+	return renderTemplate(serviceTemplate, p), nil
 }
 
 // GenerateTtydService renders the systemd service unit for the agent's web terminal.
@@ -453,6 +484,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.AlertCurl}}", p.AlertCurl,
 		"{{.SubagentExport}}", p.SubagentExport,
 		"{{.EgressDirectives}}", p.EgressDirectives,
+		"{{.HardeningDirectives}}", p.HardeningDirectives,
 		"{{.WatchChannelIDs}}", p.WatchChannelIDs,
 	)
 	return r.Replace(tmpl)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,11 +1,21 @@
 package runner
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/jahwag/clem/internal/config"
 )
+
+// mockHome overrides userHomeLookup for a test, returning testHome for any user.
+// Returns a cleanup function that restores the original.
+func mockHome(t *testing.T, testHome string) {
+	t.Helper()
+	orig := userHomeLookup
+	userHomeLookup = func(_ string) (string, error) { return testHome, nil }
+	t.Cleanup(func() { userHomeLookup = orig })
+}
 
 func baseCfg(agentKey string, ac config.AgentConfig) *config.Config {
 	return &config.Config{
@@ -159,16 +169,19 @@ func TestGenerate_DisablesClaudeAIConnectorMCPs(t *testing.T) {
 }
 
 func TestGenerateService_EgressRestrictionEnabled(t *testing.T) {
+	mockHome(t, "/home/test-lead")
 	cfg := baseCfg("lead", config.AgentConfig{
-		Name:              "Lead",
-		Model:             "claude-opus-4-7",
-		Iteration:         "1m",
-		Prompt:            "do the thing",
+		Name:                          "Lead",
+		Model:                         "claude-opus-4-7",
+		Iteration:                     "1m",
+		Prompt:                        "do the thing",
 		EgressRestrictionExperimental: true,
 	})
 
-	out := GenerateService(cfg, "lead")
-
+	out, err := GenerateService(cfg, "lead")
+	if err != nil {
+		t.Fatalf("GenerateService: %v", err)
+	}
 	for _, want := range []string{"IPAddressDeny=any", "IPAddressAllow=localhost", "IPAddressAllow=140.82.112.0/20"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in service unit, got:\n%s", want, out)
@@ -177,6 +190,7 @@ func TestGenerateService_EgressRestrictionEnabled(t *testing.T) {
 }
 
 func TestGenerateService_EgressRestrictionDisabled(t *testing.T) {
+	mockHome(t, "/home/test-lead")
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:      "Lead",
 		Model:     "claude-opus-4-7",
@@ -184,8 +198,10 @@ func TestGenerateService_EgressRestrictionDisabled(t *testing.T) {
 		Prompt:    "do the thing",
 	})
 
-	out := GenerateService(cfg, "lead")
-
+	out, err := GenerateService(cfg, "lead")
+	if err != nil {
+		t.Fatalf("GenerateService: %v", err)
+	}
 	if strings.Contains(out, "IPAddressDeny") {
 		t.Fatalf("expected no IPAddressDeny when egress_restriction unset, got:\n%s", out)
 	}
@@ -273,6 +289,7 @@ func TestGenerate_DiscordWatchSkippedForNonDiscordBackend(t *testing.T) {
 }
 
 func TestGenerateService_PullsTtydUp(t *testing.T) {
+	mockHome(t, "/home/test-worker")
 	cfg := baseCfg("worker", config.AgentConfig{
 		Name:      "Worker",
 		Model:     "claude-opus-4-7",
@@ -280,13 +297,72 @@ func TestGenerateService_PullsTtydUp(t *testing.T) {
 		Prompt:    "do the thing",
 	})
 
-	out := GenerateService(cfg, "worker")
-
+	out, err := GenerateService(cfg, "worker")
+	if err != nil {
+		t.Fatalf("GenerateService: %v", err)
+	}
 	// Wants= ensures starting clem-test-worker also pulls the ttyd sidecar.
 	// Without this, BindsTo+PartOf only propagate stops back, leaving the
 	// web terminal dead until the next provision.
 	want := "Wants=clem-ttyd-test-worker.service"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected %q in service unit, got:\n%s", want, out)
+	}
+}
+
+func TestGenerateService_HardeningDirectivesPresent(t *testing.T) {
+	mockHome(t, "/home/test-lead")
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-opus-4-7", Iteration: "1m", Prompt: "do the thing",
+	})
+	out, err := GenerateService(cfg, "lead")
+	if err != nil {
+		t.Fatalf("GenerateService: %v", err)
+	}
+	for _, want := range []string{
+		"NoNewPrivileges=yes",
+		"ProtectSystem=strict",
+		"ProtectHome=read-only",
+		"PrivateTmp=yes",
+		"ReadOnlyPaths=/home/test-lead/CLAUDE.md /home/test-lead/CLAUDE.local.md",
+		"ReadWritePaths=/home/test-lead/.claude /home/test-lead/.local/state /home/test-lead/test",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in service unit, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerateService_HardeningUsesAbsoluteHomePath(t *testing.T) {
+	const customHome = "/data/agents/custom-home"
+	mockHome(t, customHome)
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-opus-4-7", Iteration: "1m", Prompt: "do the thing",
+	})
+	out, err := GenerateService(cfg, "lead")
+	if err != nil {
+		t.Fatalf("GenerateService: %v", err)
+	}
+	if !strings.Contains(out, customHome) {
+		t.Errorf("expected absolute home path %q in service unit, got:\n%s", customHome, out)
+	}
+	if strings.Contains(out, "%h") {
+		t.Errorf("service unit must not contain %%h specifier, got:\n%s", out)
+	}
+}
+
+func TestGenerateService_MissingUserFails(t *testing.T) {
+	orig := userHomeLookup
+	userHomeLookup = func(username string) (string, error) {
+		return "", fmt.Errorf("user not found: %s", username)
+	}
+	t.Cleanup(func() { userHomeLookup = orig })
+
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-opus-4-7", Iteration: "1m", Prompt: "do the thing",
+	})
+	_, err := GenerateService(cfg, "lead")
+	if err == nil {
+		t.Fatal("expected error for missing user, got nil")
 	}
 }


### PR DESCRIPTION
Closes #78.

## What

Adds filesystem hardening to all agent systemd service units so the kernel rejects writes to `~/CLAUDE.md` and `~/CLAUDE.local.md` (EROFS). A compromised agent cannot persist injected instructions across iterations via these auto-loaded files.

Directives added to every agent service unit:
```
NoNewPrivileges=yes
ProtectSystem=strict
ProtectHome=read-only
PrivateTmp=yes
ReadOnlyPaths=<home>/CLAUDE.md <home>/CLAUDE.local.md
ReadWritePaths=<home>/.claude <home>/.local/state <home>/<project>
```

## Why os/user.Lookup instead of %h

`%h` in a system unit resolves to the **service manager's** home (`/root`), not the `User=` target's home — systemd issue [#12389](https://github.com/systemd/systemd/issues/12389). `GenerateService` now calls `os/user.Lookup` at provision time and emits absolute paths. It returns `(string, error)` so a missing OS user surfaces early with a clear message rather than silently producing a broken unit.

## Test coverage

- `TestGenerateService_HardeningDirectivesPresent` — all six directives present
- `TestGenerateService_HardeningUsesAbsoluteHomePath` — custom home path used verbatim, no `%h`
- `TestGenerateService_MissingUserFails` — `(string, error)` surfaces user-not-found error
- Existing egress and ttyd tests updated to use `mockHome` helper

## Out of scope (per issue)

- Permission deny rules (issue #79)
- Locking `~/.claude/skills/` or `~/.claude/plugins/`
- `<workdir>/CLAUDE.md` auto-load hardening (separate design)