### PR TITLE
fix(provision): use git_email as allowed_signers principal when set

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -337,6 +337,9 @@ func ConfigureGit(username, homeDir, pubKey, gitName, gitEmail string) error {
 	}
 
 	commitEmail := username + "@clem"
+	if gitEmail != "" {
+		commitEmail = gitEmail
+	}
 	allowedSignersPath := filepath.Join(sshDir, "allowed_signers")
 	if err := os.WriteFile(allowedSignersPath, []byte(commitEmail+" "+pubKey+"\n"), 0644); err != nil {
 		return fmt.Errorf("writing allowed_signers: %w", err)

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -796,8 +796,9 @@ func TestConfigureGit_WritesUserIdentity(t *testing.T) {
 	withStub(t)
 	dir := t.TempDir()
 	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
+	gitEmail := "212849679+clauderesearch@users.noreply.github.com"
 
-	if err := ConfigureGit("testuser", dir, pubKey, "clauderesearch", "212849679+clauderesearch@users.noreply.github.com"); err != nil {
+	if err := ConfigureGit("testuser", dir, pubKey, "clauderesearch", gitEmail); err != nil {
 		t.Fatalf("ConfigureGit: %v", err)
 	}
 
@@ -809,8 +810,17 @@ func TestConfigureGit_WritesUserIdentity(t *testing.T) {
 	if !strings.Contains(gcStr, "\tname = clauderesearch") {
 		t.Errorf(".gitconfig missing name: %s", gcStr)
 	}
-	if !strings.Contains(gcStr, "\temail = 212849679+clauderesearch@users.noreply.github.com") {
+	if !strings.Contains(gcStr, "\temail = "+gitEmail) {
 		t.Errorf(".gitconfig missing email: %s", gcStr)
+	}
+
+	asData, err := os.ReadFile(filepath.Join(dir, ".ssh", "allowed_signers"))
+	if err != nil {
+		t.Fatalf("allowed_signers not written: %v", err)
+	}
+	asStr := string(asData)
+	if !strings.HasPrefix(asStr, gitEmail+" ") {
+		t.Errorf("allowed_signers principal should be gitEmail %q, got: %s", gitEmail, asStr)
 	}
 }
 


### PR DESCRIPTION
Closes #57.

## Problem

`ConfigureGit` always wrote `username@clem` as the principal in `~/.ssh/allowed_signers`. When `git_email` is set in `clem.yaml`, the committer email in `.gitconfig` is `git_email`, not `username@clem`. Git matches the committer email against principals in `allowed_signers` when verifying signatures, so `git verify-commit HEAD` reported "No principal matched" for any agent with `git_email` configured.

## Fix

Use `git_email` as the `allowed_signers` principal when it is non-empty; fall back to `username@clem` only when `git_email` is not set.

## Test

Extended `TestConfigureGit_WritesUserIdentity` to assert that `allowed_signers` starts with `gitEmail` when one is provided. Existing tests for the no-email fallback and idempotency are unchanged and still pass.