### PR TITLE
fix(runner): substitute {{agent.*}} placeholders in prompt

### DIFF
--- a/internal/agentdoc/agentdoc.go
+++ b/internal/agentdoc/agentdoc.go
@@ -77,10 +77,14 @@ func Render(cfg *config.Config, agentKey, repoDir string) ([]byte, Mode, error) 
 		return nil, ModeNone, fmt.Errorf("reading %s: %w", perAgentPath, err)
 	}
 
-	return []byte(substitute(sb.String(), cfg, agentKey)), ModeSplit, nil
+	return []byte(Substitute(sb.String(), cfg, agentKey)), ModeSplit, nil
 }
 
-func substitute(content string, cfg *config.Config, agentKey string) string {
+// Substitute replaces {{var}} placeholders in content using cfg and the given
+// agent key. Exposed so other packages (e.g. runner) can reuse the same
+// substitution rules when rendering operator-authored strings such as the
+// per-agent prompt.
+func Substitute(content string, cfg *config.Config, agentKey string) string {
 	ac := cfg.Agents[agentKey]
 	pairs := []string{
 		"{{project}}", cfg.Project,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jahwag/clem/internal/agentdoc"
 	"github.com/jahwag/clem/internal/config"
 	"github.com/jahwag/clem/internal/coordination"
 )
@@ -400,7 +401,10 @@ func Generate(cfg *config.Config, agentKey string) string {
 	iterDur, _ := ac.IterationDuration() // validated at load time
 	iterSec := int(iterDur.Seconds())
 
-	promptText := ac.Prompt
+	// Render {{agent.name}}, {{channels.*}}, etc. in the operator-authored
+	// prompt the same way CLAUDE.local.md is rendered. Without this, agents
+	// receive the literal placeholder text and cannot identify themselves.
+	promptText := agentdoc.Substitute(ac.Prompt, cfg, agentKey)
 	if ac.Caveman.Enabled() {
 		promptText = "/caveman " + ac.Caveman.Level() + "\n" + promptText
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -142,6 +142,27 @@ func TestGenerate_PreservesUserKillPPID(t *testing.T) {
 	}
 }
 
+func TestGenerate_SubstitutesPromptPlaceholders(t *testing.T) {
+	cfg := baseCfg("workerb", config.AgentConfig{
+		Name:      "Solane",
+		Role:      "Software Engineer",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "Act as {{agent.name}} ({{agent.role}}) in #{{channels.general}}",
+	})
+
+	out := Generate(cfg, "workerb")
+
+	for _, want := range []string{"Act as Solane (Software Engineer)", "#333"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in runner, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "{{agent.name}}") || strings.Contains(out, "{{agent.role}}") || strings.Contains(out, "{{channels.general}}") {
+		t.Errorf("placeholders left unsubstituted in runner:\n%s", out)
+	}
+}
+
 func TestGenerate_DisablesClaudeAIConnectorMCPs(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:      "Lead",


### PR DESCRIPTION
## Summary
- `prompt:` from `clem.yaml` was injected into `runner.sh` verbatim — agents saw literal `{{agent.name}}` and could not identify themselves.
- Render the prompt through the same `Substitute` helper used for `CLAUDE.local.md` so `{{agent.name}}`, `{{agent.role}}`, `{{channels.*}}`, `{{project}}`, `{{primary_milestone}}`, `{{operator.*}}` all resolve.
- Export `agentdoc.Substitute` (was lowercase `substitute`) for cross-package reuse.

## Test plan
- [x] \`go test ./...\` green
- [x] New \`TestGenerate_SubstitutesPromptPlaceholders\` covers \`{{agent.name}}\`, \`{{agent.role}}\`, \`{{channels.general}}\`
- [ ] After merge: rebuild clem, \`clem provision\`, \`clem down && clem up\` — verify each agent's first prompt renders its real name