### PR TITLE
fix(watchdog): derive stale threshold from iteration_duration

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -37,6 +37,7 @@ check_agent() {
     local agent_key="$1"
     local os_user="$2"
     local service="$3"
+    local stale_threshold="$4"
     local cooldown_file="$COOLDOWN_DIR/${agent_key}.cooldown"
 
     # Check cooldown
@@ -92,12 +93,15 @@ check_agent() {
         return
     fi
 
-    # Case 2: stale agent — runner log hasn't been updated in 30+ minutes
+    # Case 2: stale agent — runner log hasn't been touched in longer than
+    # the agent's own sleep interval (plus a small margin). The per-agent
+    # threshold is computed at provision time from iteration_duration so
+    # long-iteration configs don't trip on a normal between-iteration sleep.
     local logfile="/home/${os_user}/.claude/${agent_key}-runner.log"
     if [ -f "$logfile" ]; then
         local log_age
         log_age=$(( $(date +%s) - $(stat -c %Y "$logfile") ))
-        if (( log_age > 1800 )); then
+        if (( log_age > stale_threshold )); then
             echo "$(date -Iseconds) $agent_key: stale for $((log_age/60))min — hard restarting"
             pkill -u "$os_user" -f claude || true
             sleep 2
@@ -231,6 +235,18 @@ AccuracySec=30s
 WantedBy=timers.target
 `
 
+// staleMarginSeconds is added to an agent's iteration duration to derive the
+// per-agent stale threshold passed to check_agent. Sized to comfortably exceed
+// one watchdog tick (5 min) so a sleeping agent isn't restarted mid-cycle.
+const staleMarginSeconds = 300
+
+// staleFloorSeconds is the minimum stale threshold regardless of iteration
+// duration. The runner log goes quiet for the whole claude session (the loop
+// only logs at iteration boundaries), so a short-iteration agent must keep at
+// least the historical 30-minute grace or healthy mid-task sessions get
+// hard-restarted.
+const staleFloorSeconds = 1800
+
 type watchdogParams struct {
 	Project        string
 	EnvSource      string
@@ -278,7 +294,15 @@ func GenerateScript(cfg *config.Config) string {
 	for _, key := range keys {
 		osUser := cfg.OSUsername(key)
 		svc := cfg.ServiceName(key)
-		checks.WriteString(fmt.Sprintf(`check_agent "%s" "%s" "%s"`+"\n", key, osUser, svc))
+		ac := cfg.Agents[key]
+		iterDur, _ := ac.IterationDuration() // validated at load time
+		// Agents sleep up to iterDur between iterations; allow a 5-minute
+		// margin so the next iteration's log line lands before we flag stale.
+		stale := int(iterDur.Seconds()) + staleMarginSeconds
+		if stale < staleFloorSeconds {
+			stale = staleFloorSeconds
+		}
+		checks.WriteString(fmt.Sprintf(`check_agent "%s" "%s" "%s" "%d"`+"\n", key, osUser, svc, stale))
 	}
 
 	// Egress monitoring is wired in only when at least one agent is contained.

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -103,6 +103,48 @@ func TestGenerateScript_SlackBackendAlertCurl(t *testing.T) {
 	}
 }
 
+func TestGenerateScript_StaleThresholdPerAgent(t *testing.T) {
+	cfg := &config.Config{
+		Project: "test",
+		Coordination: config.Coordination{
+			Backend: "discord",
+			Channels: map[string]string{
+				"alerts":  "111",
+				"tasks":   "222",
+				"general": "333",
+			},
+		},
+		Agents: map[string]config.AgentConfig{
+			"lead":     {Name: "Lead", Model: "claude-opus-4-7", Iteration: "45m", Prompt: "x"},
+			"follower": {Name: "Follower", Model: "claude-opus-4-7", Iteration: "5m", Prompt: "y"},
+		},
+	}
+	s := GenerateScript(cfg)
+
+	// 45m iteration → 2700 + 300 margin = 3000
+	wantLead := `check_agent "lead" "test-lead" "clem-test-lead.service" "3000"`
+	if !strings.Contains(s, wantLead) {
+		t.Errorf("expected lead invocation with 3000s stale threshold, missing %q\n---\n%s", wantLead, s)
+	}
+	// 5m iteration → 300 + 300 = 600, floored to 1800: the runner log is
+	// silent for the whole claude session, so short-iteration agents keep
+	// the historical 30-minute grace instead of being killed mid-task.
+	wantFollower := `check_agent "follower" "test-follower" "clem-test-follower.service" "1800"`
+	if !strings.Contains(s, wantFollower) {
+		t.Errorf("expected follower invocation floored at 1800s stale threshold, missing %q\n---\n%s", wantFollower, s)
+	}
+
+	// The hardcoded 30-minute threshold must be gone — the only valid path is
+	// the per-agent variable. A literal `> 1800` in the script would mean we
+	// regressed back to the old behavior.
+	if strings.Contains(s, `(( log_age > 1800 ))`) {
+		t.Errorf("hardcoded 1800s threshold must be replaced by stale_threshold var:\n%s", s)
+	}
+	if !strings.Contains(s, `(( log_age > stale_threshold ))`) {
+		t.Errorf("expected stale_threshold variable in stale check, got:\n%s", s)
+	}
+}
+
 func TestGenerateScript_OOMCheckPresent(t *testing.T) {
 	s := GenerateScript(baseCfg())
 	for _, want := range []string{


### PR DESCRIPTION
Closes #82.

The `check_agent` stale check hardcodes a 1800s log-age threshold. Any
agent with `iteration_duration` > 30 min logs `Sleeping Xs` and then
goes quiet for X seconds; the watchdog flags it stale and hard-restarts
mid-sleep, breaking the configured cadence.

This change derives the threshold per agent at provision time:
`stale = iterDur.Seconds() + 300` (5-min margin so a normal sleep
plus one watchdog tick can't trip it). The value is passed as the
fourth positional arg to `check_agent`, replacing the literal `1800`
in the bash comparison.

Acceptance from the issue:
- 25m iteration → 1800s threshold (not restarted at 30 min into a sleep).
- 5m default → 600s threshold (no regression).
- Hardcoded `> 1800` gone; replaced by `> stale_threshold` shell var.

Test added: `TestGenerateScript_StaleThresholdPerAgent` asserts both
the per-agent invocation lines and the absence of the old literal.