### PR TITLE
fix(config): validate provider and provider_url at Load() time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -417,6 +417,9 @@ func Load(path string) (*Config, error) {
 		if _, err := ac.IterationDuration(); err != nil {
 			return nil, fmt.Errorf("agent %s: %w", key, err)
 		}
+		if _, err := ac.ProviderEnv(); err != nil {
+			return nil, fmt.Errorf("agent %s: %w", key, err)
+		}
 		if ac.WebTerminalPort != 0 {
 			if ac.WebTerminalPort < 1024 || ac.WebTerminalPort > 65535 {
 				return nil, fmt.Errorf("agent %s: web_terminal_port must be 1024-65535, got %d", key, ac.WebTerminalPort)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -219,6 +219,7 @@ agents:
     name: "Lead"
     model: "llama3"
     provider: ollama
+    provider_url: "http://localhost:11434"
 `
 	path := writeYAML(t, yaml)
 	cfg, err := Load(path)
@@ -742,6 +743,63 @@ agents:
 	_, err := Load(path)
 	if err == nil {
 		t.Fatal("expected error for invalid effort value, got nil")
+	}
+}
+
+func TestLoad_ProviderUnknownRejectsAtLoad(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  worker:
+    name: "Worker"
+    model: "claude-sonnet-4-6"
+    provider: olaama
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for unknown provider, got nil")
+	}
+}
+
+func TestLoad_ProviderOllamaMissingURLRejectsAtLoad(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  worker:
+    name: "Worker"
+    model: "llama3"
+    provider: ollama
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for ollama missing provider_url, got nil")
+	}
+}
+
+func TestLoad_ProviderOllamaWithURLAccepted(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  worker:
+    name: "Worker"
+    model: "llama3"
+    provider: ollama
+    provider_url: "http://localhost:11434"
+`)
+	if _, err := Load(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Load()` now validates the `provider` field and the `provider_url` requirement for `ollama`/`openai-compat` agents immediately, rather than silently passing and failing later during `clem provision`.

The fix calls `ac.ProviderEnv()` (pure read, no side effects) inside the agent validation loop and wraps any error with the agent key for context. Three tests added: unknown provider rejected, ollama missing URL rejected, ollama with URL accepted. The existing `TestLoad_SubagentModelNoDefaultForOllama` test was updated to supply the now-required `provider_url`.

Closes #83