### PR TITLE
fix(runner): prefer pipx-isolated MCP binaries over /usr/local/bin

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -46,9 +46,21 @@ export CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1
 # Load secrets (written by clem provision, never committed)
 [ -f "$HOME/.env" ] && source "$HOME/.env"
 {{.SubagentExport}}
-# Write ephemeral .mcp.json from env (python3 ensures correct JSON encoding)
+# Write ephemeral .mcp.json from env (python3 ensures correct JSON encoding).
+# Each Python-based MCP server is resolved via _mcp_bin which prefers an
+# isolated pipx venv at /opt/pipx/bin if present and falls back to the
+# system pip install at /usr/local/bin. Pipx is the supported install path
+# (see README): each MCP gets its own pydantic + pydantic-core pair, so a
+# system pydantic-core upgrade cannot desync from the wheel an MCP was
+# built against. Pre-0.9.5 hardcoded /usr/local/bin and broke every time
+# system Python state drifted, requiring jahwag to re-edit .mcp.json every
+# iteration because the runner overwrites it.
 python3 -c "
 import json, os
+def _mcp_bin(name):
+    pipx = '/opt/pipx/bin/' + name
+    sysbin = '/usr/local/bin/' + name
+    return pipx if os.path.exists(pipx) else sysbin
 cfg = {'mcpServers': {}}
 # Discord bot. When channel IDs are configured the MCP server also runs a
 # gateway watcher that pushes one debounced notification per burst into this
@@ -59,7 +71,7 @@ if os.environ.get('DISCORD_TOKEN'):
     if _watch:
         _discord_env['DISCORD_WATCH_CHANNELS'] = _watch
         _discord_env['CLEM_TMUX_TARGET'] = '{{.AgentKey}}'
-    cfg['mcpServers']['discord-bot'] = {'command': '/usr/local/bin/mcp-discord', 'env': _discord_env}
+    cfg['mcpServers']['discord-bot'] = {'command': _mcp_bin('mcp-discord'), 'env': _discord_env}
 # Slack (korotovsky/slack-mcp-server). Read access is free; write access
 # (conversations_add_message) requires SLACK_MCP_ADD_MESSAGE_TOOL — enabled
 # here by default so agents can actually post, matching the Discord default.
@@ -67,12 +79,16 @@ if os.environ.get('DISCORD_TOKEN'):
 # SLACK_MCP_ENABLED_TOOLS is optional: comma-separated list to restrict the
 # exposed toolset. Useful for small local models (e.g. Nemotron 4B) that get
 # confused by the full 13-tool surface. Leave unset on cloud Claude / Opus.
+#
+# slack-mcp-server is a Go binary (not Python) so the pipx fallback does
+# not apply; we still resolve it through _mcp_bin for symmetry / future-
+# proofing in case the upstream ships a Python version.
 if os.environ.get('SLACK_MCP_XOXP_TOKEN'):
     slack_args = ['--transport', 'stdio']
     if os.environ.get('SLACK_MCP_ENABLED_TOOLS'):
         slack_args += ['--enabled-tools', os.environ['SLACK_MCP_ENABLED_TOOLS']]
     cfg['mcpServers']['slack-mcp'] = {
-        'command': '/usr/local/bin/slack-mcp-server',
+        'command': _mcp_bin('slack-mcp-server'),
         'args': slack_args,
         'env': {
             'SLACK_MCP_XOXP_TOKEN': os.environ['SLACK_MCP_XOXP_TOKEN'],
@@ -82,7 +98,7 @@ if os.environ.get('SLACK_MCP_XOXP_TOKEN'):
 # Prefect MCP (needs SSH_HOST + ES_PASSWORD)
 if os.environ.get('SSH_HOST') and os.environ.get('ES_PASSWORD'):
     cfg['mcpServers']['prefect'] = {
-        'command': '/usr/local/bin/prefect-mcp',
+        'command': _mcp_bin('prefect-mcp'),
         'env': {
             'SSH_HOST': os.environ['SSH_HOST'],
             'SSH_USER': os.environ.get('SSH_USER', 'ubuntu'),
@@ -98,7 +114,7 @@ if os.environ.get('SSH_HOST') and os.environ.get('ES_PASSWORD'):
 # Social media (Typefully backend — local MCP server)
 if os.environ.get('TYPEFULLY_API_KEY'):
     cfg['mcpServers']['social'] = {
-        'command': '/usr/local/bin/social-mcp',
+        'command': _mcp_bin('social-mcp'),
         'env': {'TYPEFULLY_API_KEY': os.environ['TYPEFULLY_API_KEY']}
     }
 print(json.dumps(cfg, indent=2))
@@ -181,8 +197,14 @@ tail -500 "$LOGFILE" > "$LOGFILE.tmp" 2>/dev/null && mv "$LOGFILE.tmp" "$LOGFILE
 [ -f "$HOME/.env" ] && source "$HOME/.env"
 {{.SubagentExport}}
 # Write opencode.json with Ollama provider + discord-bot MCP (if token is set).
+# MCP binary paths come from _mcp_bin (pipx-isolated venv preferred over system
+# pip install — see the claude-code runner template above for the rationale).
 python3 -c "
 import json, os
+def _mcp_bin(name):
+    pipx = '/opt/pipx/bin/' + name
+    sysbin = '/usr/local/bin/' + name
+    return pipx if os.path.exists(pipx) else sysbin
 cfg = {
     '\$schema': 'https://opencode.ai/config.json',
     'provider': {},
@@ -204,12 +226,12 @@ if os.environ.get('DISCORD_TOKEN'):
         _discord_env['CLEM_TMUX_TARGET'] = '{{.AgentKey}}'
     cfg['mcp']['discord-bot'] = {
         'type': 'local',
-        'command': ['/usr/local/bin/mcp-discord'],
+        'command': [_mcp_bin('mcp-discord')],
         'enabled': True,
         'environment': _discord_env,
     }
 if os.environ.get('SLACK_MCP_XOXP_TOKEN'):
-    slack_cmd = ['/usr/local/bin/slack-mcp-server', '--transport', 'stdio']
+    slack_cmd = [_mcp_bin('slack-mcp-server'), '--transport', 'stdio']
     if os.environ.get('SLACK_MCP_ENABLED_TOOLS'):
         slack_cmd += ['--enabled-tools', os.environ['SLACK_MCP_ENABLED_TOOLS']]
     cfg['mcp']['slack-mcp'] = {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -168,6 +168,49 @@ func TestGenerate_DisablesClaudeAIConnectorMCPs(t *testing.T) {
 	}
 }
 
+// TestGenerate_McpBinResolverPrefersPipx pins the pipx-vs-system fallback
+// in the runner's .mcp.json writer. v0.9.5 introduced _mcp_bin to stop
+// hardcoding /usr/local/bin paths that desync from system Python state and
+// require manual operator edits to .mcp.json every iteration. The helper
+// must (a) be defined, (b) prefer /opt/pipx/bin, (c) fall back to
+// /usr/local/bin, and (d) be used at every Python-MCP call site.
+func TestGenerate_McpBinResolverPrefersPipx(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+
+	if !strings.Contains(out, "def _mcp_bin(name):") {
+		t.Error("runner must define _mcp_bin in the .mcp.json writer")
+	}
+	if !strings.Contains(out, "'/opt/pipx/bin/' + name") {
+		t.Error("_mcp_bin must check the pipx path /opt/pipx/bin/<name> first")
+	}
+	if !strings.Contains(out, "'/usr/local/bin/' + name") {
+		t.Error("_mcp_bin must fall back to /usr/local/bin/<name>")
+	}
+	for _, mcp := range []string{"mcp-discord", "prefect-mcp", "social-mcp", "slack-mcp-server"} {
+		want := "_mcp_bin('" + mcp + "')"
+		if !strings.Contains(out, want) {
+			t.Errorf("runner must resolve %s via _mcp_bin, expected substring %q", mcp, want)
+		}
+	}
+	// Hardcoded /usr/local/bin/<mcp> calls outside _mcp_bin would defeat
+	// the fallback. Pin them out so a future copy-paste cannot regress.
+	for _, banned := range []string{
+		"'command': '/usr/local/bin/mcp-discord'",
+		"'command': '/usr/local/bin/prefect-mcp'",
+		"'command': '/usr/local/bin/social-mcp'",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("runner must not hardcode %q (use _mcp_bin)", banned)
+		}
+	}
+}
+
 func TestGenerateService_EgressRestrictionEnabled(t *testing.T) {
 	mockHome(t, "/home/test-lead")
 	cfg := baseCfg("lead", config.AgentConfig{


### PR DESCRIPTION
## Summary
Runner template rewrites `.mcp.json` on every iteration with hardcoded `/usr/local/bin/<mcp>` paths for the four Python MCP servers. When operators install via `pipx` (the v0.9.1 README's explicit recommendation to avoid system pydantic-core drift), the pipx binaries land at `/opt/pipx/bin/<mcp>` inside isolated venvs. Hardcoded `/usr/local/bin` paths then point at broken/stale system installs and the agent loses MCP access. Operator manually re-edits `.mcp.json` → next iteration overwrites it.

Visible on cdev as a steady supply of `discord-bot: /usr/local/bin/mcp-discord  - ✗ Failed to connect` from agents that were re-pointed at `/opt/pipx/bin` minutes earlier.

## Fix
Both runner templates (claude-code and opencode) resolve each Python MCP through:

```python
def _mcp_bin(name):
    pipx = '/opt/pipx/bin/' + name
    sysbin = '/usr/local/bin/' + name
    return pipx if os.path.exists(pipx) else sysbin
```

`slack-mcp-server` (Go binary, not Python) routes through the same helper for symmetry — if upstream ever ships a Python build the fallback already works.

## Test plan
- [x] `go test ./...` green
- [x] `TestGenerate_McpBinResolverPrefersPipx` pins helper definition, pipx-first lookup, `/usr/local/bin` fallback, and that all four MCP entries call `_mcp_bin` instead of hardcoding paths
- [x] Negative half forbids any `'command': '/usr/local/bin/<mcp>'` literal in the rendered runner — copy-paste regressions blocked
- [ ] After merge: tag v0.9.5, deploy on cdev, agents stop reverting `.mcp.json` to broken paths