### PR TITLE
fix(vault): escape backslash in sops --set jq expression

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -101,10 +101,11 @@ func Set(vaultName, keyval string) error {
 	}
 
 	// sops --set '["vaults"]["<vaultName>"]["KEY"] "value"' secrets.sops.yaml
+	// Escape \ before " so jq interprets the value as a literal string.
 	setExpr := fmt.Sprintf(`["vaults"]["%s"]["%s"] "%s"`,
-		strings.ReplaceAll(vaultName, `"`, `\"`),
-		strings.ReplaceAll(key, `"`, `\"`),
-		strings.ReplaceAll(value, `"`, `\"`),
+		jqEscape(vaultName),
+		jqEscape(key),
+		jqEscape(value),
 	)
 	out, err := exec.Command("sops", "--set", setExpr, secretsFile).CombinedOutput()
 	if err != nil {
@@ -365,6 +366,14 @@ func ensureSops() error {
 		return fmt.Errorf("%s not found — run 'clem vault set' to create it", secretsFile)
 	}
 	return nil
+}
+
+// jqEscape escapes a string for use in a sops --set jq expression string literal.
+// Backslashes must be escaped before quotes to avoid double-processing.
+func jqEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
 }
 
 // ensureSopsBin checks only that the sops binary exists, not the secrets file.

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -145,6 +145,45 @@ func TestSet_RejectsMalformedKeyval(t *testing.T) {
 	}
 }
 
+func TestJqEscape(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`simple`, `simple`},
+		{`with"quote`, `with\"quote`},
+		{`back\slash`, `back\\slash`},
+		{`C:\Users\token`, `C:\\Users\\token`},
+		{`\n literal`, `\\n literal`},
+		{`both\"`, `both\\\"`},
+	}
+	for _, c := range cases {
+		got := jqEscape(c.input)
+		if got != c.want {
+			t.Errorf("jqEscape(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestSet_BackslashInValue(t *testing.T) {
+	requireSopsAndAge(t)
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	if err := Set("myvault", `PATH=C:\Users\token`); err != nil {
+		t.Fatalf("Set with backslash: %v", err)
+	}
+
+	secrets, err := DecryptForAgent("", []string{"myvault"})
+	if err != nil {
+		t.Fatalf("DecryptForAgent: %v", err)
+	}
+	want := `C:\Users\token`
+	if got := secrets["myvault.PATH"]; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // requireAgeKeygen skips if age-keygen is not on PATH.
 func requireAgeKeygen(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
Closes #60.

## What

`vault.Set` was interpolating secret values (and vault/key names) directly
into the jq string literal for `sops --set` with only `"` → `\"` escaping.
A backslash in the value was passed verbatim to jq, which interprets `\n`,
`\t`, `\\` etc. as escape sequences — silently storing a different value
than the operator supplied.

## Changes

| File | Change |
|------|--------|
| `internal/vault/vault.go` | Add `jqEscape()` that escapes `\` before `"`. Apply to vaultName, key, and value in `Set()`. |
| `internal/vault/vault_test.go` | `TestJqEscape` unit test (no sops/age needed); `TestSet_BackslashInValue` integration test round-trips a Windows-path value through Set → DecryptForAgent. |

## Escape order

Backslashes must be escaped before double-quotes:

```
input:  C:\Users\token
after \ → \\:  C:\\Users\\token   (jq stores literal backslashes)
after " → \":  unchanged          (no quotes in this example)
```

Reversing the order would double-escape the backslash that was introduced
by the `"` → `\"` step.