### PR TITLE
fix(provision): move JoinsNamespaceOf to [Unit] section (followup #107)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -317,15 +317,17 @@ Description=Clem web terminal: {{.AgentName}} ({{.Project}})
 After=clem-{{.Project}}-{{.AgentKey}}.service
 BindsTo=clem-{{.Project}}-{{.AgentKey}}.service
 PartOf=clem-{{.Project}}-{{.AgentKey}}.service
+# The agent unit runs with PrivateTmp=yes, so its tmux socket lives in a
+# private /tmp namespace. ttyd must enter that same namespace to attach.
+# JoinsNamespaceOf belongs in [Unit] (not [Service]); systemd silently
+# ignores it elsewhere. The directive is also a no-op unless this unit
+# itself enables PrivateTmp below.
+JoinsNamespaceOf=clem-{{.Project}}-{{.AgentKey}}.service
 
 [Service]
 Type=simple
 User={{.OSUser}}
-# The agent unit runs with PrivateTmp=yes, so its tmux socket lives in a
-# private /tmp namespace. ttyd must enter that same namespace to attach;
-# JoinsNamespaceOf is a no-op unless this unit also enables PrivateTmp.
 PrivateTmp=yes
-JoinsNamespaceOf=clem-{{.Project}}-{{.AgentKey}}.service
 ExecStart=/usr/local/bin/ttyd -R -i {{.TtydBind}} -p {{.TtydPort}} tmux attach-session -t {{.AgentKey}}
 Restart=on-failure
 RestartSec=5

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -329,6 +329,19 @@ func TestGenerateTtydService_JoinsAgentPrivateTmp(t *testing.T) {
 			t.Errorf("expected %q in ttyd unit, got:\n%s", want, out)
 		}
 	}
+
+	// JoinsNamespaceOf is a [Unit]-section directive. If it lands in
+	// [Service] systemd silently ignores it and the namespace is not joined
+	// (clem #106 follow-up). Anchor on newline to avoid matching the same
+	// tokens inside doc comments.
+	serviceIdx := strings.Index(out, "\n[Service]")
+	joinsIdx := strings.Index(out, "\nJoinsNamespaceOf=")
+	if serviceIdx == -1 || joinsIdx == -1 {
+		t.Fatalf("missing required section/directive in ttyd unit:\n%s", out)
+	}
+	if joinsIdx > serviceIdx {
+		t.Errorf("JoinsNamespaceOf must live in [Unit] before [Service], got:\n%s", out)
+	}
 }
 
 func TestGenerateService_HardeningDirectivesPresent(t *testing.T) {


### PR DESCRIPTION
## Summary

- v0.8.1 (#107) put `JoinsNamespaceOf=` in `[Service]`. systemd silently ignores it there (it's a `[Unit]`-section directive), so ttyd kept its own mount namespace and the bug was not actually fixed.
- Verified on cdev: `readlink /proc/<lead>/ns/mnt` = `mnt:[4026532482]` but `readlink /proc/<ttyd>/ns/mnt` = `mnt:[4026532485]` despite the directive being present in the unit file.
- Move the directive into `[Unit]` and add a regression test that anchors on newlines (`\n[Service]`, `\nJoinsNamespaceOf=`) so doc-comment occurrences can't fool the index check.

Followup to #107 / closes the original symptom from #106.

## Test plan

- [x] `go test ./...`
- [ ] After merge: re-provision cdev on v0.8.2, restart, compare `/proc/<lead>/ns/mnt` vs `/proc/<ttyd>/ns/mnt` — should match.
- [ ] Open `http://127.0.0.1:7681/` and confirm tmux session attaches.