### PR TITLE
fix(config): reject invalid effort values at Load() time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -426,6 +426,12 @@ func Load(path string) (*Config, error) {
 			}
 			usedPorts[ac.WebTerminalPort] = key
 		}
+		switch ac.Effort {
+		case "", "low", "medium", "high":
+			// valid
+		default:
+			return nil, fmt.Errorf("agent %s: effort must be low, medium, or high, got %q", key, ac.Effort)
+		}
 		ac.normalizeSubagentModel()
 		if err := ac.validateExtensions(key); err != nil {
 			return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,9 +220,9 @@ type AgentConfig struct {
 	// full IDs (claude-sonnet-4-6). Empty = inherit main model.
 	SubagentModel string `yaml:"subagent_model"`
 	// Effort caps extended-thinking budget per session via Claude Code's
-	// effortLevel setting. Accepts "low", "medium", "high". Empty = use
-	// Claude Code's own default (currently medium). Lowering trims output
-	// tokens — the dominant cost driver in agent loops.
+	// effortLevel setting. Accepts "low", "medium", "high", "xhigh", "max".
+	// Empty = use Claude Code's own default (currently medium). Lowering trims
+	// output tokens — the dominant cost driver in agent loops.
 	Effort string `yaml:"effort"`
 	// GitName and GitEmail set the agent's git user identity during provision.
 	// Without these, commits are authored with whatever identity the OAuth login
@@ -427,10 +427,10 @@ func Load(path string) (*Config, error) {
 			usedPorts[ac.WebTerminalPort] = key
 		}
 		switch ac.Effort {
-		case "", "low", "medium", "high":
+		case "", "low", "medium", "high", "xhigh", "max":
 			// valid
 		default:
-			return nil, fmt.Errorf("agent %s: effort must be low, medium, or high, got %q", key, ac.Effort)
+			return nil, fmt.Errorf("agent %s: effort must be low, medium, high, xhigh, or max, got %q", key, ac.Effort)
 		}
 		ac.normalizeSubagentModel()
 		if err := ac.validateExtensions(key); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -693,3 +693,55 @@ agents:
 	}
 }
 
+func TestLoad_EffortValidValues(t *testing.T) {
+	for _, effort := range []string{"", "low", "medium", "high"} {
+		yaml := `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    effort: ` + effort + "\n"
+		if effort == "" {
+			yaml = `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+`
+		}
+		path := writeYAML(t, yaml)
+		if _, err := Load(path); err != nil {
+			t.Errorf("effort=%q: unexpected error: %v", effort, err)
+		}
+	}
+}
+
+func TestLoad_EffortInvalidRejects(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    effort: hight
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid effort value, got nil")
+	}
+}
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -694,7 +694,7 @@ agents:
 }
 
 func TestLoad_EffortValidValues(t *testing.T) {
-	for _, effort := range []string{"", "low", "medium", "high"} {
+	for _, effort := range []string{"", "low", "medium", "high", "xhigh", "max"} {
 		yaml := `
 project: myteam
 coordination:


### PR DESCRIPTION
Closes #95.

## Problem

`AgentConfig.Effort` accepted any string. A typo like `effort: hight` wrote `"effortLevel": "hight"` to `settings.json` with no error, silently ignoring the operator's intent.

## Fix

Added a `switch` in the per-agent validation loop in `Load()` — same pattern used for `runtime` and `provider` validation. Valid values: `""`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`; anything else returns an error at config load time.

## Tests

- `TestLoad_EffortValidValues`: asserts all six valid values (including empty) load without error.
- `TestLoad_EffortInvalidRejects`: asserts `effort: hight` returns a non-nil error.