### PR TITLE
feat(runner): register browser-render MCP when env present

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -118,6 +118,15 @@ if os.environ.get('TYPEFULLY_API_KEY'):
         'command': _mcp_bin('social-mcp'),
         'env': {'TYPEFULLY_API_KEY': os.environ['TYPEFULLY_API_KEY']}
     }
+# browser-render (remote Playwright service for visual QA)
+if os.environ.get('BROWSER_RENDER_URL') and os.environ.get('BROWSER_RENDER_API_KEY'):
+    cfg['mcpServers']['browser-render'] = {
+        'command': _mcp_bin('mcp-browser-render'),
+        'env': {
+            'BROWSER_RENDER_URL': os.environ['BROWSER_RENDER_URL'],
+            'BROWSER_RENDER_API_KEY': os.environ['BROWSER_RENDER_API_KEY'],
+        }
+    }
 print(json.dumps(cfg, indent=2))
 " > "$WORKDIR/.mcp.json"
 
@@ -242,6 +251,16 @@ if os.environ.get('SLACK_MCP_XOXP_TOKEN'):
         'environment': {
             'SLACK_MCP_XOXP_TOKEN': os.environ['SLACK_MCP_XOXP_TOKEN'],
             'SLACK_MCP_ADD_MESSAGE_TOOL': os.environ.get('SLACK_MCP_ADD_MESSAGE_TOOL', 'true'),
+        },
+    }
+if os.environ.get('BROWSER_RENDER_URL') and os.environ.get('BROWSER_RENDER_API_KEY'):
+    cfg['mcp']['browser-render'] = {
+        'type': 'local',
+        'command': [_mcp_bin('mcp-browser-render')],
+        'enabled': True,
+        'environment': {
+            'BROWSER_RENDER_URL': os.environ['BROWSER_RENDER_URL'],
+            'BROWSER_RENDER_API_KEY': os.environ['BROWSER_RENDER_API_KEY'],
         },
     }
 print(json.dumps(cfg, indent=2))


### PR DESCRIPTION
## Summary
- Both `claude-code` and `opencode` runner templates now register a `browser-render` MCP server entry when `BROWSER_RENDER_URL` and `BROWSER_RENDER_API_KEY` are both set in the agent's `.env`.
- Resolved via the existing `_mcp_bin('mcp-browser-render')` helper — operator installs the stdio binary globally the same way `mcp-discord`, `prefect-mcp`, `social-mcp`, and `slack-mcp-server` are installed today.

## Why
Agents need a Playwright-backed visual-QA surface (e.g. for PR preview reviews) without each agent shipping its own Chromium — RAM-prohibitive at scale. Pattern: one shared `browser-render` HTTP service on a different host, accessed via a thin stdio MCP wrapper per agent. Tools return small JSON plus artifact URLs, so screenshot bytes never enter agent context.

## Test plan
- [x] `go test ./internal/runner/...` passes
- [x] Verified end-to-end against a live deployment: runner regenerates `.mcp.json` with the new entry on next iteration; `mcp-browser-render` stdio bin responds to `tools/list` from the agent's OS user.