### PR TITLE
fix(vault): qualify DecryptForAgent keys as vaultName.keyName

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -88,8 +88,9 @@ func runProvision(cmd *cobra.Command, args []string) error {
 				fmt.Println("  skipping .env — run clem vault init and set secrets first")
 			}
 		} else {
-			merged := make(map[string]string, len(secrets)+len(providerEnv))
-			for k, v := range secrets {
+			flatSecrets := vault.FlatSecrets(secrets)
+			merged := make(map[string]string, len(flatSecrets)+len(providerEnv))
+			for k, v := range flatSecrets {
 				merged[k] = v
 			}
 			for k, v := range providerEnv {
@@ -103,11 +104,11 @@ func runProvision(cmd *cobra.Command, args []string) error {
 			// If wrangler credentials are present, write the wrangler config file
 			if err := agent.WriteWranglerConfig(osUser, homeDir, secrets); err != nil {
 				fmt.Printf("  warning: writing wrangler config: %v\n", err)
-			} else if secrets["WRANGLER_OAUTH_TOKEN"] != "" {
+			} else if flatSecrets["WRANGLER_OAUTH_TOKEN"] != "" {
 				fmt.Printf("  wrote wrangler config for %s\n", osUser)
 			}
 
-			ghToken = secrets["GH_TOKEN"]
+			ghToken = flatSecrets["GH_TOKEN"]
 			if ghToken != "" && ac.GitEmail == "" {
 				fmt.Printf("  warning: agent %s has GH_TOKEN but no git_email in clem.yaml — commits may leak operator identity\n", agentKey)
 			}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -115,10 +115,16 @@ func WriteEnvFile(username, homeDir string, secrets map[string]string) error {
 
 	var sb strings.Builder
 	for k, v := range secrets {
+		// Strip vault-name prefix ("vaultName.keyName" → "keyName") so the
+		// exported name is the bare secret key. Keys without a dot pass through.
+		envKey := k
+		if i := strings.IndexByte(k, '.'); i >= 0 {
+			envKey = k[i+1:]
+		}
 		// Single-quote the value so bash treats it as fully literal.
 		// Only ' needs escaping: end the quoted string, append literal ', reopen.
 		escaped := strings.ReplaceAll(v, "'", `'\''`)
-		sb.WriteString(fmt.Sprintf("export %s='%s'\n", k, escaped))
+		sb.WriteString(fmt.Sprintf("export %s='%s'\n", envKey, escaped))
 	}
 
 	if err := os.WriteFile(envPath, []byte(sb.String()), 0600); err != nil {
@@ -411,14 +417,29 @@ func InstallGitHooks(username, homeDir string) error {
 	return nil
 }
 
+// flatSecret looks up a bare key in a vault-qualified secrets map
+// ("vaultName.keyName" format). Returns the value for the first matching key
+// suffix; returns "" if not found.
+func flatSecret(secrets map[string]string, key string) string {
+	for k, v := range secrets {
+		if k == key {
+			return v
+		}
+		if i := strings.IndexByte(k, '.'); i >= 0 && k[i+1:] == key {
+			return v
+		}
+	}
+	return ""
+}
+
 // WriteWranglerConfig writes a wrangler OAuth config for the agent if the
 // matching env vars are present in the secrets map. Idempotent — safe to call
 // every provision. The wrangler binary auto-refreshes the OAuth token using
 // the refresh token, so this stays valid as long as the refresh token does.
 func WriteWranglerConfig(username, homeDir string, secrets map[string]string) error {
-	oauth := secrets["WRANGLER_OAUTH_TOKEN"]
-	refresh := secrets["WRANGLER_REFRESH_TOKEN"]
-	expiration := secrets["WRANGLER_EXPIRATION"]
+	oauth := flatSecret(secrets, "WRANGLER_OAUTH_TOKEN")
+	refresh := flatSecret(secrets, "WRANGLER_REFRESH_TOKEN")
+	expiration := flatSecret(secrets, "WRANGLER_EXPIRATION")
 	if oauth == "" || refresh == "" {
 		return nil // not configured for this agent
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,12 +116,13 @@ type PermissionsConfig struct {
 	Deny []string `yaml:"deny"`
 }
 
-// ExpandVaultRefs replaces ${vault:BUCKET.KEY} refs in s using the flat
-// secrets map from vault.DecryptForAgent. Unresolvable refs are left as-is.
+// ExpandVaultRefs replaces ${vault:BUCKET.KEY} refs in s using the qualified
+// secrets map from vault.DecryptForAgent (keys are "vaultName.keyName").
+// Unresolvable refs are left as-is.
 func ExpandVaultRefs(s string, secrets map[string]string) string {
 	return vaultRefRe.ReplaceAllStringFunc(s, func(match string) string {
 		m := vaultRefRe.FindStringSubmatch(match)
-		if v, ok := secrets[m[2]]; ok {
+		if v, ok := secrets[m[1]+"."+m[2]]; ok {
 			return v
 		}
 		return match

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -641,8 +641,8 @@ agents:
 
 func TestExpandVaultRefs(t *testing.T) {
 	secrets := map[string]string{
-		"DISCORD_TOKEN": "tok123",
-		"GH_TOKEN":      "ghp_abc",
+		"discord-lead.DISCORD_TOKEN": "tok123",
+		"github.GH_TOKEN":            "ghp_abc",
 	}
 	cases := []struct {
 		in   string
@@ -653,6 +653,28 @@ func TestExpandVaultRefs(t *testing.T) {
 		{"prefix-${vault:discord-lead.DISCORD_TOKEN}-suffix", "prefix-tok123-suffix"},
 		{"${vault:other.MISSING}", "${vault:other.MISSING}"},
 		{"no refs here", "no refs here"},
+	}
+	for _, tc := range cases {
+		if got := ExpandVaultRefs(tc.in, secrets); got != tc.want {
+			t.Errorf("ExpandVaultRefs(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestExpandVaultRefs_KeyCollision(t *testing.T) {
+	// Two vaults share the same key name; ExpandVaultRefs must resolve each ref
+	// to its correct vault rather than silently delivering the wrong value.
+	secrets := map[string]string{
+		"github.API_KEY": "github-token",
+		"openai.API_KEY": "openai-token",
+	}
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"${vault:github.API_KEY}", "github-token"},
+		{"${vault:openai.API_KEY}", "openai-token"},
+		{"${vault:other.API_KEY}", "${vault:other.API_KEY}"},
 	}
 	for _, tc := range cases {
 		if got := ExpandVaultRefs(tc.in, secrets); got != tc.want {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -258,11 +258,28 @@ func DecryptForAgent(agentKey string, vaultNames []string) (map[string]string, e
 			}
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) == 2 {
-				result[parts[0]] = parts[1]
+				result[vaultName+"."+parts[0]] = parts[1]
 			}
 		}
 	}
 	return result, nil
+}
+
+// FlatSecrets strips the vault-name prefix from keys returned by DecryptForAgent,
+// producing a map keyed by bare secret name. When two vaults share a key name,
+// the last entry in iteration order wins (same as the previous flat behaviour).
+// Use this for shell .env exports and direct by-name lookups; use the qualified
+// map for ExpandVaultRefs so vault-name disambiguation is preserved.
+func FlatSecrets(secrets map[string]string) map[string]string {
+	flat := make(map[string]string, len(secrets))
+	for k, v := range secrets {
+		if i := strings.IndexByte(k, '.'); i >= 0 {
+			flat[k[i+1:]] = v
+		} else {
+			flat[k] = v
+		}
+	}
+	return flat
 }
 
 func decryptLegacyAgent(agentKey, decrypted string) (map[string]string, error) {


### PR DESCRIPTION
Closes #92.

## What

`DecryptForAgent` was keying all secrets by bare name (`API_KEY`), so when
two vaults in an agent's list shared a key name, the flat map kept
last-write-wins and `ExpandVaultRefs` silently delivered the wrong
credential.

## Changes

| File | Change |
|------|--------|
| `internal/vault/vault.go` | `DecryptForAgent` keys results as `"vaultName.keyName"`. New `FlatSecrets()` helper strips the prefix for callers that need bare names. |
| `internal/config/config.go` | `ExpandVaultRefs` looks up `secrets[m[1]+"."+m[2]]` so the vault qualifier is respected. |
| `internal/agent/manager.go` | `WriteEnvFile` strips vault prefix before writing env var names. New private `flatSecret()` helper; `WriteWranglerConfig` uses it for bare-key lookups. |
| `cmd/provision.go` | Uses `vault.FlatSecrets(secrets)` for direct key lookups (`GH_TOKEN`, `WRANGLER_OAUTH_TOKEN`) and for building the merged `.env` map. |
| `internal/config/config_test.go` | Existing test updated to vault-qualified keys; new `TestExpandVaultRefs_KeyCollision` covers the two-vault same-key case. |

## Behaviour unchanged for single-vault configs

Agents with one vault (the common case) see no behaviour change: the
`.env` file, wrangler config, and MCP env values all resolve identically
to before.