### PR TITLE
fix(update): only overwrite dst when EvalSymlinks succeeds

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -81,7 +81,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolving current binary path: %w", err)
 	}
-	dst, _ = filepath.EvalSymlinks(dst)
+	if resolved, err := filepath.EvalSymlinks(dst); err == nil {
+		dst = resolved
+	}
 
 	if err := os.Rename(tmpPath, dst); err != nil {
 		return fmt.Errorf("replacing %s (may need sudo): %w", dst, err)


### PR DESCRIPTION
Closes #65.

## What

`cmd/update.go` discarded the error from `filepath.EvalSymlinks`, keeping the unresolved path when resolution failed. A subsequent `os.Rename` then wrote the new binary to the symlink itself rather than its target, silently destroying the install layout.

## Fix

Only update `dst` when `EvalSymlinks` succeeds:

```go
if resolved, err := filepath.EvalSymlinks(dst); err == nil {
    dst = resolved
}
```

No behaviour change on the happy path (symlink resolves fine). Broken-symlink and filesystem-error cases now fall back to renaming over the unresolved `os.Executable()` path instead of clobbering the symlink.

## Test

No test file exists for `cmd/update.go`; the change is a one-line guard on an `os`-level call that requires real filesystem setup to exercise. Verified with `go build` and `go vet`.