### PR TITLE
fix(watchdog): write OOM marker after journal scan, not before

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -122,13 +122,13 @@ check_agent() {
 
 check_oom() {
     local marker="$COOLDOWN_DIR/oom.last"
-    local since
+    local since new_ts
+    new_ts=$(date +%s)
     if [ -f "$marker" ]; then
         since="@$(cat "$marker")"
     else
         since="5 minutes ago"
     fi
-    date +%s > "$marker"
 
     local hits
     hits=$(journalctl --since "$since" --no-pager 2>/dev/null \
@@ -140,6 +140,7 @@ check_oom() {
         mem=$(free -h | awk '/^Mem:/ {printf "%s/%s", $3, $2} /^Swap:/ {printf " swap=%s/%s", $3, $2}')
         send_alert "🔥 clem/$PROJECT OOM-kill detected (last 5min): $hits — RAM $mem"
     fi
+    echo "$new_ts" > "$marker"
 }
 
 {{.AgentChecks}}

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -76,4 +76,12 @@ func TestGenerateScript_OOMCheckPresent(t *testing.T) {
 	if defIdx == -1 || callIdx == -1 || callIdx <= defIdx {
 		t.Errorf("check_oom must be defined and then invoked (def=%d call=%d)", defIdx, callIdx)
 	}
+
+	// marker must be written after the journalctl scan to avoid silently
+	// dropping events on interruption between the two lines.
+	markerWriteIdx := strings.Index(s, `echo "$new_ts" > "$marker"`)
+	journalIdx := strings.Index(s, `journalctl --since "$since" --no-pager`)
+	if markerWriteIdx == -1 || journalIdx == -1 || markerWriteIdx <= journalIdx {
+		t.Errorf("marker write must appear after journalctl scan (markerWrite=%d journalctl=%d)", markerWriteIdx, journalIdx)
+	}
 }


### PR DESCRIPTION
Closes #74.

## Problem

`check_oom()` wrote `oom.last` **before** running `journalctl`. Any interruption between those two lines (SIGTERM on systemd stop, concurrent tick, self-OOM) advanced the marker past events that were never scanned. The next invocation used the already-advanced timestamp as its `--since` lower bound and silently dropped every OOM event in that gap.

The bare `date +%s > "$marker"` redirect also produced a zero-byte file on disk-full, causing subsequent invocations to pass `--since "@"` to journalctl (suppressed by `2>/dev/null`), silently disabling OOM alerting until the marker was manually repaired.

## Fix

- Capture `new_ts=$(date +%s)` before the scan so the covered window is bounded regardless of scan duration.
- Move the marker write (`echo "$new_ts" > "$marker"`) to after the `journalctl` pipeline completes.
- Worst case on interruption: the same window is rescanned on the next tick, which may produce a duplicate alert. This is preferable to a silent miss.

## Test

Added an ordering assertion to `TestGenerateScript_OOMCheckPresent`: the marker write (`echo "$new_ts" > "$marker"`) must appear after the `journalctl` call in the generated script.