### PR TITLE
fix(provision): pass project name directly to WriteSettings

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -114,7 +114,7 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		}
 
 		// 3. Write Claude Code settings (skip MCP trust dialog, onboarding)
-		if err := agent.WriteSettings(osUser, homeDir, ac.Effort); err != nil {
+		if err := agent.WriteSettings(osUser, homeDir, cfg.Project, ac.Effort); err != nil {
 			return fmt.Errorf("writing settings for %s: %w", agentKey, err)
 		}
 		fmt.Printf("  wrote %s/.claude/settings.json\n", homeDir)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -455,7 +455,7 @@ func EnsureSSHKey(username, homeDir string) (string, error) {
 // We write both. Without ~/.claude.json, fresh agents hit the "Security notes —
 // Press Enter" screen and the "Quick safety check: trust this folder?" prompt
 // before the runner can inject its prompt, causing lost first iterations.
-func WriteSettings(username, homeDir, effort string) error {
+func WriteSettings(username, homeDir, project, effort string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
 	if err := os.MkdirAll(claudeDir, 0755); err != nil {
 		return fmt.Errorf("creating .claude dir: %w", err)
@@ -484,7 +484,7 @@ func WriteSettings(username, homeDir, effort string) error {
 	// lastOnboardingVersion prevents the next claude upgrade from re-prompting.
 	// projects.<workdir>.hasTrustDialogAccepted dismisses the folder-trust
 	// dialog for the agent's working directory.
-	workDirKey := filepath.Join(homeDir, projectFromUsername(username))
+	workDirKey := filepath.Join(homeDir, project)
 	appState := fmt.Sprintf(`{
   "hasCompletedOnboarding": true,
   "lastOnboardingVersion": "99.0.0",
@@ -507,16 +507,6 @@ func WriteSettings(username, homeDir, effort string) error {
 	ChownPath(claudeDir, username)
 	ChownPath(appStatePath, username)
 	return nil
-}
-
-// projectFromUsername extracts the project name from a clem-provisioned OS
-// username of the form "<project>-<agentkey>". Used to locate the agent's
-// working directory for the per-project trust entry in ~/.claude.json.
-func projectFromUsername(username string) string {
-	if i := strings.LastIndex(username, "-"); i > 0 {
-		return username[:i]
-	}
-	return username
 }
 
 // InstallService writes and enables a systemd service for an agent.

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -430,20 +430,21 @@ func writeTestableHook(t *testing.T, stubDiffCmd string) string {
 
 // --- Executor seam tests ---
 
-func TestProjectFromUsername(t *testing.T) {
-	cases := []struct {
-		in, want string
-	}{
-		{"myproject-ada", "myproject"},
-		{"clem-dev-ada", "clem-dev"},
-		{"nohyphen", "nohyphen"},
-		{"", ""},
+func TestWriteSettings_WorkdirKeyUsesProjectDirectly(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	// Agent key "my-agent" contains a hyphen; project is "myproject".
+	// The workdir key in .claude.json must be homeDir/myproject, not homeDir/myproject-my.
+	if err := WriteSettings("myproject-my-agent", dir, "myproject", ""); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
 	}
-	for _, tc := range cases {
-		got := projectFromUsername(tc.in)
-		if got != tc.want {
-			t.Errorf("projectFromUsername(%q) = %q, want %q", tc.in, got, tc.want)
-		}
+	data, err := os.ReadFile(filepath.Join(dir, ".claude.json"))
+	if err != nil {
+		t.Fatalf(".claude.json not written: %v", err)
+	}
+	wantKey := filepath.Join(dir, "myproject")
+	if !strings.Contains(string(data), wantKey) {
+		t.Errorf(".claude.json workdir key: want %q in\n%s", wantKey, data)
 	}
 }
 
@@ -508,7 +509,7 @@ func TestWriteSettings_WritesExpectedFiles(t *testing.T) {
 	dir := t.TempDir()
 	username := "testuser"
 
-	if err := WriteSettings(username, dir, ""); err != nil {
+	if err := WriteSettings(username, dir, "myproject", ""); err != nil {
 		t.Fatalf("WriteSettings: %v", err)
 	}
 
@@ -548,7 +549,7 @@ func TestWriteSettings_RendersEffortLevel(t *testing.T) {
 	withStub(t)
 	dir := t.TempDir()
 
-	if err := WriteSettings("testuser", dir, "low"); err != nil {
+	if err := WriteSettings("testuser", dir, "myproject", "low"); err != nil {
 		t.Fatalf("WriteSettings: %v", err)
 	}
 	settingsData, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))


### PR DESCRIPTION
Closes #96.

## Problem

`WriteSettings` called `projectFromUsername(username)` to derive the working-directory key for the per-project trust entry in `~/.claude.json`. That function used `strings.LastIndex` to strip the agent-key suffix, assuming the agent key has no hyphens.

Agent keys match `^[a-z][a-z0-9-]{0,30}$` so hyphens are valid. With project `myproject` and agent key `my-agent`, the username is `myproject-my-agent`; `LastIndex` finds the last `-` and returns `myproject-my` instead of `myproject`. Claude Code finds no matching trust entry and fires the folder-trust dialog on first run, wasting the first iteration.

## Fix

Removed `projectFromUsername` and added a `project` parameter to `WriteSettings`. The caller (`runProvision` in `cmd/provision.go`) already has `cfg.Project` — no re-derivation needed.

## Tests

- Deleted `TestProjectFromUsername` (function removed).
- Added `TestWriteSettings_WorkdirKeyUsesProjectDirectly`: provisions with username `myproject-my-agent` (hyphenated agent key) and project `myproject`, asserts the workdir key in `.claude.json` is `<homeDir>/myproject`, not `<homeDir>/myproject-my`.
- Updated existing `WriteSettings` tests to pass the new `project` argument.