### PR TITLE
fix(provision,agent): unblock OAuth refresh + claude self-update under hardening (v0.8.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,13 @@ Not Linux, or missing core userspace. Use a standard Ubuntu/Debian host.
 Inspect the service: `systemctl status clem-<project>-<agentkey>.service`. Common causes: `.env` missing (run `clem provision` again after setting vaults), `claude` not installed per agent (provision reinstalls), or MCP server binary missing on PATH.
 
 **Agent not posting to Discord/Slack**  
-Check `clem logs <agent>`. The runner logs MCP server startup. If `mcp-discord` is missing, install: `pip3 install --break-system-packages git+https://github.com/Bytelope/mcp-discord.git`. Confirm the bot was invited to the server. **`DISCORD_TOKEN` must be the raw token** (no `Bot ` prefix); `discord.py` adds it internally - pasting `"Bot …"` yields 401. For Slack: use a bot token (`xoxb-`), not a user token (`xoxp-`) - user tokens post as you, not the bot.
+Check `clem logs <agent>`. The runner logs MCP server startup. If `mcp-discord` is missing, install with `pipx` (recommended) so its dependencies live in an isolated venv: `pipx install git+https://github.com/Bytelope/mcp-discord.git`. Avoid `pip install --break-system-packages` for Python MCP servers - the agent service runs with `ProtectHome=read-only`, so any later dependency drift (e.g. a system `pydantic-core` upgrade desyncing from the wheel an MCP server was built against) cannot be self-healed from inside the sandbox and the MCP will fail to boot. `pipx` venvs decouple each MCP from system Python state and survive `apt upgrade`. Confirm the bot was invited to the server. **`DISCORD_TOKEN` must be the raw token** (no `Bot ` prefix); `discord.py` adds it internally - pasting `"Bot …"` yields 401. For Slack: use a bot token (`xoxb-`), not a user token (`xoxp-`) - user tokens post as you, not the bot.
 
-**Token expired** (`clem status` shows `EXPIRED`)  
-Re-run `sudo clem login <agent>`. OAuth tokens last ~30 days. You can also automate refresh via cron.
+**`clem login` keeps prompting daily / `clem status` flips to `EXPIRED` every 8 hours**  
+You probably ran a clem older than v0.8.4. The Claude Max access token genuinely lasts only ~8 hours, but Claude Code refreshes it automatically using the long-lived refresh token stored alongside it. Pre-0.8.4 `clem status` displayed the *access* token expiry and pre-0.8.4 `NeedsLogin` gated on a 7-day window - so it always reported "expired" and trained operators to log in daily for nothing. Upgrade to v0.8.4+; status now shows `auto-refresh` whenever a refresh token is present, and only reports `missing` when manual `clem login` is actually required.
+
+**Token actually missing** (`clem status` shows `missing`)  
+Re-run `sudo clem login <agent>`. The refresh token itself is long-lived; you only need to re-login if the credentials file is wiped or the refresh token is server-side revoked.
 
 **Agent wakes up and does nothing**  
 Open the task forum - threads must exist with `[TODO]` status. Agents only work what's on the board.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -53,16 +53,10 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		expiry := agent.TokenExpiry(fmt.Sprintf("/home/%s", osUser))
-		expiryStr := "missing"
-		if !expiry.IsZero() {
-			daysLeft := int(time.Until(expiry).Hours() / 24)
-			if daysLeft < 0 {
-				expiryStr = fmt.Sprintf("EXPIRED (%d days)", -daysLeft)
-			} else {
-				expiryStr = fmt.Sprintf("%s (%dd)", expiry.Format("2006-01-02"), daysLeft)
-			}
-		}
+		homeDir := fmt.Sprintf("/home/%s", osUser)
+		expiry := agent.TokenExpiry(homeDir)
+		hasRefresh := agent.HasRefreshToken(homeDir)
+		expiryStr := tokenExpiryDisplay(expiry, hasRefresh)
 
 		logPath := fmt.Sprintf("/home/%s/.claude/%s-runner.log", osUser, agentKey)
 		lastLog := agent.LastLogLine(logPath)
@@ -79,4 +73,28 @@ func repeatStr(s string, n int) string {
 		result += s
 	}
 	return result
+}
+
+// tokenExpiryDisplay formats the access-token expiry for `clem status`.
+// Claude Max access tokens last ~8h and are refreshed transparently, so we
+// distinguish "no credentials at all" (login required) from "access token
+// short/expired but refresh token present" (auto-refresh handles it).
+func tokenExpiryDisplay(expiry time.Time, hasRefresh bool) string {
+	if expiry.IsZero() && !hasRefresh {
+		return "missing"
+	}
+	if expiry.IsZero() {
+		return "auto-refresh"
+	}
+	remaining := time.Until(expiry)
+	if remaining < 0 {
+		if hasRefresh {
+			return "auto-refresh"
+		}
+		return fmt.Sprintf("EXPIRED (%dd)", -int(remaining.Hours()/24))
+	}
+	if remaining < 24*time.Hour {
+		return fmt.Sprintf("%s (%dh)", expiry.Format("2006-01-02"), int(remaining.Hours()))
+	}
+	return fmt.Sprintf("%s (%dd)", expiry.Format("2006-01-02"), int(remaining.Hours()/24))
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// tokenExpiryDisplay encodes the user-visible truth that Claude Max access
+// tokens are short-lived but auto-refreshed; without these branches the
+// pre-0.8.4 cosmetic "EXPIRES 0d" alarm comes back.
+func TestTokenExpiryDisplay(t *testing.T) {
+	cases := []struct {
+		name       string
+		expiry     time.Time
+		hasRefresh bool
+		wantSub    string
+	}{
+		{"missing-everything", time.Time{}, false, "missing"},
+		{"refresh-only-no-expiry", time.Time{}, true, "auto-refresh"},
+		{"expired-but-refresh-present", time.Now().Add(-2 * time.Hour), true, "auto-refresh"},
+		{"expired-and-no-refresh", time.Now().Add(-72 * time.Hour), false, "EXPIRED"},
+		{"valid-hours", time.Now().Add(3 * time.Hour), true, "h)"},
+		{"valid-days", time.Now().Add(5 * 24 * time.Hour), true, "d)"},
+	}
+	for _, tc := range cases {
+		got := tokenExpiryDisplay(tc.expiry, tc.hasRefresh)
+		if !strings.Contains(got, tc.wantSub) {
+			t.Errorf("%s: got %q, want substring %q", tc.name, got, tc.wantSub)
+		}
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -614,35 +614,53 @@ func TmuxAlive(osUser, sessionName string) bool {
 // credentials is a subset of ~/.claude/.credentials.json
 type credentials struct {
 	ClaudeAiOauth struct {
-		ExpiresAt int64 `json:"expiresAt"`
+		ExpiresAt    int64  `json:"expiresAt"`
+		RefreshToken string `json:"refreshToken"`
 	} `json:"claudeAiOauth"`
 }
 
-// TokenExpiry reads the Claude token expiry from <homeDir>/.claude/.credentials.json.
-// Returns zero time if missing or unreadable.
-func TokenExpiry(homeDir string) time.Time {
+func readCredentials(homeDir string) (credentials, bool) {
 	credPath := filepath.Join(homeDir, ".claude", ".credentials.json")
 	data, err := os.ReadFile(credPath)
 	if err != nil {
-		return time.Time{}
+		return credentials{}, false
 	}
 	var creds credentials
 	if err := json.Unmarshal(data, &creds); err != nil {
-		return time.Time{}
+		return credentials{}, false
 	}
-	if creds.ClaudeAiOauth.ExpiresAt == 0 {
+	return creds, true
+}
+
+// TokenExpiry reads the Claude access-token expiry from <homeDir>/.claude/.credentials.json.
+// Returns zero time if missing or unreadable. Note: Claude Max access tokens
+// have an ~8-hour life and are auto-refreshed by Claude Code using the
+// refresh token — see HasRefreshToken / NeedsLogin.
+func TokenExpiry(homeDir string) time.Time {
+	creds, ok := readCredentials(homeDir)
+	if !ok || creds.ClaudeAiOauth.ExpiresAt == 0 {
 		return time.Time{}
 	}
 	return time.Unix(creds.ClaudeAiOauth.ExpiresAt/1000, 0)
 }
 
-// NeedsLogin returns true if the token is missing or expires within 7 days.
+// HasRefreshToken reports whether <homeDir>/.claude/.credentials.json contains
+// a non-empty OAuth refresh token. This is the real "logged in" signal —
+// Claude Code uses the refresh token to mint new ~8h access tokens
+// automatically, so a present refresh token means no manual login is needed
+// even if the access token has already expired.
+func HasRefreshToken(homeDir string) bool {
+	creds, ok := readCredentials(homeDir)
+	return ok && creds.ClaudeAiOauth.RefreshToken != ""
+}
+
+// NeedsLogin returns true only when manual `claude /login` is actually
+// required: the credentials file is missing, unreadable, or carries no
+// refresh token. Access-token expiry is intentionally NOT checked — those
+// are short-lived (~8h) and refreshed transparently by Claude Code, so
+// gating on access expiry would prompt unnecessary daily logins.
 func NeedsLogin(homeDir string) bool {
-	expiry := TokenExpiry(homeDir)
-	if expiry.IsZero() {
-		return true
-	}
-	return time.Until(expiry) < 7*24*time.Hour
+	return !HasRefreshToken(homeDir)
 }
 
 // ChownPath changes ownership of a path to the given user (best effort).

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -487,20 +487,59 @@ func TestNeedsLogin_NoToken(t *testing.T) {
 	}
 }
 
-func TestNeedsLogin_ValidToken(t *testing.T) {
-	dir := t.TempDir()
+// writeCreds is a small helper for credentials-file fixtures.
+func writeCreds(t *testing.T, dir string, oauth map[string]any) {
+	t.Helper()
 	claudeDir := filepath.Join(dir, ".claude")
 	if err := os.MkdirAll(claudeDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	future := time.Now().Add(30 * 24 * time.Hour)
-	creds := map[string]any{
-		"claudeAiOauth": map[string]any{"expiresAt": future.UnixMilli()},
+	data, err := json.Marshal(map[string]any{"claudeAiOauth": oauth})
+	if err != nil {
+		t.Fatal(err)
 	}
-	data, _ := json.Marshal(creds)
-	os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), data, 0600) //nolint:errcheck
+	if err := os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Refresh-token presence — not access-token expiry — gates NeedsLogin.
+// Claude Max access tokens live ~8h and refresh transparently; gating on
+// expiry would prompt unnecessary daily logins.
+func TestNeedsLogin_RefreshTokenPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeCreds(t, dir, map[string]any{
+		"expiresAt":    time.Now().Add(-1 * time.Hour).UnixMilli(), // already expired
+		"refreshToken": "rt_abc",
+	})
 	if NeedsLogin(dir) {
-		t.Error("NeedsLogin should return false when token is valid for 30 days")
+		t.Error("NeedsLogin should return false when a refresh token is present, even if access token expired")
+	}
+}
+
+func TestNeedsLogin_RefreshTokenMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeCreds(t, dir, map[string]any{
+		"expiresAt": time.Now().Add(24 * time.Hour).UnixMilli(),
+		// no refreshToken
+	})
+	if !NeedsLogin(dir) {
+		t.Error("NeedsLogin should return true when refresh token is missing — access token alone cannot self-renew")
+	}
+}
+
+func TestHasRefreshToken(t *testing.T) {
+	dir := t.TempDir()
+	if HasRefreshToken(dir) {
+		t.Error("HasRefreshToken should be false when credentials file is missing")
+	}
+	writeCreds(t, dir, map[string]any{"refreshToken": ""})
+	if HasRefreshToken(dir) {
+		t.Error("HasRefreshToken should be false when refreshToken is empty")
+	}
+	writeCreds(t, dir, map[string]any{"refreshToken": "rt_xyz"})
+	if !HasRefreshToken(dir) {
+		t.Error("HasRefreshToken should be true when refreshToken is non-empty")
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -421,16 +421,26 @@ func Generate(cfg *config.Config, agentKey string) string {
 // an agent service. homeDir must come from os/user.Lookup — not %h, which
 // resolves to the service manager's home (root) in system units (systemd #12389).
 //
-// ReadWritePaths must include both ~/.claude (settings dir written at provision
-// time) and ~/.claude.json (Claude Code's runtime state file at the home root).
-// The latter sits OUTSIDE .claude/ and ProtectHome=read-only would otherwise
-// trip Claude Code's startup with EROFS on first write.
+// ReadWritePaths must cover every path Claude Code writes during normal
+// operation under ProtectHome=read-only. Missing any of these causes EROFS
+// at runtime which can manifest as failed self-update, broken OAuth refresh
+// (refresh-token rotation needs to persist new credentials staging state),
+// or hung MCP servers:
+//   - ~/.claude              settings + .credentials.json
+//   - ~/.claude.json         runtime state at home root, outside .claude/
+//   - ~/.cache/claude        Claude Code XDG cache (sessions, staging)
+//   - ~/.cache/claude-cli-nodejs  legacy cache path used by older builds
+//   - ~/.local/share/claude  XDG data dir; `claude install` writes versions here
+//   - ~/.local/state         systemd-recommended XDG state dir
+//   - ~/.npm                 npm cache used by claude install when fetching tarballs
+//   - ~/<project>            agent's working tree
 func buildHardeningDirectives(homeDir, project string) string {
 	return fmt.Sprintf(
 		"NoNewPrivileges=yes\nProtectSystem=strict\nProtectHome=read-only\nPrivateTmp=yes\n"+
 			"ReadOnlyPaths=%s/CLAUDE.md %s/CLAUDE.local.md\n"+
-			"ReadWritePaths=%s/.claude %s/.claude.json %s/.local/state %s/%s\n",
-		homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, project,
+			"ReadWritePaths=%s/.claude %s/.claude.json %s/.cache/claude %s/.cache/claude-cli-nodejs %s/.local/share/claude %s/.local/state %s/.npm %s/%s\n",
+		homeDir, homeDir,
+		homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, project,
 	)
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -359,7 +359,7 @@ func TestGenerateService_HardeningDirectivesPresent(t *testing.T) {
 		"ProtectHome=read-only",
 		"PrivateTmp=yes",
 		"ReadOnlyPaths=/home/test-lead/CLAUDE.md /home/test-lead/CLAUDE.local.md",
-		"ReadWritePaths=/home/test-lead/.claude /home/test-lead/.claude.json /home/test-lead/.local/state /home/test-lead/test",
+		"ReadWritePaths=/home/test-lead/.claude /home/test-lead/.claude.json /home/test-lead/.cache/claude /home/test-lead/.cache/claude-cli-nodejs /home/test-lead/.local/share/claude /home/test-lead/.local/state /home/test-lead/.npm /home/test-lead/test",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in service unit, got:\n%s", want, out)


### PR DESCRIPTION
## Summary
- Two regressions from the v0.8.x hardening rollout (PR #87 chain) combined to make Claude Code agents appear to log out daily on cdev.
- **`buildHardeningDirectives`** now grants `ReadWritePaths` for `~/.cache/claude`, `~/.cache/claude-cli-nodejs`, `~/.local/share/claude` and `~/.npm`. Previously these were blocked by `ProtectHome=read-only`, causing every iteration to log `EROFS: read-only file system, open '/home/<user>/.local/share/claude/versions/...'` from `claude install`. The same write block can trip OAuth refresh-token rotation (Anthropic stages the new credentials before atomic rename), invalidating the refresh token and forcing manual `claude /login`.
- **`NeedsLogin`** previously gated on `time.Until(accessTokenExpiry) < 7*24*time.Hour`. Claude Max access tokens last ~8h and are refreshed transparently from the refresh token, so this check was always true for Max users. `clem status` therefore always read `TOKEN EXPIRES 0d`, training operators to log in daily even when refresh worked. New behaviour: gate on refresh-token presence (`HasRefreshToken`); display `auto-refresh` whenever a refresh token is present, hours-precision when <1d access remains, and `missing` only when manual login is genuinely required.
- README troubleshooting section: explain the daily-login false alarm and recommend `pipx` for Python MCP servers (the hardening also blocks `pip install` inside the agent sandbox, so isolated venvs are the supported path).

## Empirical evidence
Reproduced the EROFS chain on the cdev VPS via `systemd-run` with the v0.8.3 hardening profile:
```
OK_credentials_tmp
BLOCKED_cache
BLOCKED_local_share
/usr/bin/bash: line 1: /home/cdev-lead/.cache/claude/test.tmp: Read-only file system
/usr/bin/bash: line 1: /home/cdev-lead/.local/share/claude/test.tmp: Read-only file system
```
Worker runner log corroborates: every iteration emits the same `EROFS .../local/share/claude/versions/2.1.132` line.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all green
- [x] `runner_test`: updated `TestGenerateService_HardeningDirectivesPresent` covers the new `ReadWritePaths` entries
- [x] `manager_test`: new `TestNeedsLogin_RefreshTokenPresent`, `TestNeedsLogin_RefreshTokenMissing`, `TestHasRefreshToken` pin the new semantics
- [x] `status_test` (new file): `TestTokenExpiryDisplay` covers all six branches of the display helper
- [ ] After merge: tag `v0.8.4`, then on cdev `ssh cdev 'clem update && clem provision'` to regenerate the systemd units with the new hardening directives. Verify no `EROFS` in worker runner log on next iteration. Verify `clem status` shows `auto-refresh` instead of `0d` once the access token rotates.