### PR TITLE
fix(provision): re-provision updates stale git_name / git_email

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -331,11 +331,29 @@ done
 exit 0
 `, PrePushAllowSecretMarker, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapRegex, PrePushAllowSecretMarker)
 
-// ConfigureGit writes SSH commit-signing configuration and optionally the git
-// user identity to the agent's ~/.gitconfig. Idempotent — safe to call every
-// provision. pubKey is the agent's ed25519 public key (returned by EnsureSSHKey).
-// gitName and gitEmail, when non-empty, set git user.name / user.email; existing
-// values are preserved (operator-set identity is never overwritten).
+// stripGitConfigKey removes every line of `content` whose leading text is
+// "\t<key> = ". Used to clear stale name/email entries before re-writing them
+// with the current configured values.
+func stripGitConfigKey(content, key string) string {
+	prefix := "\t" + key + " = "
+	lines := strings.Split(content, "\n")
+	out := lines[:0]
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// ConfigureGit writes SSH commit-signing configuration and the git user
+// identity to the agent's ~/.gitconfig. Idempotent — safe to call every
+// provision. pubKey is the agent's ed25519 public key (returned by
+// EnsureSSHKey). When gitName / gitEmail are non-empty, any pre-existing
+// "\tname = " / "\temail = " line is stripped and replaced so clem.yaml stays
+// authoritative across re-provisions; empty inputs leave the existing value
+// untouched.
 func ConfigureGit(username, homeDir, pubKey, gitName, gitEmail string) error {
 	sshDir := filepath.Join(homeDir, ".ssh")
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
@@ -366,11 +384,17 @@ func ConfigureGit(username, homeDir, pubKey, gitName, gitEmail string) error {
 			signingKey, allowedSignersPath,
 		)
 	}
+	if gitName != "" {
+		content = stripGitConfigKey(content, "name")
+	}
+	if gitEmail != "" {
+		content = stripGitConfigKey(content, "email")
+	}
 	var identityLines []string
-	if gitName != "" && !strings.Contains(content, "\tname = ") {
+	if gitName != "" {
 		identityLines = append(identityLines, "\tname = "+gitName)
 	}
-	if gitEmail != "" && !strings.Contains(content, "\temail = ") {
+	if gitEmail != "" {
 		identityLines = append(identityLines, "\temail = "+gitEmail)
 	}
 	if len(identityLines) > 0 {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -824,13 +824,13 @@ func TestConfigureGit_WritesUserIdentity(t *testing.T) {
 	}
 }
 
-func TestConfigureGit_PreservesExistingIdentity(t *testing.T) {
+func TestConfigureGit_OverwritesExistingIdentity(t *testing.T) {
 	withStub(t)
 	dir := t.TempDir()
 	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
 
-	// pre-existing operator-set identity
-	existing := "[user]\n\tname = operator\n\temail = operator@example.com\n"
+	// pre-existing stale identity (e.g. from a prior provision)
+	existing := "[user]\n\tname = old-name\n\temail = old@example.com\n"
 	if err := os.WriteFile(filepath.Join(dir, ".gitconfig"), []byte(existing), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -841,11 +841,42 @@ func TestConfigureGit_PreservesExistingIdentity(t *testing.T) {
 
 	gcData, _ := os.ReadFile(filepath.Join(dir, ".gitconfig"))
 	gcStr := string(gcData)
-	if strings.Contains(gcStr, "clauderesearch") {
-		t.Errorf("ConfigureGit overwrote operator name: %s", gcStr)
+	if !strings.Contains(gcStr, "\tname = clauderesearch") {
+		t.Errorf("ConfigureGit did not write new name: %s", gcStr)
 	}
-	if strings.Contains(gcStr, "bot@example.com") {
-		t.Errorf("ConfigureGit overwrote operator email: %s", gcStr)
+	if !strings.Contains(gcStr, "\temail = bot@example.com") {
+		t.Errorf("ConfigureGit did not write new email: %s", gcStr)
+	}
+	if strings.Contains(gcStr, "old-name") {
+		t.Errorf("stale name was not removed: %s", gcStr)
+	}
+	if strings.Contains(gcStr, "old@example.com") {
+		t.Errorf("stale email was not removed: %s", gcStr)
+	}
+}
+
+func TestConfigureGit_LeavesIdentityWhenInputsEmpty(t *testing.T) {
+	withStub(t)
+	dir := t.TempDir()
+	pubKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPubKeyData testuser@clem"
+
+	// operator-set identity present; clem.yaml supplies no git_name / git_email
+	existing := "[user]\n\tname = operator\n\temail = operator@example.com\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitconfig"), []byte(existing), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ConfigureGit("testuser", dir, pubKey, "", ""); err != nil {
+		t.Fatalf("ConfigureGit: %v", err)
+	}
+
+	gcData, _ := os.ReadFile(filepath.Join(dir, ".gitconfig"))
+	gcStr := string(gcData)
+	if !strings.Contains(gcStr, "\tname = operator") {
+		t.Errorf("operator name was removed despite empty input: %s", gcStr)
+	}
+	if !strings.Contains(gcStr, "\temail = operator@example.com") {
+		t.Errorf("operator email was removed despite empty input: %s", gcStr)
 	}
 }
 


### PR DESCRIPTION
Closes #58.

## What

`ConfigureGit` guarded identity writes with substring checks on the existing
`.gitconfig`, so once `\tname = ` / `\temail = ` were present they could never
be updated. Operators who corrected `git_name` / `git_email` in `clem.yaml`
and re-ran `clem provision` saw the stale identity persist.

## Changes

| File | Change |
|------|--------|
| `internal/agent/manager.go` | New `stripGitConfigKey` helper; `ConfigureGit` now strips the existing `\tname = ` / `\temail = ` lines before re-appending the configured values when they are non-empty. Empty inputs still leave existing values alone. |
| `internal/agent/manager_test.go` | Replace `TestConfigureGit_PreservesExistingIdentity` (which asserted the buggy "never overwrite" behaviour) with `TestConfigureGit_OverwritesExistingIdentity` plus a new `TestConfigureGit_LeavesIdentityWhenInputsEmpty` covering the preserve-when-unset path. |

## Semantics

| Case | Before | After |
|------|--------|-------|
| `git_email` changed in `clem.yaml`, re-provision | stale value retained | replaced with current value |
| `git_email` empty in `clem.yaml`, operator wrote one manually | preserved | preserved (unchanged) |
| Repeated provision with same values | idempotent (one entry) | idempotent (one entry, existing test still green) |

This is symmetric with how `allowed_signers` is unconditionally rewritten on
every provision call.