### PR TITLE
feat(config): per-agent systemd resource_limits

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,6 +271,56 @@ type AgentConfig struct {
 	// Despite these limitations, this provides meaningful containment against
 	// naive outbound connections. Use with understanding of the gaps above.
 	EgressRestrictionExperimental bool `yaml:"egress_restriction_experimental"`
+	// ResourceLimits caps CPU/memory/IO for the agent's systemd service via
+	// cgroup directives. Use when co-locating agents with other workloads
+	// (e.g. CI runners on the same VPS) so one cannot starve the other.
+	// Empty fields are omitted from the generated unit — systemd defaults apply.
+	ResourceLimits ResourceLimits `yaml:"resource_limits"`
+}
+
+// ResourceLimits maps directly to systemd cgroup directives. All fields
+// optional; empty values are omitted from the rendered service unit.
+//
+// Field strings are written verbatim into the [Service] section; validation
+// is delegated to systemd. Standard formats:
+//   - CPUQuota:   "150%" (1.5 cores), "50%" (half a core), "200ms/1s"
+//   - MemoryHigh: "8G", "512M" (soft throttle — process slowed but not killed)
+//   - MemoryMax:  "10G" (hard kill — fires before global OOM-killer)
+//   - CPUWeight:  1..10000 (default 100; higher = more shares under contention)
+//   - IOWeight:   1..10000 (default 100; higher = more disk bandwidth)
+type ResourceLimits struct {
+	CPUQuota   string `yaml:"cpu_quota"`
+	MemoryHigh string `yaml:"memory_high"`
+	MemoryMax  string `yaml:"memory_max"`
+	CPUWeight  int    `yaml:"cpu_weight"`
+	IOWeight   int    `yaml:"io_weight"`
+}
+
+// Directives renders the resource-limit block for injection into a systemd
+// service unit's [Service] section. Returns an empty string when no fields
+// are set, so callers can safely concatenate without conditional logic.
+func (r ResourceLimits) Directives() string {
+	var lines []string
+	if r.CPUQuota != "" {
+		lines = append(lines, "CPUQuota="+r.CPUQuota)
+	}
+	if r.MemoryHigh != "" {
+		lines = append(lines, "MemoryHigh="+r.MemoryHigh)
+	}
+	if r.MemoryMax != "" {
+		lines = append(lines, "MemoryMax="+r.MemoryMax)
+	}
+	if r.CPUWeight != 0 {
+		lines = append(lines, fmt.Sprintf("CPUWeight=%d", r.CPUWeight))
+	}
+	if r.IOWeight != 0 {
+		lines = append(lines, fmt.Sprintf("IOWeight=%d", r.IOWeight))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return "# Resource limits (resource_limits in clem.yaml)\n" +
+		strings.Join(lines, "\n") + "\n"
 }
 
 // RuntimeKind returns the normalized runtime name for this agent.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -313,7 +313,7 @@ ExecStart=/usr/bin/tmux new-session -d -s {{.AgentKey}} {{.HomeDir}}/.local/bin/
 ExecStop=/usr/bin/tmux kill-session -t {{.AgentKey}}
 RemainAfterExit=yes
 Restart=no
-{{.HardeningDirectives}}{{.EgressDirectives}}
+{{.HardeningDirectives}}{{.EgressDirectives}}{{.ResourceDirectives}}
 [Install]
 WantedBy=multi-user.target
 `
@@ -388,6 +388,7 @@ type RunnerParams struct {
 	AlertCurl         string
 	EgressDirectives    string
 	HardeningDirectives string
+	ResourceDirectives  string
 	// WatchChannelIDs is the comma-separated list of Discord channel IDs the
 	// MCP server's gateway watcher should observe. Empty disables the watcher
 	// even when DISCORD_TOKEN is set, preserving the original tool-only mode.
@@ -523,6 +524,7 @@ func GenerateService(cfg *config.Config, agentKey string) (string, error) {
 		HomeDir:             homeDir,
 		EgressDirectives:    egress,
 		HardeningDirectives: buildHardeningDirectives(homeDir, cfg.Project),
+		ResourceDirectives:  ac.ResourceLimits.Directives(),
 	}
 	return renderTemplate(serviceTemplate, p), nil
 }
@@ -565,6 +567,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.SubagentExport}}", p.SubagentExport,
 		"{{.EgressDirectives}}", p.EgressDirectives,
 		"{{.HardeningDirectives}}", p.HardeningDirectives,
+		"{{.ResourceDirectives}}", p.ResourceDirectives,
 		"{{.WatchChannelIDs}}", p.WatchChannelIDs,
 	)
 	return r.Replace(tmpl)


### PR DESCRIPTION
## Summary
Adds a `resource_limits:` block to `AgentConfig`. Each field maps directly to a systemd cgroup directive (`CPUQuota`, `MemoryHigh`, `MemoryMax`, `CPUWeight`, `IOWeight`) and is injected into the agent's service unit's `[Service]` section.

```yaml
agents:
  lead:
    resource_limits:
      cpu_quota:   "150%"   # 1.5 cores max
      memory_high: "8G"     # soft throttle
      memory_max:  "10G"    # hard kill before host OOM-killer
      cpu_weight:  150      # priority under contention (default 100)
      io_weight:   150
```

## Why
For co-located workloads — e.g. running CI runners on the same VPS as `clem` agents — one process can OOM-kill the other or starve it of CPU. Per-agent cgroup caps let operators reserve CPU/RAM headroom and set relative priority (sister `CPUWeight`/`IOWeight` above 100 + runner weights below 100 = sisters keep priority under contention).

Backward-compatible: empty block = no directives rendered. All existing deployments unaffected.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all green
- [ ] Provision an agent w/ `resource_limits` set → verify `systemctl cat <service>` shows the rendered block
- [ ] `systemctl show <service> | grep -E "CPUQuota|MemoryHigh"` matches config
