### PR TITLE
fix(agent): pre-push hook scopes to added lines + clem:allow-secret marker

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -212,9 +212,31 @@ const UnicodeTrapRegex = `[\x{200B}-\x{200F}\x{2028}-\x{202E}\x{FEFF}]`
 //  2. Base64-encoded secrets: long base64 runs are decoded and re-scanned
 //     against SecretPatternRegex. Closes encoded-exfil bypass.
 //  3. Unicode traps: zero-width + bidi-override + BOM mid-content. Closes
-//     hidden-instruction-smuggling bypass.
+//     hidden-instruction-smuggling bypass. No allow-marker — zero-width
+//     and bidi-override characters are never legitimate in source.
 //  4. Code that reads protected secret env vars (Go/Python/Node). Closes
 //     indirect runtime-exfil bypass. Skip with CLEM_HOOK_SKIP_CODE_SCAN=1.
+//
+// Two scoping rules apply to passes 1, 2, and 4 to keep the hook usable
+// when forks legitimately need to sync history that contains test fixtures
+// for the very regexes we install:
+//
+//   a. Only ADDED diff lines (lines starting with `+`, excluding the
+//      `+++ b/path` file headers) are scanned. A removed line cannot
+//      introduce a secret to the remote even if it textually matches —
+//      it was already there. This eliminates the most common false
+//      positive: cumulative-diff fork-sync where an unannotated old
+//      version of a fixture line is being replaced by an annotated new
+//      version, and both versions appear in the diff.
+//
+//   b. Lines containing the literal marker `clem:allow-secret` are
+//      dropped before scanning. This is the documented escape hatch for
+//      legitimate test fixtures (e.g. positives tables for the hook's
+//      own regex tests). The marker is namespaced to avoid colliding
+//      with prose mentions and is scoped to the same line as the
+//      secret-shaped string. Pass 3 ignores the marker by design.
+const PrePushAllowSecretMarker = "clem:allow-secret"
+
 var prePushHookContent = fmt.Sprintf(`#!/bin/bash
 # Installed by clem provision. Do not edit by hand - will be overwritten.
 # Pass 1: literal credential patterns (tokens, keys, PEM blocks).
@@ -222,11 +244,23 @@ var prePushHookContent = fmt.Sprintf(`#!/bin/bash
 # Pass 3: Unicode traps (zero-width / bidi / BOM - hidden-instruction smuggling).
 # Pass 4: code that reads protected secret env vars (Go/Python/Node).
 #         Skip with: CLEM_HOOK_SKIP_CODE_SCAN=1 git push
+#
+# Scope (passes 1, 2, 4): added lines only (^\+ excluding ^\+\+\+), and
+# any line carrying the marker '%s' is skipped. Pass 3 scans every line
+# regardless because hidden-character smuggling has no legitimate use.
 
 zero="0000000000000000000000000000000000000000"
 patterns='%s'
 code_patterns='%s'
 unicode_traps='%s'
+allow_marker='%s'
+
+# extract_added prints diff lines that introduce content on the remote:
+# they start with a single '+' (the '+++' file-header line is excluded)
+# and do not carry the allow-secret marker.
+extract_added() {
+  grep -E '^\+([^+]|$)' | grep -v -F "$allow_marker"
+}
 
 while read local_ref local_sha remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue
@@ -239,21 +273,22 @@ while read local_ref local_sha remote_ref remote_sha; do
     diff_cmd="git diff $range"
   fi
   diff=$($diff_cmd 2>/dev/null)
+  added=$(echo "$diff" | extract_added)
 
-  # Pass 1: direct literal secret match
-  hits=$(echo "$diff" | grep -E "$patterns" | head -3)
+  # Pass 1: direct literal secret match (added lines, no allow-marker).
+  hits=$(echo "$added" | grep -E "$patterns" | head -3)
   if [ -n "$hits" ]; then
     echo "clem pre-push hook: push blocked - secret pattern detected in $range" >&2
     echo "$hits" | sed 's/^/  /' >&2
     echo "" >&2
     echo "Rotate the leaked credential immediately if it is real. To override" >&2
-    echo "for a false positive, push with --no-verify (think first)." >&2
+    echo "for an intentional test fixture, append '$allow_marker' to the same" >&2
+    echo "line. As a last resort, push with --no-verify (think first)." >&2
     exit 1
   fi
 
-  # Pass 2: base64-decode + re-scan. Finds long base64 runs, decodes each,
-  # greps the decoded bytes for secret patterns. Skips chunks that fail to
-  # decode (normal diff content).
+  # Pass 2: base64-decode + re-scan added lines. Long base64 runs that
+  # decode to secret-shaped bytes are blocked.
   while IFS= read -r chunk; do
     [ -z "$chunk" ] && continue
     decoded=$(echo "$chunk" | base64 -d 2>/dev/null) || continue
@@ -262,9 +297,11 @@ while read local_ref local_sha remote_ref remote_sha; do
       echo "  $chunk -> decoded hit" >&2
       exit 1
     fi
-  done < <(echo "$diff" | grep -oE '[A-Za-z0-9+/]{40,}={0,2}')
+  done < <(echo "$added" | grep -oE '[A-Za-z0-9+/]{40,}={0,2}')
 
-  # Pass 3: unicode traps for hidden-instruction smuggling.
+  # Pass 3: unicode traps. Scans the entire diff (added + removed +
+  # context) since hidden control characters never have a legitimate
+  # source-code use; allow-marker intentionally ignored.
   uhits=$(echo "$diff" | grep -P "$unicode_traps" | head -3)
   if [ -n "$uhits" ]; then
     echo "clem pre-push hook: push blocked - unicode control/override characters detected in $range (possible prompt-injection smuggling)" >&2
@@ -274,18 +311,19 @@ while read local_ref local_sha remote_ref remote_sha; do
 
   # Pass 4: indirect runtime exfil via os.Getenv on protected names.
   if [ "${CLEM_HOOK_SKIP_CODE_SCAN:-0}" != "1" ]; then
-    code_hits=$(echo "$diff" | grep -E "$code_patterns" | head -3)
+    code_hits=$(echo "$added" | grep -E "$code_patterns" | head -3)
     if [ -n "$code_hits" ]; then
       echo "clem pre-push hook: push blocked - diff reads a protected secret env var in $range" >&2
       echo "$code_hits" | sed 's/^/  /' >&2
       echo "" >&2
-      echo "Set CLEM_HOOK_SKIP_CODE_SCAN=1 if this read is intentional and reviewed." >&2
+      echo "Set CLEM_HOOK_SKIP_CODE_SCAN=1 if this read is intentional and reviewed," >&2
+      echo "or append '$allow_marker' to the line if it is a test fixture." >&2
       exit 1
     fi
   fi
 done
 exit 0
-`, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapRegex)
+`, PrePushAllowSecretMarker, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapRegex, PrePushAllowSecretMarker)
 
 // ConfigureGit writes SSH commit-signing configuration and optionally the git
 // user identity to the agent's ~/.gitconfig. Idempotent — safe to call every

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -58,19 +58,19 @@ func TestSecretPatternRegex_MatchesKnownCredentials(t *testing.T) {
 		name  string
 		input string
 	}{
-		{"github classic PAT", "ghp_1234567890abcdefghijklmnopqrstuvwxyz"},
-		{"github OAuth token", "gho_1234567890abcdefghijklmnopqrstuvwxyz"},
-		{"github App server", "ghs_1234567890abcdefghijklmnopqrstuvwxyz"},
-		{"github fine-grained PAT", "github_pat_11ABCDEFG0abcdefghijkl_" + strings.Repeat("a", 60)},
-		{"anthropic API key", "sk-ant-abcdefghijklmnopqrstuvwxyz12345"},
-		{"openai API key", "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890"},
-		{"slack bot token", "xoxb-1234567890-0987654321-abcdefghij"},
-		{"slack user token", "xoxp-1234567890-abcdefghij-klmnopqrst"},
-		{"aws access key", "AKIAIOSFODNN7EXAMPLE"},
-		{"age secret key", "AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNO"},
-		{"openssh private key", "-----BEGIN OPENSSH PRIVATE KEY-----"},
-		{"rsa private key", "-----BEGIN RSA PRIVATE KEY-----"},
-		{"generic private key", "-----BEGIN PRIVATE KEY-----"},
+		{"github classic PAT", "ghp_1234567890abcdefghijklmnopqrstuvwxyz"},                                  // clem:allow-secret
+		{"github OAuth token", "gho_1234567890abcdefghijklmnopqrstuvwxyz"},                                  // clem:allow-secret
+		{"github App server", "ghs_1234567890abcdefghijklmnopqrstuvwxyz"},                                   // clem:allow-secret
+		{"github fine-grained PAT", "github_pat_11ABCDEFG0abcdefghijkl_" + strings.Repeat("a", 60)},         // clem:allow-secret
+		{"anthropic API key", "sk-ant-abcdefghijklmnopqrstuvwxyz12345"},                                     // clem:allow-secret
+		{"openai API key", "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890"},                                  // clem:allow-secret
+		{"slack bot token", "xoxb-1234567890-0987654321-abcdefghij"},                                        // clem:allow-secret
+		{"slack user token", "xoxp-1234567890-abcdefghij-klmnopqrst"},                                       // clem:allow-secret
+		{"aws access key", "AKIAIOSFODNN7EXAMPLE"},                                                          // clem:allow-secret
+		{"age secret key", "AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNO"},           // clem:allow-secret
+		{"openssh private key", "-----BEGIN OPENSSH PRIVATE KEY-----"},                                      // clem:allow-secret
+		{"rsa private key", "-----BEGIN RSA PRIVATE KEY-----"},                                              // clem:allow-secret
+		{"generic private key", "-----BEGIN PRIVATE KEY-----"},                                              // clem:allow-secret
 	}
 	for _, tc := range positives {
 		if !re.MatchString(tc.input) {
@@ -128,6 +128,12 @@ func TestPrePushHookContent_IsExecutableBash(t *testing.T) {
 	}
 	if !strings.Contains(prePushHookContent, "base64 -d") {
 		t.Error("pre-push hook should include base64 decode pass (Pass 2, red-team A9)")
+	}
+	if !strings.Contains(prePushHookContent, PrePushAllowSecretMarker) {
+		t.Errorf("pre-push hook should embed allow-marker %q so bash and Go agree on the bypass token", PrePushAllowSecretMarker)
+	}
+	if !strings.Contains(prePushHookContent, `grep -E '^\+([^+]|$)'`) {
+		t.Error("pre-push hook should restrict secret-pattern scanning to ADDED diff lines (^+ excluding ^+++)")
 	}
 }
 
@@ -192,7 +198,7 @@ func TestPrePushHook_BlocksBase64EncodedSecret(t *testing.T) {
 		}
 	}
 	// Construct the base64 of a fake GitHub PAT.
-	token := "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+	token := "ghp_1234567890abcdefghijklmnopqrstuvwxyz" // clem:allow-secret
 	// Go's encoding/base64 is imported at package level in other tests - use
 	// the /usr/bin/base64 binary here to keep this test self-contained.
 	encodedCmd := exec.Command("bash", "-c", "echo -n "+token+" | base64")
@@ -271,7 +277,7 @@ func TestPrePushHook_BlocksSecretPush(t *testing.T) {
 	}
 
 	hookPath := writeTestableHook(t,
-		"echo '+token = \"ghp_1234567890abcdefghijklmnopqrstuvwxyz\"'")
+		"echo '+token = \"ghp_1234567890abcdefghijklmnopqrstuvwxyz\"'") // clem:allow-secret
 
 	cmd := exec.Command("bash", hookPath)
 	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
@@ -281,6 +287,73 @@ func TestPrePushHook_BlocksSecretPush(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "push blocked") {
 		t.Errorf("hook output missing 'push blocked' message:\n%s", out)
+	}
+}
+
+// TestPrePushHook_AllowsRemovedSecretLine pins the added-only scope rule:
+// a removed line that textually matches the secret pattern cannot leak the
+// token to the remote (it was already there and is now being deleted), so
+// the hook must NOT block. Without this rule, every fork-sync that touches
+// a file whose previous version contained a secret-shaped fixture is blocked
+// — see the regression Ada reported on cdev 2026-05-09.
+func TestPrePushHook_AllowsRemovedSecretLine(t *testing.T) {
+	for _, bin := range []string{"bash", "grep"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+	hookPath := writeTestableHook(t,
+		"echo '-token = \"ghp_1234567890abcdefghijklmnopqrstuvwxyz\"'") // clem:allow-secret
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hook should have exited 0 on removed-line diff, got error %v. output:\n%s", err, out)
+	}
+}
+
+// TestPrePushHook_AllowsLineWithAllowMarker pins the marker escape hatch:
+// an ADDED line containing a secret-shaped string AND the
+// PrePushAllowSecretMarker on the same line must NOT block. This lets the
+// hook's own regex test fixtures live in the repo without making fork sync
+// a wedge. The marker must be on the SAME line as the secret — line scope is
+// intentional so a stray marker elsewhere cannot blanket-bypass scanning.
+func TestPrePushHook_AllowsLineWithAllowMarker(t *testing.T) {
+	for _, bin := range []string{"bash", "grep"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+	// Build the stub diff line at runtime so this source line itself does
+	// not embed a secret-shaped literal that would trip the hook when the
+	// commit lands.
+	addedLine := "+token := \"ghp_" + strings.Repeat("X", 36) + "\" // " + PrePushAllowSecretMarker
+	hookPath := writeTestableHook(t, "echo '"+addedLine+"'")
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hook should have exited 0 on marker-bearing line, got error %v. output:\n%s", err, out)
+	}
+}
+
+// TestPrePushHook_StillBlocksAddedSecretWithoutMarker is the negative side
+// of the marker rule: removing the marker brings the block back. Together
+// with TestPrePushHook_AllowsLineWithAllowMarker this guarantees the marker
+// is the only difference and not a regex-loosening bug.
+func TestPrePushHook_StillBlocksAddedSecretWithoutMarker(t *testing.T) {
+	for _, bin := range []string{"bash", "grep"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH - skipping integration test", bin)
+		}
+	}
+	addedLine := "+token := \"ghp_" + strings.Repeat("X", 36) + "\""
+	hookPath := writeTestableHook(t, "echo '"+addedLine+"'")
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader("refs/heads/feature aaa refs/heads/feature bbb\n")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("hook should have blocked added secret without marker, got exit 0. output:\n%s", out)
 	}
 }
 
@@ -315,14 +388,14 @@ func TestSecretCodePatternRegex_MatchesKnownPatterns(t *testing.T) {
 		name  string
 		input string
 	}{
-		{"go GH_TOKEN", `token := os.Getenv("GH_TOKEN")`},
-		{"go DISCORD_TOKEN", `d := os.Getenv("DISCORD_TOKEN")`},
-		{"go ANTHROPIC_API_KEY", `k := os.Getenv("ANTHROPIC_API_KEY")`},
-		{"go AWS_SECRET_ACCESS_KEY", `s := os.Getenv("AWS_SECRET_ACCESS_KEY")`},
-		{"go SLACK_MCP_XOXP_TOKEN", `t := os.Getenv("SLACK_MCP_XOXP_TOKEN")`},
-		{"python double-quote GH_TOKEN", `tok = os.environ["GH_TOKEN"]`},
-		{"node GH_TOKEN", `const t = process.env.GH_TOKEN`},
-		{"node ANTHROPIC_API_KEY", `const k = process.env.ANTHROPIC_API_KEY`},
+		{"go GH_TOKEN", `token := os.Getenv("GH_TOKEN")`},                  // clem:allow-secret
+		{"go DISCORD_TOKEN", `d := os.Getenv("DISCORD_TOKEN")`},            // clem:allow-secret
+		{"go ANTHROPIC_API_KEY", `k := os.Getenv("ANTHROPIC_API_KEY")`},    // clem:allow-secret
+		{"go AWS_SECRET_ACCESS_KEY", `s := os.Getenv("AWS_SECRET_ACCESS_KEY")`}, // clem:allow-secret
+		{"go SLACK_MCP_XOXP_TOKEN", `t := os.Getenv("SLACK_MCP_XOXP_TOKEN")`},   // clem:allow-secret
+		{"python double-quote GH_TOKEN", `tok = os.environ["GH_TOKEN"]`},   // clem:allow-secret
+		{"node GH_TOKEN", `const t = process.env.GH_TOKEN`},                // clem:allow-secret
+		{"node ANTHROPIC_API_KEY", `const k = process.env.ANTHROPIC_API_KEY`}, // clem:allow-secret
 	}
 	for _, tc := range positives {
 		if !re.MatchString(tc.input) {


### PR DESCRIPTION
## Summary
- Pre-push hook scanned every line of the cumulative diff (added/removed/context). Two consequences: forks couldn't sync upstream main once `manager_test.go` (which intentionally ships secret-shaped fixtures for the regex tests) changed in upstream, and consumer-repo test fixtures had no documented escape hatch besides `--no-verify`.
- Reported by Ada (clem-dev agent on cdev) on 2026-05-09 after v0.9.1 squash-merged `manager_test.go` changes; her workaround was to skip syncing main and branch from the local ref instead.

## Two new scoping rules (passes 1, 2, 4 — pass 3 unicode unchanged)
**a. Added-line scope.** Only `^\+` lines (excluding `^\+\+\+` file headers) are scanned. A removed line cannot leak a token to the remote — it was already there. Eliminates the cumulative-diff fork-sync false positive entirely.

**b. `clem:allow-secret` marker.** Lines containing the literal marker are dropped before scanning. Marker is namespaced (no prose collisions) and same-line scoped (no blanket bypass via stray markers). Single Go const `PrePushAllowSecretMarker` is the source of truth for both bash hook and Go tests, mirroring `SecretPatternRegex`. Pass 3 (unicode traps) deliberately ignores the marker — zero-width / bidi-override / BOM characters never have a legitimate source-code use.

## Fixture annotations
The hook's own positive-fixture lines in `manager_test.go` (`TestSecretPatternRegex_MatchesKnownCredentials`, `TestSecretCodePatternRegex_MatchesKnownPatterns`, two integration test stubs) are annotated with `// clem:allow-secret`. Post-merge fork sync will not regress.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all green
- [x] `TestPrePushHookContent_IsExecutableBash` now also asserts marker + `^\+([^+]|$)` filter present
- [x] `TestPrePushHook_AllowsRemovedSecretLine`: stub diff with `-` line carrying secret must NOT block (added-only scope)
- [x] `TestPrePushHook_AllowsLineWithAllowMarker`: stub diff with `+` line carrying secret AND marker must NOT block. Pattern built at runtime from `ghp_` + 36 X's so this source line doesn't embed a literal that would later trip the hook
- [x] `TestPrePushHook_StillBlocksAddedSecretWithoutMarker`: removing the marker brings the block back (proves marker is the only difference, regex not loosened)
- [x] Existing block tests still pass — each stub diff uses `+`-prefixed line and none carry the marker
- [ ] After merge: ship v0.9.2, `clem update && clem provision` on cdev, restart agents — Ada can then sync upstream main without the workaround

## Deploy
1. Merge → tag v0.9.2 → release
2. `ssh cdev`
3. `clem update`
4. `cd /opt/clem-self-dev && clem provision` (regenerates Ada's hook with new scope rules)
5. `cd /root/consultant-dev-team && clem provision` (cdev project for completeness)
6. `systemctl restart clem-cdev-lead clem-cdev-worker clem-clem-dev-ada`