### PR TITLE
fix(watchdog): render send_alert from coordination backend

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jahwag/clem/internal/config"
+	"github.com/jahwag/clem/internal/coordination"
 )
 
 const watchdogScript = `#!/bin/bash
@@ -18,20 +19,13 @@ COOLDOWN_SECONDS=300
 
 mkdir -p "$COOLDOWN_DIR"
 
-# Discord token sourced from orchestrator agent's .env
-DISCORD_WEBHOOK=""
+# Chat backend token sourced from orchestrator agent's .env
 {{.EnvSource}}
 
 send_alert() {
     local msg="$1"
-    if [ -n "$DISCORD_TOKEN" ] && [ -n "{{.AlertChannel}}" ]; then
-        local body
-        body=$(python3 -c "import json,sys; print(json.dumps({'content':sys.argv[1]}))" "$msg")
-        curl -s -X POST \
-            "https://discord.com/api/v10/channels/{{.AlertChannel}}/messages" \
-            -H "Authorization: Bot $DISCORD_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$body" > /dev/null 2>&1
+    if [ -n "${{.TokenEnvVar}}" ] && [ -n "{{.AlertChannel}}" ]; then
+        {{.AlertCurl}}
     fi
     echo "$(date -Iseconds) ALERT: $msg"
 }
@@ -175,6 +169,8 @@ type watchdogParams struct {
 	Project      string
 	EnvSource    string
 	AlertChannel string
+	TokenEnvVar  string
+	AlertCurl    string
 	AgentChecks  string
 }
 
@@ -202,6 +198,10 @@ func GenerateScript(cfg *config.Config) string {
 	envSource := fmt.Sprintf(`[ -f "/home/%s/.env" ] && source "/home/%s/.env"`, orchestratorUser, orchestratorUser)
 
 	alertChannel := cfg.Coordination.Channels["alerts"]
+	backend, _ := coordination.Known(cfg.Coordination.Backend) // validated at load time
+	// $msg is the bash local set by send_alert; AlertTemplate expands it at
+	// runtime so the curl body matches the per-backend wire format.
+	alertCurl := fmt.Sprintf(backend.AlertTemplate, alertChannel, "$msg")
 
 	var checks strings.Builder
 	for _, key := range keys {
@@ -214,6 +214,8 @@ func GenerateScript(cfg *config.Config) string {
 		Project:      cfg.Project,
 		EnvSource:    envSource,
 		AlertChannel: alertChannel,
+		TokenEnvVar:  backend.TokenEnvVar,
+		AlertCurl:    alertCurl,
 		AgentChecks:  strings.TrimRight(checks.String(), "\n"),
 	}
 
@@ -221,6 +223,8 @@ func GenerateScript(cfg *config.Config) string {
 		"{{.Project}}", p.Project,
 		"{{.EnvSource}}", p.EnvSource,
 		"{{.AlertChannel}}", p.AlertChannel,
+		"{{.TokenEnvVar}}", p.TokenEnvVar,
+		"{{.AlertCurl}}", p.AlertCurl,
 		"{{.AgentChecks}}", p.AgentChecks,
 	)
 	return r.Replace(watchdogScript)

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -24,6 +24,8 @@ mkdir -p "$COOLDOWN_DIR"
 
 send_alert() {
     local msg="$1"
+    local safe_msg
+    safe_msg=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1])[1:-1])" "$msg" 2>/dev/null) || safe_msg=$msg
     if [ -n "${{.TokenEnvVar}}" ] && [ -n "{{.AlertChannel}}" ]; then
         {{.AlertCurl}}
     fi
@@ -201,7 +203,7 @@ func GenerateScript(cfg *config.Config) string {
 	backend, _ := coordination.Known(cfg.Coordination.Backend) // validated at load time
 	// $msg is the bash local set by send_alert; AlertTemplate expands it at
 	// runtime so the curl body matches the per-backend wire format.
-	alertCurl := fmt.Sprintf(backend.AlertTemplate, alertChannel, "$msg")
+	alertCurl := fmt.Sprintf(backend.AlertTemplate, alertChannel, "$safe_msg")
 
 	var checks strings.Builder
 	for _, key := range keys {

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -54,6 +54,54 @@ func TestGenerateScript_PostRestartRecheckSuppressesAlert(t *testing.T) {
 	}
 }
 
+func TestGenerateScript_DiscordBackendAlertCurl(t *testing.T) {
+	s := GenerateScript(baseCfg())
+	for _, want := range []string{
+		`if [ -n "$DISCORD_TOKEN" ] && [ -n "111" ]; then`,
+		`https://discord.com/api/v10/channels/111/messages`,
+		`-H "Authorization: Bot $DISCORD_TOKEN"`,
+		`-d "{\"content\":\"$msg\"}"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("discord-backend script missing %q\n---\n%s", want, s)
+		}
+	}
+	// Slack-only patterns must not leak into the Discord script.
+	for _, deny := range []string{
+		`SLACK_MCP_XOXP_TOKEN`,
+		`slack.com/api/chat.postMessage`,
+	} {
+		if strings.Contains(s, deny) {
+			t.Errorf("discord-backend script must not contain %q\n---\n%s", deny, s)
+		}
+	}
+}
+
+func TestGenerateScript_SlackBackendAlertCurl(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Coordination.Backend = "slack"
+	s := GenerateScript(cfg)
+	for _, want := range []string{
+		`if [ -n "$SLACK_MCP_XOXP_TOKEN" ] && [ -n "111" ]; then`,
+		`https://slack.com/api/chat.postMessage`,
+		`-H "Authorization: Bearer $SLACK_MCP_XOXP_TOKEN"`,
+		`-d "{\"channel\":\"111\",\"text\":\"$msg\"}"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("slack-backend script missing %q\n---\n%s", want, s)
+		}
+	}
+	// Discord-only patterns must not leak into the Slack script.
+	for _, deny := range []string{
+		`DISCORD_TOKEN`,
+		`discord.com/api/v10`,
+	} {
+		if strings.Contains(s, deny) {
+			t.Errorf("slack-backend script must not contain %q\n---\n%s", deny, s)
+		}
+	}
+}
+
 func TestGenerateScript_OOMCheckPresent(t *testing.T) {
 	s := GenerateScript(baseCfg())
 	for _, want := range []string{

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -60,7 +60,8 @@ func TestGenerateScript_DiscordBackendAlertCurl(t *testing.T) {
 		`if [ -n "$DISCORD_TOKEN" ] && [ -n "111" ]; then`,
 		`https://discord.com/api/v10/channels/111/messages`,
 		`-H "Authorization: Bot $DISCORD_TOKEN"`,
-		`-d "{\"content\":\"$msg\"}"`,
+		`-d "{\"content\":\"$safe_msg\"}"`,
+		`safe_msg=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1])[1:-1])" "$msg" 2>/dev/null) || safe_msg=$msg`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("discord-backend script missing %q\n---\n%s", want, s)
@@ -85,7 +86,7 @@ func TestGenerateScript_SlackBackendAlertCurl(t *testing.T) {
 		`if [ -n "$SLACK_MCP_XOXP_TOKEN" ] && [ -n "111" ]; then`,
 		`https://slack.com/api/chat.postMessage`,
 		`-H "Authorization: Bearer $SLACK_MCP_XOXP_TOKEN"`,
-		`-d "{\"channel\":\"111\",\"text\":\"$msg\"}"`,
+		`-d "{\"channel\":\"111\",\"text\":\"$safe_msg\"}"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("slack-backend script missing %q\n---\n%s", want, s)


### PR DESCRIPTION
Closes #91.

`send_alert` in `internal/watchdog/watchdog.go` hardcoded the Discord
bot API: a literal `curl https://discord.com/...` plus a
`[ -n "$DISCORD_TOKEN" ]` gate. Deployments running
`coordination.backend: slack` got watchdog restarts but no alerts, since
the Slack MCP server reads `SLACK_MCP_XOXP_TOKEN`, not `DISCORD_TOKEN`.

This change mirrors what `runner.Generate` already does:

```go
backend, _ := coordination.Known(cfg.Coordination.Backend)
alertCurl := fmt.Sprintf(backend.AlertTemplate, alertChannel, "$msg")
```

`$msg` is the bash local set inside `send_alert`, so `backend.AlertTemplate`
expands it at runtime; the rendered curl matches whichever backend the
operator configured. The send_alert wrapper now reads:

```bash
send_alert() {
    local msg="$1"
    if [ -n "$DISCORD_TOKEN" ] && [ -n "111" ]; then
        curl -s -X POST "https://discord.com/api/v10/channels/111/messages" \
            -H "Authorization: Bot $DISCORD_TOKEN" -H "Content-Type: application/json" \
            -d "{\"content\":\"$msg\"}" > /dev/null 2>&1
    fi
    echo "$(date -Iseconds) ALERT: $msg"
}
```

…for `backend=discord`, and the equivalent `slack.com/api/chat.postMessage`
form with `$SLACK_MCP_XOXP_TOKEN` for `backend=slack`.

## Tests

`TestGenerateScript_DiscordBackendAlertCurl` and
`TestGenerateScript_SlackBackendAlertCurl` assert the rendered script
contains the right endpoint, token env var, and JSON body shape for each
backend, and crucially that the *other* backend's tokens / URLs do not
leak into the wrong script.