### PR TITLE
feat(provision): per-agent permission denies via managed-settings.json

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -234,6 +234,13 @@ func runProvision(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("  installed %s\n", cfg.WatchdogTimerName())
 
+	// 7. Write host-level managed-settings.json (root-owned; agent users cannot override)
+	managedPath := "/etc/claude-code/managed-settings.json"
+	if err := agent.WriteHostManagedSettings(cfg, managedPath); err != nil {
+		return fmt.Errorf("writing managed-settings: %w", err)
+	}
+	fmt.Printf("\nwrote %s\n", managedPath)
+
 	fmt.Printf("\nProvisioning complete. Run 'clem login' then 'clem up'.\n")
 	return nil
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -904,6 +905,37 @@ func InstallExtensions(username, homeDir string, ext config.ExtensionsConfig, ca
 		}
 	}
 	return nil
+}
+
+// WriteHostManagedSettings writes the merged deny list from all agents in cfg
+// to path (typically /etc/claude-code/managed-settings.json). The file is
+// root-owned and cannot be overridden by agent users. Idempotent.
+func WriteHostManagedSettings(cfg *config.Config, path string) error {
+	seen := make(map[string]bool)
+	denies := []string{}
+	for _, ac := range cfg.Agents {
+		for _, d := range ac.Permissions.Deny {
+			if !seen[d] {
+				seen[d] = true
+				denies = append(denies, d)
+			}
+		}
+	}
+	sort.Strings(denies)
+	doc := map[string]any{
+		"permissions": map[string]any{
+			"deny": denies,
+		},
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating managed-settings dir: %w", err)
+	}
+	return os.WriteFile(path, out, 0644)
 }
 
 // LastLogLine returns the last non-empty line of a log file.

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jahwag/clem/internal/config"
 )
 
 // stubExec records invocations and returns canned responses. Replaces sys in tests
@@ -892,4 +894,103 @@ func equalSlice(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestWriteHostManagedSettings_WritesDenyList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "etc", "claude-code", "managed-settings.json")
+
+	cfg := &config.Config{
+		Project: "test",
+		Agents: map[string]config.AgentConfig{
+			"lead": {Permissions: config.PermissionsConfig{Deny: []string{"Bash(curl:*)", "Bash(wget:*)"}}},
+			"worker": {Permissions: config.PermissionsConfig{Deny: []string{"Bash(rm:*)", "Bash(curl:*)"}}},
+		},
+	}
+
+	if err := WriteHostManagedSettings(cfg, path); err != nil {
+		t.Fatalf("WriteHostManagedSettings: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("managed-settings.json not written: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	perms, ok := doc["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected permissions object, got: %v", doc)
+	}
+	deny, ok := perms["deny"].([]any)
+	if !ok {
+		t.Fatalf("expected deny array, got: %v", perms)
+	}
+
+	// curl appears in both agents but must deduplicate; result sorted.
+	wantDenies := []string{"Bash(curl:*)", "Bash(rm:*)", "Bash(wget:*)"}
+	if len(deny) != len(wantDenies) {
+		t.Fatalf("expected %d deny entries, got %d: %v", len(wantDenies), len(deny), deny)
+	}
+	for i, want := range wantDenies {
+		if deny[i] != want {
+			t.Errorf("deny[%d] = %q, want %q", i, deny[i], want)
+		}
+	}
+}
+
+func TestWriteHostManagedSettings_EmptyDenyWhenNoPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed-settings.json")
+
+	cfg := &config.Config{
+		Project: "test",
+		Agents: map[string]config.AgentConfig{
+			"lead": {Name: "Lead"},
+		},
+	}
+
+	if err := WriteHostManagedSettings(cfg, path); err != nil {
+		t.Fatalf("WriteHostManagedSettings: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	perms := doc["permissions"].(map[string]any)
+	deny := perms["deny"].([]any)
+	if len(deny) != 0 {
+		t.Errorf("expected empty deny list, got: %v", deny)
+	}
+}
+
+func TestWriteHostManagedSettings_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed-settings.json")
+	cfg := &config.Config{
+		Project: "test",
+		Agents: map[string]config.AgentConfig{
+			"lead": {Permissions: config.PermissionsConfig{Deny: []string{"Bash(curl:*)"}}},
+		},
+	}
+
+	if err := WriteHostManagedSettings(cfg, path); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	first, _ := os.ReadFile(path)
+
+	if err := WriteHostManagedSettings(cfg, path); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	second, _ := os.ReadFile(path)
+
+	if string(first) != string(second) {
+		t.Errorf("WriteHostManagedSettings not idempotent:\nfirst=%s\nsecond=%s", first, second)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,14 @@ type ExtensionsConfig struct {
 	MCPServers   []MCPServerConfig   `yaml:"mcp_servers"`
 }
 
+// PermissionsConfig declares opt-in deny rules written to the root-owned
+// /etc/claude-code/managed-settings.json at provision time. Deny lists from
+// all agents on the host are merged into one file (managed-settings is
+// host-level, not per-user). Empty or absent block = no clem-injected denies.
+type PermissionsConfig struct {
+	Deny []string `yaml:"deny"`
+}
+
 // ExpandVaultRefs replaces ${vault:BUCKET.KEY} refs in s using the flat
 // secrets map from vault.DecryptForAgent. Unresolvable refs are left as-is.
 func ExpandVaultRefs(s string, secrets map[string]string) string {
@@ -217,6 +225,17 @@ type AgentConfig struct {
 	// install for this agent at provision time. caveman: true is handled as a
 	// shorthand that prepends the caveman marketplace and plugin entries.
 	Extensions ExtensionsConfig `yaml:"extensions"`
+	// Permissions configures root-owned /etc/claude-code/managed-settings.json
+	// deny rules for this agent. managed-settings.json has higher precedence
+	// than the agent's own ~/.claude/settings.json and cannot be overridden by
+	// the agent user. Deny patterns are merged from all agents at provision time.
+	// Empty or absent block means no clem-injected denies for this agent.
+	//
+	// WARNING: Bash(...) arg-pattern denies are fragile — they do not catch
+	// equivalent invocations (env-var URLs, renamed remotes, aliased flags).
+	// For high-stakes constraints, add a PreToolUse hook in addition to or
+	// instead of deny patterns.
+	Permissions PermissionsConfig `yaml:"permissions"`
 	// EgressRestrictionExperimental adds systemd IPAddressDeny=any + IPAddressAllow
 	// rules to the agent service unit. EXPERIMENTAL — known limitations:
 	//


### PR DESCRIPTION
## Summary

- Adds `permissions.deny` list to each agent in `clem.yaml`; parsed into `PermissionsConfig` in `internal/config/config.go`
- `agent.WriteHostManagedSettings` merges deny rules from all agents (deduplicates, sorts), writes `/etc/claude-code/managed-settings.json` (root-owned, cannot be overridden by agent users)
- `clem provision` calls `WriteHostManagedSettings` after the watchdog step; idempotent on re-run

**Pattern fragility caveat:** `Bash(...)` arg-pattern denies do not catch equivalent invocations (env-var URLs, renamed remotes, aliased flags). For high-stakes constraints, add a PreToolUse hook in addition to or instead of deny patterns. This limitation is documented in the `AgentConfig.Permissions` field comment.

**Verified:** `/etc/claude-code/managed-settings.json` is the documented path for Claude Code's host-level managed settings (higher precedence than `~/.claude/settings.json`, agent user cannot override).

## Out of scope (per issue)
- PreToolUse hook generation
- Per-agent scoping within managed-settings
- Cleanup of stale entries when an agent is removed from `clem.yaml`

## Test plan
- [ ] `go test ./...` passes (all existing tests green + 3 new `TestWriteHostManagedSettings_*` tests)
- [ ] Two agents with overlapping deny entries → merged file has deduplicated, sorted list
- [ ] Agent with no `permissions` block → `deny` array is empty (`[]`)
- [ ] Double provision produces identical file (idempotent)

Closes #79