### PR TITLE
fix(provision): tolerate missing CLAUDE.md / CLAUDE.local.md in ReadOnlyPaths

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -449,9 +449,17 @@ func Generate(cfg *config.Config, agentKey string) string {
 // ReadOnlyPaths so the operator's instructions cannot be silently
 // rewritten by the agent.
 func buildHardeningDirectives(homeDir, _ string) string {
+	// The leading '-' on each ReadOnlyPaths entry tells systemd to ignore
+	// the path if it does not exist. Without it, missing CLAUDE.md or
+	// CLAUDE.local.md at $HOME root causes "Failed to set up mount
+	// namespacing: No such file or directory" (status=226/NAMESPACE) and
+	// the agent service refuses to start. Both files are operator-owned
+	// and may legitimately be absent (Daisy keeps her CLAUDE.local.md in
+	// the project subdir, not at $HOME root) — they should be locked
+	// when present, not required.
 	return fmt.Sprintf(
 		"NoNewPrivileges=yes\nProtectSystem=strict\nPrivateTmp=yes\n"+
-			"ReadOnlyPaths=%s/CLAUDE.md %s/CLAUDE.local.md\n",
+			"ReadOnlyPaths=-%s/CLAUDE.md -%s/CLAUDE.local.md\n",
 		homeDir, homeDir,
 	)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -357,7 +357,7 @@ func TestGenerateService_HardeningDirectivesPresent(t *testing.T) {
 		"NoNewPrivileges=yes",
 		"ProtectSystem=strict",
 		"PrivateTmp=yes",
-		"ReadOnlyPaths=/home/test-lead/CLAUDE.md /home/test-lead/CLAUDE.local.md",
+		"ReadOnlyPaths=-/home/test-lead/CLAUDE.md -/home/test-lead/CLAUDE.local.md",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in service unit, got:\n%s", want, out)


### PR DESCRIPTION
## Summary
After dropping `ProtectHome=read-only` in v0.9.3, the remaining hardening directive — `ReadOnlyPaths` for the operator's CLAUDE.md files — became the dominant namespace operation at unit start. systemd refuses to start the unit if any `ReadOnlyPaths` entry doesn't exist:

```
Failed to set up mount namespacing: /home/<user>/CLAUDE.local.md: No such file or directory
Control process exited, code=exited, status=226/NAMESPACE
```

Both files are operator-owned and may legitimately be absent at `$HOME` root — agents typically keep `CLAUDE.local.md` in the project subdir (`~/<project>/CLAUDE.local.md`, written by `clem provision`) rather than at home root. `ReadOnlyPaths` should lock these files WHEN PRESENT, not require them.

Prefix each entry with `-` per systemd path syntax so missing paths are silently ignored. Pre-v0.9.3 the `ProtectHome=read-only` mount was applied first and made these `ReadOnlyPaths` entries no-ops on missing paths, which is why the bug only surfaced now.

## Test plan
- [x] `go test ./internal/runner/...` green
- [x] `TestGenerateService_HardeningDirectivesPresent` updated to expect dash-prefixed form
- [ ] After merge: tag v0.9.4, `clem update && clem provision && systemctl restart` on cdev — services start clean without manual sed hotfix