### PR TITLE
fix(agent): single-quote .env values to prevent bash variable expansion

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -114,7 +114,10 @@ func WriteEnvFile(username, homeDir string, secrets map[string]string) error {
 
 	var sb strings.Builder
 	for k, v := range secrets {
-		sb.WriteString(fmt.Sprintf("export %s=%q\n", k, v))
+		// Single-quote the value so bash treats it as fully literal.
+		// Only ' needs escaping: end the quoted string, append literal ', reopen.
+		escaped := strings.ReplaceAll(v, "'", `'\''`)
+		sb.WriteString(fmt.Sprintf("export %s='%s'\n", k, escaped))
 	}
 
 	if err := os.WriteFile(envPath, []byte(sb.String()), 0600); err != nil {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -610,6 +610,39 @@ func TestWriteEnvFile_WritesSecretsAndGitignore(t *testing.T) {
 	}
 }
 
+func TestWriteEnvFile_SingleQuotesSpecialChars(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	// Values containing $, backtick, and ' must be written literally (no bash expansion).
+	secrets := map[string]string{
+		"DOLLAR":   "foo$bar",
+		"BACKTICK": "foo`bar`baz",
+		"QUOTE":    "it's here",
+	}
+
+	if err := WriteEnvFile("testuser", dir, secrets); err != nil {
+		t.Fatalf("WriteEnvFile: %v", err)
+	}
+
+	envData, err := os.ReadFile(filepath.Join(dir, ".env"))
+	if err != nil {
+		t.Fatalf(".env not written: %v", err)
+	}
+	envStr := string(envData)
+
+	// All values must use single-quote syntax so bash treats them as literals.
+	if !strings.Contains(envStr, "export DOLLAR='foo$bar'") {
+		t.Errorf("DOLLAR not single-quoted literally: %s", envStr)
+	}
+	if !strings.Contains(envStr, "export BACKTICK='foo`bar`baz'") {
+		t.Errorf("BACKTICK not single-quoted literally: %s", envStr)
+	}
+	// Single quote in value must be escaped as '\''
+	if !strings.Contains(envStr, `export QUOTE='it'\''s here'`) {
+		t.Errorf("QUOTE single-quote not escaped correctly: %s", envStr)
+	}
+}
+
 func TestConfigureGit_WritesSigningConfig(t *testing.T) {
 	withStub(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #64.

## Problem

`WriteEnvFile` used `fmt.Sprintf("export %s=%q\n", k, v)`. Go's `%q` verb produces double-quoted strings that do **not** escape `$` or backticks. When bash sources the `.env` file, values containing `$` are silently truncated by variable expansion, and backtick values trigger subshell execution.

## Fix

Single-quote each value. The only character requiring escaping in a bash single-quoted string is `'` itself, handled by the `'\''` pattern:

```go
escaped := strings.ReplaceAll(v, "'", `'\''`)
sb.WriteString(fmt.Sprintf("export %s='%s'\n", k, escaped))
```

## Tests

Added `TestWriteEnvFile_SingleQuotesSpecialChars` asserting that values containing `$`, backtick, and `'` are written with the correct single-quote escaping.