### PR TITLE
fix(runner): add CLAUDE.local.md size guard to opencode runner

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -248,10 +248,22 @@ print(json.dumps(cfg, indent=2))
 
 SLEEP_ACTIVE={{.SleepActive}}
 SLEEP_NIGHT={{.SleepNight}}
+MAX_CLAUDE_MD_BYTES=12288
+MAX_LESSONS_MESSAGES=25
 
 while true; do
     START=$(date +%s)
     PROMPT='{{.Prompt}}'
+
+    # Guard: CLAUDE.local.md too large (token waste)
+    if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
+        SIZE=$(stat -c %s "$WORKDIR/CLAUDE.local.md" 2>/dev/null || echo 0)
+        if (( SIZE > MAX_CLAUDE_MD_BYTES )); then
+            log "WARNING: CLAUDE.local.md is ${SIZE} bytes (max ${MAX_CLAUDE_MD_BYTES}) — alerting"
+            source "$HOME/.env" 2>/dev/null
+            {{.AlertCurl}}
+        fi
+    fi
 
     log "Starting {{.AgentName}} (opencode, fresh session)"
     MODEL_ARG=""

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -439,6 +439,29 @@ func TestGenerateService_HardeningUsesAbsoluteHomePath(t *testing.T) {
 	}
 }
 
+func TestGenerate_OpencodeRunnerHasClaudeMdGuard(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Runtime:   "opencode",
+		Model:     "nemotron-3-nano:4b",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+
+	for _, want := range []string{
+		"MAX_CLAUDE_MD_BYTES=12288",
+		"MAX_LESSONS_MESSAGES=25",
+		`if [ -f "$WORKDIR/CLAUDE.local.md" ]`,
+		"SIZE > MAX_CLAUDE_MD_BYTES",
+		"WARNING: CLAUDE.local.md is ${SIZE} bytes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("opencode runner missing CLAUDE.local.md guard: expected %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
 func TestGenerateService_MissingUserFails(t *testing.T) {
 	orig := userHomeLookup
 	userHomeLookup = func(username string) (string, error) {


### PR DESCRIPTION
Closes #59.

## What

The `claude-code` runner template already guards against `CLAUDE.local.md` exceeding `MAX_CLAUDE_MD_BYTES` and fires an alert via `AlertCurl`. The `opencode` runner was missing this block entirely, so bloated instruction files on opencode agents went silently undetected.

## Change

Added to `opencodeRunnerTemplate` in `internal/runner/runner.go`:
- `MAX_CLAUDE_MD_BYTES=12288` and `MAX_LESSONS_MESSAGES=25` constants (matching the claude-code runner)
- The `WORKDIR/CLAUDE.local.md` size guard block, positioned before the main loop body

`AlertCurl` is already computed and passed via `RunnerParams` for all runtime kinds, so no changes to `Generate()` are needed.

## Test

Added `TestGenerate_OpencodeRunnerHasClaudeMdGuard` asserting the constants and guard block appear in the rendered opencode runner output, mirroring the existing claude-code runner test pattern.