### PR TITLE
fix(provision): grant ReadWrite for ~/.claude.json

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -420,12 +420,17 @@ func Generate(cfg *config.Config, agentKey string) string {
 // buildHardeningDirectives returns the systemd filesystem hardening block for
 // an agent service. homeDir must come from os/user.Lookup — not %h, which
 // resolves to the service manager's home (root) in system units (systemd #12389).
+//
+// ReadWritePaths must include both ~/.claude (settings dir written at provision
+// time) and ~/.claude.json (Claude Code's runtime state file at the home root).
+// The latter sits OUTSIDE .claude/ and ProtectHome=read-only would otherwise
+// trip Claude Code's startup with EROFS on first write.
 func buildHardeningDirectives(homeDir, project string) string {
 	return fmt.Sprintf(
 		"NoNewPrivileges=yes\nProtectSystem=strict\nProtectHome=read-only\nPrivateTmp=yes\n"+
 			"ReadOnlyPaths=%s/CLAUDE.md %s/CLAUDE.local.md\n"+
-			"ReadWritePaths=%s/.claude %s/.local/state %s/%s\n",
-		homeDir, homeDir, homeDir, homeDir, homeDir, project,
+			"ReadWritePaths=%s/.claude %s/.claude.json %s/.local/state %s/%s\n",
+		homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, project,
 	)
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -359,7 +359,7 @@ func TestGenerateService_HardeningDirectivesPresent(t *testing.T) {
 		"ProtectHome=read-only",
 		"PrivateTmp=yes",
 		"ReadOnlyPaths=/home/test-lead/CLAUDE.md /home/test-lead/CLAUDE.local.md",
-		"ReadWritePaths=/home/test-lead/.claude /home/test-lead/.local/state /home/test-lead/test",
+		"ReadWritePaths=/home/test-lead/.claude /home/test-lead/.claude.json /home/test-lead/.local/state /home/test-lead/test",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in service unit, got:\n%s", want, out)


### PR DESCRIPTION
## Summary

Claude Code writes runtime state to \`~/.claude.json\` (a file at the home root, not inside \`.claude/\`). After #87 added \`ProtectHome=read-only\`, agent startup tripped on first write:

\`\`\`
EROFS: read-only file system, open '/home/cdev-lead/.claude.json'
\`\`\`

Add the file to \`ReadWritePaths\` alongside \`~/.claude\`, \`~/.local/state\`, and the project dir.

## Test plan

- [x] \`go test ./...\` (existing hardening test extended to assert the new path)
- [ ] After merge: re-provision, restart agent, confirm no EROFS in journal and \`.claude.json\` updates on first run.