### PR TITLE
fix(provision): drop ProtectHome=read-only; rely on Unix 0750 home perms

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -421,26 +421,38 @@ func Generate(cfg *config.Config, agentKey string) string {
 // an agent service. homeDir must come from os/user.Lookup — not %h, which
 // resolves to the service manager's home (root) in system units (systemd #12389).
 //
-// ReadWritePaths must cover every path Claude Code writes during normal
-// operation under ProtectHome=read-only. Missing any of these causes EROFS
-// at runtime which can manifest as failed self-update, broken OAuth refresh
-// (refresh-token rotation needs to persist new credentials staging state),
-// or hung MCP servers:
-//   - ~/.claude              settings + .credentials.json
-//   - ~/.claude.json         runtime state at home root, outside .claude/
-//   - ~/.cache/claude        Claude Code XDG cache (sessions, staging)
-//   - ~/.cache/claude-cli-nodejs  legacy cache path used by older builds
-//   - ~/.local/share/claude  XDG data dir; `claude install` writes versions here
-//   - ~/.local/state         systemd-recommended XDG state dir
-//   - ~/.npm                 npm cache used by claude install when fetching tarballs
-//   - ~/<project>            agent's working tree
-func buildHardeningDirectives(homeDir, project string) string {
+// Design: cross-agent isolation is enforced by Unix permissions on
+// /home/<agent> (mode 0750, owner = agent, others = none — provisioned by
+// useradd and not loosened anywhere). One agent cannot read or write
+// another agent's home regardless of systemd hardening, so layering
+// ProtectHome=read-only on top of those permissions adds no security
+// against the threat model and creates a steady stream of false positives:
+//
+//   - v0.8.3 (#109) added ReadWritePaths=~/.claude.json to fix the first
+//     EROFS surfaced by Claude Code at startup.
+//   - v0.9.1 (#133) added ~/.cache/claude, ~/.cache/claude-cli-nodejs,
+//     ~/.local/share/claude, ~/.npm to fix self-update + OAuth refresh
+//     EROFS spam in the runner log.
+//   - v0.9.3 (this change) hits the next mole: Claude Code writes
+//     ~/.claude.json atomically by creating ~/.claude.json.tmp and
+//     renaming it, which requires write to the PARENT directory ($HOME
+//     itself). ReadWritePaths grants write to specific inodes only, not
+//     to their containing directory, so atomic-write tempfiles in
+//     read-only $HOME always EROFS. The web terminal at port 7681
+//     surfaces this as a bun openSync error from the cli entrypoint.
+//
+// Rather than continue adding paths every time Claude Code writes
+// somewhere new, drop ProtectHome entirely. The agent retains full write
+// access to its own $HOME (already restricted to itself by Unix perms)
+// and is still blocked from /etc, /usr, and other system locations by
+// ProtectSystem=strict. CLAUDE.md remains explicitly locked via
+// ReadOnlyPaths so the operator's instructions cannot be silently
+// rewritten by the agent.
+func buildHardeningDirectives(homeDir, _ string) string {
 	return fmt.Sprintf(
-		"NoNewPrivileges=yes\nProtectSystem=strict\nProtectHome=read-only\nPrivateTmp=yes\n"+
-			"ReadOnlyPaths=%s/CLAUDE.md %s/CLAUDE.local.md\n"+
-			"ReadWritePaths=%s/.claude %s/.claude.json %s/.cache/claude %s/.cache/claude-cli-nodejs %s/.local/share/claude %s/.local/state %s/.npm %s/%s\n",
+		"NoNewPrivileges=yes\nProtectSystem=strict\nPrivateTmp=yes\n"+
+			"ReadOnlyPaths=%s/CLAUDE.md %s/CLAUDE.local.md\n",
 		homeDir, homeDir,
-		homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, homeDir, project,
 	)
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -356,13 +356,24 @@ func TestGenerateService_HardeningDirectivesPresent(t *testing.T) {
 	for _, want := range []string{
 		"NoNewPrivileges=yes",
 		"ProtectSystem=strict",
-		"ProtectHome=read-only",
 		"PrivateTmp=yes",
 		"ReadOnlyPaths=/home/test-lead/CLAUDE.md /home/test-lead/CLAUDE.local.md",
-		"ReadWritePaths=/home/test-lead/.claude /home/test-lead/.claude.json /home/test-lead/.cache/claude /home/test-lead/.cache/claude-cli-nodejs /home/test-lead/.local/share/claude /home/test-lead/.local/state /home/test-lead/.npm /home/test-lead/test",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in service unit, got:\n%s", want, out)
+		}
+	}
+	// ProtectHome=read-only was dropped in v0.9.3 — see buildHardeningDirectives
+	// doc comment for the rationale (cross-agent isolation already comes from
+	// 0750 perms on /home/<agent>; ProtectHome added EROFS whack-a-mole without
+	// adding security against the threat model). Pin it removed so a future
+	// well-meaning re-add cannot silently regress every Claude Code path.
+	for _, banned := range []string{
+		"ProtectHome=",
+		"ReadWritePaths=",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("hardening must not contain %q (cross-agent isolation = Unix perms; per-path RW carveouts cause EROFS regressions). Got:\n%s", banned, out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Three releases of incremental ReadWritePaths additions (v0.8.3 → v0.9.1 → next) failed to keep Claude Code working under `ProtectHome=read-only` because every release surfaces another path it writes. Most recent example: Claude Code rewrites `~/.claude.json` atomically (write `~/.claude.json.tmp` + rename), which needs write to the PARENT directory (`$HOME` itself). `ReadWritePaths` grants write to specific inodes only, never to their containing directory, so atomic-write tempfiles always EROFS. Bun openSync surfaces this from the cli entrypoint at `/$bunfs/root/src/entrypoints/cli.js`.

`ProtectHome=read-only` was added on top of permissions that already isolate agents:

```
$ stat -c '%a %U' /home/cdev-lead /home/cdev-worker /home/clem-dev-ada
750 cdev-lead
750 cdev-worker
750 clem-dev-ada
```

Mode `0750` with each agent in its own primary group means peer agents cannot read or write each other's home regardless of systemd hardening. `ProtectHome` added no security against the actual threat model (one compromised agent reaching into another agent's secrets); its only effect was an EROFS treadmill that drove daily operator interrupts.

## Changes
- `ProtectHome=read-only` line removed.
- All `ReadWritePaths` carveouts removed.
- `ProtectSystem=strict` retained — still locks `/etc`, `/usr`, `/opt`.
- `ReadOnlyPaths=$HOME/CLAUDE.md $HOME/CLAUDE.local.md` retained — original goal of PR #87 hardening.
- Second `buildHardeningDirectives` parameter renamed to `_` since project no longer participates.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all green
- [x] `TestGenerateService_HardeningDirectivesPresent` asserts the four retained directives AND pins the removal: `ProtectHome=` and `ReadWritePaths=` must NOT appear in the generated unit. Without this negative assertion a future re-add would silently regress all Claude Code writes again.
- [ ] After merge: tag v0.9.3, `clem update && clem provision` on cdev, restart agents — no more EROFS spam, no more daily-login alarm, ttyd at port 7681 stops surfacing bun openSync errors

## Why this is the last hardening change in this series
Whack-a-mole stops because the root cause is structural: ProtectHome only allows writes to specifically-named inodes, but most config-writers atomically replace files via tempfile + rename, which requires write to the PARENT directory. There is no list of paths that satisfies both "atomic-write friendly" and "ProtectHome=read-only". Either you grant the entire home (defeating ProtectHome) or you accept EROFS at every new tempfile location. Cross-agent isolation already exists at the Unix layer (`0750` per-user homes), so dropping ProtectHome loses no defense.