### PR TITLE
feat(sidecar): privileged MCP sidecars over loopback HTTP

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -288,6 +288,13 @@ func runProvision(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// 5c. Privileged MCP sidecars: stand up mcp-proxy listeners under a dedicated
+	// system user so secrets that can't be HTTP-brokered stay out of agent .envs.
+	// Also after the agent loop — the loopback firewall keys on subscriber UIDs.
+	if err := provisionMCPSidecars(); err != nil {
+		return err
+	}
+
 	// 6. Install watchdog
 	fmt.Printf("\n[watchdog]\n")
 	wdScript := watchdog.GenerateScript(cfg)
@@ -493,4 +500,113 @@ func provisionEgress() error {
 	}
 	fmt.Printf("  installed + started %s (port %d)\n", cfg.PipelockServiceName(), cfg.Egress.ProxyPortOrDefault())
 	return nil
+}
+
+// provisionMCPSidecars stands up the privileged MCP sidecar stack: the dedicated
+// mcp system user, the pinned mcp-proxy bridge, one loopback listener per
+// subscribed sidecar (mcp-proxy fronting the wrapped stdio MCP server, with the
+// upstream secret supplied root-side via EnvironmentFile), and a loopback
+// nftables firewall that lets only each listener's subscribing agent UID(s)
+// reach its port. No-op when no agent subscribes to a sidecar. Must run after
+// the agent loop so subscriber UIDs resolve.
+func provisionMCPSidecars() error {
+	listeners := cfg.SidecarListeners()
+	if len(listeners) == 0 {
+		return nil
+	}
+	fmt.Printf("\n[mcp-sidecars]\n")
+	mcpUser := cfg.MCPSidecars.SystemUserOrDefault()
+	if err := agent.EnsureSystemUser(mcpUser); err != nil {
+		return fmt.Errorf("mcp-sidecars: %w", err)
+	}
+	if err := agent.InstallMCPProxy(); err != nil {
+		return fmt.Errorf("mcp-sidecars: %w", err)
+	}
+	if err := os.MkdirAll("/etc/clem", 0755); err != nil {
+		return fmt.Errorf("mcp-sidecars: creating /etc/clem: %w", err)
+	}
+	if err := agent.EnsureOwnedDir(proxy.SidecarStateDir, mcpUser); err != nil {
+		return fmt.Errorf("mcp-sidecars: state dir: %w", err)
+	}
+
+	allVaults, err := vault.AllVaults()
+	if err != nil {
+		return fmt.Errorf("mcp-sidecars: reading sops: %w", err)
+	}
+
+	// Write each listener's root-owned secret env + systemd unit (not started
+	// until the firewall is up).
+	for _, l := range listeners {
+		secretEnv, err := sidecarSecretEnv(l, allVaults)
+		if err != nil {
+			return fmt.Errorf("mcp-sidecars: sidecar %s: %w", l.Server.Name, err)
+		}
+		envPath := proxy.SidecarEnvFile(cfg.Project, l.Server.Name, l.AgentKey)
+		if err := agent.WriteSystemdEnvFile(envPath, secretEnv); err != nil {
+			return fmt.Errorf("mcp-sidecars: sidecar %s: %w", l.Server.Name, err)
+		}
+		svcName := cfg.SidecarServiceName(l.Server.Name, l.AgentKey)
+		if err := agent.InstallServiceByName(svcName, proxy.GenerateSidecarService(cfg, l)); err != nil {
+			return fmt.Errorf("mcp-sidecars: installing %s: %w", svcName, err)
+		}
+		fmt.Printf("  wrote %s + installed %s (port %d, %d secret(s))\n", envPath, svcName, l.Port, len(secretEnv))
+	}
+
+	// Loopback firewall first (fail-closed: subscribers only), then the listeners.
+	nft, err := proxy.GenerateSidecarNftables(cfg)
+	if err != nil {
+		return fmt.Errorf("mcp-sidecars: %w", err)
+	}
+	nftPath := proxy.SidecarNftablesPath(cfg.Project)
+	if err := os.WriteFile(nftPath, []byte(nft), 0644); err != nil {
+		return fmt.Errorf("mcp-sidecars: writing %s: %w", nftPath, err)
+	}
+	if err := agent.InstallServiceByName(cfg.SidecarNftablesServiceName(), proxy.GenerateSidecarNftablesService(cfg)); err != nil {
+		return fmt.Errorf("mcp-sidecars: installing firewall service: %w", err)
+	}
+	if err := agent.StartService(cfg.SidecarNftablesServiceName()); err != nil {
+		return fmt.Errorf("mcp-sidecars: starting firewall: %w", err)
+	}
+	fmt.Printf("  installed + started %s\n", cfg.SidecarNftablesServiceName())
+
+	for _, l := range listeners {
+		svcName := cfg.SidecarServiceName(l.Server.Name, l.AgentKey)
+		if err := agent.StartService(svcName); err != nil {
+			return fmt.Errorf("mcp-sidecars: starting %s: %w", svcName, err)
+		}
+	}
+	fmt.Printf("  started %d sidecar listener(s)\n", len(listeners))
+	return nil
+}
+
+// sidecarSecretEnv resolves the upstream secret values for a listener. A shared
+// listener reads the named sops vault (secrets_vault); a per-agent listener
+// reads the subscribing agent's own vaults (the value differs per agent).
+func sidecarSecretEnv(l config.SidecarListener, allVaults map[string]map[string]string) (map[string]string, error) {
+	var source map[string]string
+	if l.AgentKey != "" {
+		ac := cfg.Agents[l.AgentKey]
+		sec, err := vault.DecryptForAgent(l.AgentKey, ac.Vaults)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting secrets for %s: %w", l.AgentKey, err)
+		}
+		source = vault.FlatSecrets(sec)
+	} else {
+		if l.Server.SecretsVault == "" {
+			return nil, fmt.Errorf("shared sidecar requires secrets_vault")
+		}
+		source = allVaults[l.Server.SecretsVault]
+		if source == nil {
+			return nil, fmt.Errorf("secrets_vault %q not found in sops", l.Server.SecretsVault)
+		}
+	}
+	out := make(map[string]string, len(l.Server.Secrets))
+	for _, k := range l.Server.Secrets {
+		v, ok := source[k]
+		if !ok || v == "" {
+			return nil, fmt.Errorf("secret %q not found in source vault", k)
+		}
+		out[k] = v
+	}
+	return out, nil
 }

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -534,25 +534,40 @@ func provisionMCPSidecars() error {
 		return fmt.Errorf("mcp-sidecars: reading sops: %w", err)
 	}
 
-	// Write each listener's root-owned secret env + systemd unit (not started
-	// until the firewall is up).
+	// Pre-flight: resolve EVERY listener's secrets before touching any unit. A
+	// missing secret must abort while the system is still untouched — never
+	// half-installed with a credential-holding listener left behind a stale or
+	// absent firewall (the firewall is the only cross-UID boundary on hosts
+	// without egress containment).
+	type resolved struct {
+		l   config.SidecarListener
+		env map[string]string
+	}
+	pending := make([]resolved, 0, len(listeners))
 	for _, l := range listeners {
 		secretEnv, err := sidecarSecretEnv(l, allVaults)
 		if err != nil {
 			return fmt.Errorf("mcp-sidecars: sidecar %s: %w", l.Server.Name, err)
 		}
-		envPath := proxy.SidecarEnvFile(cfg.Project, l.Server.Name, l.AgentKey)
-		if err := agent.WriteSystemdEnvFile(envPath, secretEnv); err != nil {
-			return fmt.Errorf("mcp-sidecars: sidecar %s: %w", l.Server.Name, err)
-		}
-		svcName := cfg.SidecarServiceName(l.Server.Name, l.AgentKey)
-		if err := agent.InstallServiceByName(svcName, proxy.GenerateSidecarService(cfg, l)); err != nil {
-			return fmt.Errorf("mcp-sidecars: installing %s: %w", svcName, err)
-		}
-		fmt.Printf("  wrote %s + installed %s (port %d, %d secret(s))\n", envPath, svcName, l.Port, len(secretEnv))
+		pending = append(pending, resolved{l, secretEnv})
 	}
 
-	// Loopback firewall first (fail-closed: subscribers only), then the listeners.
+	// Write each listener's root-owned secret env + (re)install its unit.
+	for _, r := range pending {
+		envPath := proxy.SidecarEnvFile(cfg.Project, r.l.Server.Name, r.l.AgentKey)
+		if err := agent.WriteSystemdEnvFile(envPath, r.env); err != nil {
+			return fmt.Errorf("mcp-sidecars: sidecar %s: %w", r.l.Server.Name, err)
+		}
+		svcName := cfg.SidecarServiceName(r.l.Server.Name, r.l.AgentKey)
+		if err := agent.InstallServiceByName(svcName, proxy.GenerateSidecarService(cfg, r.l)); err != nil {
+			return fmt.Errorf("mcp-sidecars: installing %s: %w", svcName, err)
+		}
+		fmt.Printf("  wrote %s + installed %s (port %d, %d secret(s))\n", envPath, svcName, r.l.Port, len(r.env))
+	}
+
+	// Apply the loopback firewall (and REAPPLY on re-provision) BEFORE starting
+	// listeners, so a listener is never reachable on a port the firewall has not
+	// yet locked to its subscribers.
 	nft, err := proxy.GenerateSidecarNftables(cfg)
 	if err != nil {
 		return fmt.Errorf("mcp-sidecars: %w", err)
@@ -564,18 +579,22 @@ func provisionMCPSidecars() error {
 	if err := agent.InstallServiceByName(cfg.SidecarNftablesServiceName(), proxy.GenerateSidecarNftablesService(cfg)); err != nil {
 		return fmt.Errorf("mcp-sidecars: installing firewall service: %w", err)
 	}
-	if err := agent.StartService(cfg.SidecarNftablesServiceName()); err != nil {
-		return fmt.Errorf("mcp-sidecars: starting firewall: %w", err)
+	// restart (not start) so a re-provision re-runs `nft -f` and the updated
+	// ruleset takes effect; only after this succeeds do we (re)start listeners.
+	if err := agent.RestartService(cfg.SidecarNftablesServiceName()); err != nil {
+		return fmt.Errorf("mcp-sidecars: applying firewall: %w", err)
 	}
-	fmt.Printf("  installed + started %s\n", cfg.SidecarNftablesServiceName())
+	fmt.Printf("  installed + applied %s\n", cfg.SidecarNftablesServiceName())
 
-	for _, l := range listeners {
-		svcName := cfg.SidecarServiceName(l.Server.Name, l.AgentKey)
-		if err := agent.StartService(svcName); err != nil {
+	// restart (not start) so a changed ExecStart (port/command) takes effect and
+	// the listener comes up behind the freshly-applied firewall.
+	for _, r := range pending {
+		svcName := cfg.SidecarServiceName(r.l.Server.Name, r.l.AgentKey)
+		if err := agent.RestartService(svcName); err != nil {
 			return fmt.Errorf("mcp-sidecars: starting %s: %w", svcName, err)
 		}
 	}
-	fmt.Printf("  started %d sidecar listener(s)\n", len(listeners))
+	fmt.Printf("  started %d sidecar listener(s)\n", len(pending))
 	return nil
 }
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -927,6 +927,18 @@ func StartService(serviceName string) error {
 	return nil
 }
 
+// RestartService (re)starts a systemd service. Unlike StartService, this
+// re-execs an already-running unit so a regenerated ExecStart (e.g. a changed
+// sidecar port or wrapped command) takes effect on re-provision; for a oneshot
+// firewall unit it re-applies the ruleset.
+func RestartService(serviceName string) error {
+	out, err := sys.Run("systemctl", "restart", serviceName)
+	if err != nil {
+		return fmt.Errorf("systemctl restart %s: %w\n%s", serviceName, err, out)
+	}
+	return nil
+}
+
 // StopService stops a systemd service.
 func StopService(serviceName string) error {
 	out, err := sys.Run("systemctl", "stop", serviceName)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -240,6 +240,66 @@ install -m 0755 agent-vault /usr/local/bin/agent-vault`, ver, verNoV, arch)
 	return nil
 }
 
+// MCPProxyVersion is the pinned mcp-proxy (sparfenyuk/mcp-proxy) release clem
+// installs as the sidecar stdio→streamable-HTTP bridge. Bump deliberately — it
+// fronts a privileged, credential-holding stdio MCP process.
+const MCPProxyVersion = "0.12.0"
+
+// InstallMCPProxy installs the pinned mcp-proxy into a pipx-global venv at
+// /opt/pipx (binary at /opt/pipx/bin/mcp-proxy, which must match
+// proxy.MCPProxyBin), made world-readable/executable so the dedicated mcp
+// system user can run it. Idempotent: skips when the pinned version is present.
+// pipx isolates the bridge's dependency tree from system Python — the same
+// rationale as the operator-installed Python MCP servers (see README). Same
+// PyPI TOFU caveat as InstallPipelock/InstallAgentVault applies.
+func InstallMCPProxy() error {
+	const bin = "/opt/pipx/bin/mcp-proxy" // keep in sync with proxy.MCPProxyBin
+	verCheck := bin + " --version 2>/dev/null"
+	if out, err := sys.Run("bash", "-c", verCheck); err == nil &&
+		strings.Contains(string(out), MCPProxyVersion) {
+		fmt.Printf("  mcp-proxy %s already installed\n", MCPProxyVersion)
+		return nil
+	}
+	script := fmt.Sprintf(`set -euo pipefail
+command -v pipx >/dev/null 2>&1 || { echo "pipx not found; install it first (e.g. apt-get install -y pipx)" >&2; exit 1; }
+export PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/opt/pipx/bin
+pipx install --force "mcp-proxy==%s"
+# The mcp user runs the bridge: grant traverse/read + preserve exec bits.
+chmod -R a+rX /opt/pipx`, MCPProxyVersion)
+	fmt.Printf("  installing mcp-proxy %s (pipx-global)\n", MCPProxyVersion)
+	if out, err := sys.Run("bash", "-c", script); err != nil {
+		return fmt.Errorf("installing mcp-proxy %s: %w\n%s", MCPProxyVersion, err, out)
+	}
+	return nil
+}
+
+// WriteSystemdEnvFile writes a root-owned (0600) systemd EnvironmentFile of
+// KEY=value lines. Unlike WriteEnvFile this is NOT shell-sourced — systemd
+// parses it literally, so no `export`/quoting. Used for sidecar upstream
+// secrets, which systemd injects into the listener service env (never an agent
+// .env, never the process argv). Keys are sorted for stable diffs.
+func WriteSystemdEnvFile(path string, env map[string]string) error {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		// systemd EnvironmentFile values are taken literally to end-of-line and
+		// may not contain a newline. API tokens (the only expected values) are
+		// newline-free.
+		if strings.ContainsAny(env[k], "\n\r") {
+			return fmt.Errorf("sidecar secret %q contains a newline; unsupported in EnvironmentFile", k)
+		}
+		sb.WriteString(k + "=" + env[k] + "\n")
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0600); err != nil {
+		return fmt.Errorf("writing systemd env file %s: %w", path, err)
+	}
+	return nil
+}
+
 // BrokeredEnv builds the .env contents for an agent-vault-brokered agent: each
 // brokered secret becomes a placeholder (the real value lives only in
 // agent-vault and is injected on egress), non-brokered secrets keep their real

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1346,3 +1346,34 @@ func TestInstallAgentVault_PinnedDownload(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteSystemdEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.env")
+	if err := WriteSystemdEnvFile(path, map[string]string{
+		"ES_PASSWORD": "p@ss:w/rd",
+		"ES_USER":     "elastic",
+	}); err != nil {
+		t.Fatalf("WriteSystemdEnvFile: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sorted, literal KEY=value (no export, no quoting), one per line.
+	want := "ES_PASSWORD=p@ss:w/rd\nES_USER=elastic\n"
+	if string(b) != want {
+		t.Errorf("content = %q, want %q", string(b), want)
+	}
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteSystemdEnvFile_RejectsNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.env")
+	if err := WriteSystemdEnvFile(path, map[string]string{"K": "a\nb"}); err == nil {
+		t.Fatal("expected error for newline in secret value")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -786,6 +787,84 @@ func (c *Config) AgentVaultServiceName() string {
 	return fmt.Sprintf("clem-agent-vault-%s.service", c.Project)
 }
 
+// SidecarServiceName returns the systemd service name for a sidecar listener.
+// For a per-agent sidecar there is one listener per subscriber, so the agent
+// key disambiguates; shared sidecars pass an empty agentKey.
+func (c *Config) SidecarServiceName(name, agentKey string) string {
+	if agentKey != "" {
+		return fmt.Sprintf("clem-mcp-%s-%s-%s.service", c.Project, name, agentKey)
+	}
+	return fmt.Sprintf("clem-mcp-%s-%s.service", c.Project, name)
+}
+
+// SidecarNftablesServiceName returns the systemd service name for the sidecar
+// loopback firewall (distinct from the egress firewall; sidecar isolation must
+// hold even on hosts with no egress containment).
+func (c *Config) SidecarNftablesServiceName() string {
+	return fmt.Sprintf("clem-sidecar-nft-%s.service", c.Project)
+}
+
+// SidecarListener is one concrete loopback listener clem provisions for a
+// privileged MCP sidecar. A shared sidecar yields one listener (Subscribers =
+// every subscribing agent, AgentKey = ""); a per-agent sidecar yields one
+// listener per subscriber (Subscribers = [that agent], AgentKey = that agent).
+type SidecarListener struct {
+	Server      SidecarServer
+	Port        int
+	Subscribers []string // sorted agent keys allowed to reach this listener
+	AgentKey    string   // subscriber key for per-agent identity; "" when shared
+}
+
+// SidecarListeners returns the deterministic listener layout for all subscribed
+// sidecars: the single source of truth for port allocation shared by config
+// validation, the systemd/nftables generators, provisioning, and the runner.
+// Servers are taken in config order; per-agent subscribers in sorted order;
+// ports allocated upward from base_port. Unsubscribed servers yield no listener.
+func (c *Config) SidecarListeners() []SidecarListener {
+	var out []SidecarListener
+	idx := 0
+	for _, s := range c.MCPSidecars.Servers {
+		subs := c.sidecarSubscribers(s.Name)
+		if len(subs) == 0 {
+			continue
+		}
+		if s.IdentityKind() == "per-agent" {
+			for _, ak := range subs {
+				out = append(out, SidecarListener{
+					Server:      s,
+					Port:        c.MCPSidecars.SidecarPort(idx),
+					Subscribers: []string{ak},
+					AgentKey:    ak,
+				})
+				idx++
+			}
+			continue
+		}
+		out = append(out, SidecarListener{
+			Server:      s,
+			Port:        c.MCPSidecars.SidecarPort(idx),
+			Subscribers: subs,
+		})
+		idx++
+	}
+	return out
+}
+
+// sidecarSubscribers returns the sorted agent keys subscribing to a sidecar.
+func (c *Config) sidecarSubscribers(name string) []string {
+	var subs []string
+	for ak, ac := range c.Agents {
+		for _, n := range ac.Sidecars {
+			if n == name {
+				subs = append(subs, ak)
+				break
+			}
+		}
+	}
+	sort.Strings(subs)
+	return subs
+}
+
 // IsBrokered reports whether a secret key is HTTP-brokered for this agent
 // (placeholder in .env, real value only inside agent-vault).
 func (ac AgentConfig) IsBrokered(key string) bool {
@@ -1017,28 +1096,14 @@ func (cfg *Config) validateMCPSidecars() error {
 			}
 		}
 	}
-	// Deterministic loopback-port allocation. A shared sidecar listens once; a
-	// per-agent sidecar listens once per subscribing agent. Allocated upward from
-	// base_port — check the range fits below 65535 and never collides with an
-	// agent's web_terminal_port (both bind loopback on the same host).
-	listeners := 0
-	for _, s := range cfg.MCPSidecars.Servers {
-		if s.IdentityKind() == "per-agent" {
-			for _, ac := range cfg.Agents {
-				for _, name := range ac.Sidecars {
-					if name == s.Name {
-						listeners++
-						break
-					}
-				}
-			}
-		} else if subscribedTo(cfg, s.Name) {
-			listeners++
-		}
-	}
+	// Deterministic loopback-port allocation (SidecarListeners is the single
+	// source of truth). A shared sidecar listens once; a per-agent sidecar once
+	// per subscribing agent. Check the range fits below 65535 and never collides
+	// with an agent's web_terminal_port (both bind loopback on the same host).
+	listeners := cfg.SidecarListeners()
 	base := cfg.MCPSidecars.BasePortOrDefault()
-	if listeners > 0 && base+listeners-1 > 65535 {
-		return fmt.Errorf("mcp_sidecars: %d listeners from base_port %d overflow past 65535", listeners, base)
+	if n := len(listeners); n > 0 && base+n-1 > 65535 {
+		return fmt.Errorf("mcp_sidecars: %d listeners from base_port %d overflow past 65535", n, base)
 	}
 	webPorts := map[int]string{}
 	for key, ac := range cfg.Agents {
@@ -1046,24 +1111,12 @@ func (cfg *Config) validateMCPSidecars() error {
 			webPorts[ac.WebTerminalPort] = key
 		}
 	}
-	for i := 0; i < listeners; i++ {
-		if key, clash := webPorts[base+i]; clash {
-			return fmt.Errorf("mcp_sidecars: sidecar port %d collides with agent %s web_terminal_port", base+i, key)
+	for _, l := range listeners {
+		if key, clash := webPorts[l.Port]; clash {
+			return fmt.Errorf("mcp_sidecars: sidecar %q port %d collides with agent %s web_terminal_port", l.Server.Name, l.Port, key)
 		}
 	}
 	return nil
-}
-
-// subscribedTo reports whether any agent subscribes to the named sidecar.
-func subscribedTo(cfg *Config, name string) bool {
-	for _, ac := range cfg.Agents {
-		for _, n := range ac.Sidecars {
-			if n == name {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // validateVaultServices checks the agent-vault injection rules. Services are

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,17 @@ var githubLoginRe = regexp.MustCompile(`^[a-zA-Z0-9-]{1,39}$`)
 // vaultRefRe matches ${vault:BUCKET.KEY} in MCP server env values.
 var vaultRefRe = regexp.MustCompile(`\$\{vault:([^.}]+)\.([^}]+)\}`)
 
+// reservedMCPNames are MCP server names clem's runner hardcodes (runner.go); a
+// sidecar's tool name must not collide with them or it would shadow/duplicate a
+// builtin in the agent's .mcp.json.
+var reservedMCPNames = map[string]bool{
+	"discord-bot": true, "slack-mcp": true, "social": true, "browser-render": true,
+}
+
+// secretKeyRe matches an env-var-style credential key (what a sidecar's secrets
+// and the vault keys look like).
+var secretKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // extensionNameRe allows alphanumeric names with dots, hyphens, and underscores.
 // Rejects semicolons, spaces, backticks, and other shell-special characters.
 var extensionNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
@@ -295,6 +306,11 @@ func (s SidecarServer) ToolName() string {
 	}
 	return s.Name
 }
+
+// SidecarPort returns the deterministic loopback port for the i-th sidecar
+// listener (allocated upward from base_port). Stable across provisions so
+// re-provision yields minimal nftables/.mcp.json diffs.
+func (m MCPSidecarsConfig) SidecarPort(i int) int { return m.BasePortOrDefault() + i }
 
 // VaultBackend selects how agent secrets are materialized (Phase 2). Default
 // "env" preserves the legacy flow: secrets decrypted from sops are written
@@ -966,6 +982,21 @@ func (cfg *Config) validateMCPSidecars() error {
 		if len(s.Secrets) == 0 {
 			return fmt.Errorf("%s: at least one secret is required (a sidecar with no secret to hide should be a normal MCP server)", where)
 		}
+		if !strings.HasPrefix(s.Command, "/") {
+			return fmt.Errorf("%s: command must be an absolute path, got %q", where, s.Command)
+		}
+		tn := s.ToolName()
+		if !validName.MatchString(tn) {
+			return fmt.Errorf("%s: tool name %q must match %s (set `tool:` to override)", where, tn, validName.String())
+		}
+		if reservedMCPNames[tn] {
+			return fmt.Errorf("%s: tool name %q collides with a builtin MCP server (%v); set a distinct `tool:`", where, tn, []string{"discord-bot", "slack-mcp", "social", "browser-render"})
+		}
+		for _, k := range s.Secrets {
+			if !secretKeyRe.MatchString(k) {
+				return fmt.Errorf("%s: secret key %q must match %s", where, k, secretKeyRe.String())
+			}
+		}
 		switch s.Identity {
 		case "", "shared", "per-agent":
 		default:
@@ -986,7 +1017,53 @@ func (cfg *Config) validateMCPSidecars() error {
 			}
 		}
 	}
+	// Deterministic loopback-port allocation. A shared sidecar listens once; a
+	// per-agent sidecar listens once per subscribing agent. Allocated upward from
+	// base_port — check the range fits below 65535 and never collides with an
+	// agent's web_terminal_port (both bind loopback on the same host).
+	listeners := 0
+	for _, s := range cfg.MCPSidecars.Servers {
+		if s.IdentityKind() == "per-agent" {
+			for _, ac := range cfg.Agents {
+				for _, name := range ac.Sidecars {
+					if name == s.Name {
+						listeners++
+						break
+					}
+				}
+			}
+		} else if subscribedTo(cfg, s.Name) {
+			listeners++
+		}
+	}
+	base := cfg.MCPSidecars.BasePortOrDefault()
+	if listeners > 0 && base+listeners-1 > 65535 {
+		return fmt.Errorf("mcp_sidecars: %d listeners from base_port %d overflow past 65535", listeners, base)
+	}
+	webPorts := map[int]string{}
+	for key, ac := range cfg.Agents {
+		if ac.WebTerminalPort != 0 {
+			webPorts[ac.WebTerminalPort] = key
+		}
+	}
+	for i := 0; i < listeners; i++ {
+		if key, clash := webPorts[base+i]; clash {
+			return fmt.Errorf("mcp_sidecars: sidecar port %d collides with agent %s web_terminal_port", base+i, key)
+		}
+	}
 	return nil
+}
+
+// subscribedTo reports whether any agent subscribes to the named sidecar.
+func subscribedTo(cfg *Config, name string) bool {
+	for _, ac := range cfg.Agents {
+		for _, n := range ac.Sidecars {
+			if n == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // validateVaultServices checks the agent-vault injection rules. Services are

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,7 +201,99 @@ type Config struct {
 	Operator         OperatorConfig         `yaml:"operator"`
 	Egress           EgressConfig           `yaml:"egress"`
 	Vault            VaultBackend           `yaml:"vault"`
+	MCPSidecars      MCPSidecarsConfig      `yaml:"mcp_sidecars"`
 	Agents           map[string]AgentConfig `yaml:"agents"`
+}
+
+// MCPSidecarsConfig configures privileged MCP "sidecars": MCP servers that hold
+// a secret the agent must USE but not READ, run as a dedicated non-agent system
+// user, and are reached by the agent over a loopback HTTP MCP transport. This is
+// the "sidecar" disposition in clem's secret-protection model — for credentials
+// the broker can't rewrite (gateway WebSocket tokens) or that warrant scoped
+// access (e.g. read-only Elasticsearch). A stdio MCP server cannot provide this:
+// it runs as the agent's own UID, so its secret is in the agent's reach.
+//
+// FOUNDATION ONLY (this commit): schema + validation. Provision wiring (the
+// clem-mcp system user, the stdio→HTTP bridge install, the systemd loopback
+// service, per-agent token mint, nftables allow-rule, and runner .mcp.json http
+// entry) is the follow-up build. See docs/threat-model.md and the design notes.
+type MCPSidecarsConfig struct {
+	// SystemUser is the dedicated non-login user that runs all sidecar servers.
+	// Default "clem-mcp".
+	SystemUser string `yaml:"system_user"`
+	// BasePort is the first loopback port allocated to sidecar listeners;
+	// subsequent listeners take successive ports deterministically. Default 14500.
+	BasePort int `yaml:"base_port"`
+	// Servers declares the available sidecar MCP servers; agents subscribe by
+	// name via AgentConfig.Sidecars.
+	Servers []SidecarServer `yaml:"servers"`
+}
+
+// SidecarServer is one privileged MCP server definition. The agent sees only a
+// loopback HTTP MCP endpoint + a scoped bearer token; the upstream credential
+// lives only in the sidecar process (sourced from Secrets, written to a
+// root-owned env file, never any agent .env).
+type SidecarServer struct {
+	// Name is the sidecar slug (matches validName) and the MCP server name the
+	// agent sees in .mcp.json unless Tool overrides it.
+	Name string `yaml:"name"`
+	// Identity is "shared" (one upstream credential for all subscribers, e.g.
+	// read-only ES) or "per-agent" (one listener per subscribing agent with that
+	// agent's own credential, e.g. each agent's Discord bot token). Default shared.
+	Identity string `yaml:"identity"`
+	// Command + Args are the underlying stdio MCP server the bridge wraps.
+	Command string   `yaml:"command"`
+	Args    []string `yaml:"args"`
+	// Transport is the agent-facing transport. "http" (streamable-HTTP, default;
+	// recommended) or "sse" (deprecated).
+	Transport string `yaml:"transport"`
+	// Secrets are the credential keys this sidecar holds (written to its
+	// root-owned env file); for identity per-agent they are resolved per agent.
+	Secrets []string `yaml:"secrets"`
+	// SecretsVault is the sops/agent-vault vault to pull Secrets from.
+	SecretsVault string `yaml:"secrets_vault"`
+	// Tool overrides the MCP server name the agent sees (default Name).
+	Tool string `yaml:"tool"`
+}
+
+// SystemUserOrDefault returns the sidecar system user, default clem-mcp.
+func (m MCPSidecarsConfig) SystemUserOrDefault() string {
+	if m.SystemUser == "" {
+		return "clem-mcp"
+	}
+	return m.SystemUser
+}
+
+// BasePortOrDefault returns the first sidecar loopback port, default 14500.
+func (m MCPSidecarsConfig) BasePortOrDefault() int {
+	if m.BasePort == 0 {
+		return 14500
+	}
+	return m.BasePort
+}
+
+// IdentityKind normalizes the identity to "shared" (default) or "per-agent".
+func (s SidecarServer) IdentityKind() string {
+	if s.Identity == "per-agent" {
+		return "per-agent"
+	}
+	return "shared"
+}
+
+// TransportKind normalizes the transport to "http" (default) or "sse".
+func (s SidecarServer) TransportKind() string {
+	if s.Transport == "sse" {
+		return "sse"
+	}
+	return "http"
+}
+
+// ToolName returns the MCP server name the agent sees (Tool or Name).
+func (s SidecarServer) ToolName() string {
+	if s.Tool != "" {
+		return s.Tool
+	}
+	return s.Name
 }
 
 // VaultBackend selects how agent secrets are materialized (Phase 2). Default
@@ -470,6 +562,10 @@ type AgentConfig struct {
 	// install for this agent at provision time. caveman: true is handled as a
 	// shorthand that prepends the caveman marketplace and plugin entries.
 	Extensions ExtensionsConfig `yaml:"extensions"`
+	// Sidecars lists names of mcp_sidecars.servers this agent subscribes to. Each
+	// gives the agent a loopback HTTP MCP endpoint + a scoped bearer token, with
+	// the upstream credential held by the clem-mcp user (never this agent's .env).
+	Sidecars []string `yaml:"sidecars"`
 	// Permissions configures root-owned /etc/claude-code/managed-settings.json
 	// deny rules for this agent. managed-settings.json has higher precedence
 	// than the agent's own ~/.claude/settings.json and cannot be overridden by
@@ -830,7 +926,67 @@ func Load(path string) (*Config, error) {
 	if err := cfg.validateVaultServices(); err != nil {
 		return nil, err
 	}
+	if err := cfg.validateMCPSidecars(); err != nil {
+		return nil, err
+	}
 	return &cfg, nil
+}
+
+// validateMCPSidecars checks the privileged-sidecar declarations and that every
+// agent subscription references a defined server.
+func (cfg *Config) validateMCPSidecars() error {
+	subscribed := false
+	for _, ac := range cfg.Agents {
+		if len(ac.Sidecars) > 0 {
+			subscribed = true
+		}
+	}
+	if len(cfg.MCPSidecars.Servers) == 0 && !subscribed {
+		return nil
+	}
+	if p := cfg.MCPSidecars.BasePort; p != 0 && (p < 1 || p > 65535) {
+		return fmt.Errorf("mcp_sidecars.base_port %d out of range 1-65535", p)
+	}
+	defined := map[string]bool{}
+	for i, s := range cfg.MCPSidecars.Servers {
+		where := fmt.Sprintf("mcp_sidecars.servers[%d]", i)
+		if s.Name != "" {
+			where = "mcp_sidecars " + s.Name
+		}
+		if !validName.MatchString(s.Name) {
+			return fmt.Errorf("%s: name must match %s", where, validName.String())
+		}
+		if defined[s.Name] {
+			return fmt.Errorf("%s: duplicate sidecar name %q", where, s.Name)
+		}
+		defined[s.Name] = true
+		if s.Command == "" {
+			return fmt.Errorf("%s: command is required", where)
+		}
+		if len(s.Secrets) == 0 {
+			return fmt.Errorf("%s: at least one secret is required (a sidecar with no secret to hide should be a normal MCP server)", where)
+		}
+		switch s.Identity {
+		case "", "shared", "per-agent":
+		default:
+			return fmt.Errorf("%s: identity must be shared or per-agent, got %q", where, s.Identity)
+		}
+		switch s.Transport {
+		case "", "http":
+		case "sse":
+			fmt.Fprintf(os.Stderr, "warning: %s: transport sse is deprecated; prefer http (streamable-HTTP)\n", where)
+		default:
+			return fmt.Errorf("%s: transport must be http or sse, got %q", where, s.Transport)
+		}
+	}
+	for key, ac := range cfg.Agents {
+		for _, name := range ac.Sidecars {
+			if !defined[name] {
+				return fmt.Errorf("agent %s: sidecar %q is not defined in mcp_sidecars.servers", key, name)
+			}
+		}
+	}
+	return nil
 }
 
 // validateVaultServices checks the agent-vault injection rules. Services are

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1088,6 +1088,11 @@ func (cfg *Config) validateMCPSidecars() error {
 		default:
 			return fmt.Errorf("%s: transport must be http or sse, got %q", where, s.Transport)
 		}
+		// A shared sidecar's one credential set comes from a named sops vault;
+		// per-agent reads each subscriber's own vaults at provision, so it needs none.
+		if s.IdentityKind() == "shared" && s.SecretsVault == "" {
+			return fmt.Errorf("%s: a shared sidecar requires secrets_vault (the sops vault to read its secrets from)", where)
+		}
 	}
 	for key, ac := range cfg.Agents {
 		for _, name := range ac.Sidecars {
@@ -1095,25 +1100,48 @@ func (cfg *Config) validateMCPSidecars() error {
 				return fmt.Errorf("agent %s: sidecar %q is not defined in mcp_sidecars.servers", key, name)
 			}
 		}
+		// The runner only emits the http MCP entry into the claude-code .mcp.json;
+		// an opencode agent would get the listener + firewall but never the config,
+		// a silent no-op. Reject rather than mislead.
+		if len(ac.Sidecars) > 0 && ac.RuntimeKind() == "opencode" {
+			return fmt.Errorf("agent %s: sidecars are not supported with runtime opencode", key)
+		}
 	}
 	// Deterministic loopback-port allocation (SidecarListeners is the single
 	// source of truth). A shared sidecar listens once; a per-agent sidecar once
 	// per subscribing agent. Check the range fits below 65535 and never collides
-	// with an agent's web_terminal_port (both bind loopback on the same host).
+	// with another loopback port clem binds on the same host.
 	listeners := cfg.SidecarListeners()
 	base := cfg.MCPSidecars.BasePortOrDefault()
 	if n := len(listeners); n > 0 && base+n-1 > 65535 {
 		return fmt.Errorf("mcp_sidecars: %d listeners from base_port %d overflow past 65535", n, base)
 	}
-	webPorts := map[int]string{}
+	reserved := map[int]string{}
 	for key, ac := range cfg.Agents {
 		if ac.WebTerminalPort != 0 {
-			webPorts[ac.WebTerminalPort] = key
+			reserved[ac.WebTerminalPort] = "agent " + key + " web_terminal_port"
 		}
 	}
+	egressInUse := cfg.Egress.Enabled
+	for key := range cfg.Agents {
+		if cfg.EgressEnabledFor(key) {
+			egressInUse = true
+		}
+	}
+	if egressInUse {
+		reserved[cfg.Egress.ProxyPortOrDefault()] = "egress proxy_port"
+		for _, p := range cfg.Egress.AllowLocalhostPorts {
+			reserved[p] = "egress allow_localhost_ports"
+		}
+	}
+	if cfg.Vault.IsAgentVault() {
+		// Default mgmt/MITM ports; a custom vault address near base_port is not parsed here.
+		reserved[14321] = "agent-vault management port"
+		reserved[14322] = "agent-vault MITM port"
+	}
 	for _, l := range listeners {
-		if key, clash := webPorts[l.Port]; clash {
-			return fmt.Errorf("mcp_sidecars: sidecar %q port %d collides with agent %s web_terminal_port", l.Server.Name, l.Port, key)
+		if owner, clash := reserved[l.Port]; clash {
+			return fmt.Errorf("mcp_sidecars: sidecar %q port %d collides with %s", l.Server.Name, l.Port, owner)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1352,12 +1353,111 @@ func TestLoad_Sidecar_PerAgentAndToolOverride(t *testing.T) {
       identity: per-agent
       command: /bin/x
       secrets: [DISCORD_TOKEN]
-      tool: discord-bot`)))
+      tool: discord-gw`)))
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
 	s := cfg.MCPSidecars.Servers[0]
-	if s.IdentityKind() != "per-agent" || s.ToolName() != "discord-bot" {
+	if s.IdentityKind() != "per-agent" || s.ToolName() != "discord-gw" {
 		t.Errorf("got %q / %q", s.IdentityKind(), s.ToolName())
+	}
+}
+
+func TestLoad_Sidecar_RelativeCommandRejected(t *testing.T) {
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      command: clem-mcp-http
+      secrets: [ES_USER]`))); err == nil {
+		t.Fatal("expected error: command must be absolute path")
+	}
+}
+
+func TestLoad_Sidecar_ToolNameCollidesWithBuiltin(t *testing.T) {
+	for _, builtin := range []string{"discord-bot", "slack-mcp", "social", "browser-render"} {
+		if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      command: /bin/x
+      secrets: [ES_USER]
+      tool: `+builtin))); err == nil {
+			t.Fatalf("expected error: tool %q collides with builtin", builtin)
+		}
+	}
+}
+
+func TestLoad_Sidecar_BadToolNameRejected(t *testing.T) {
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      command: /bin/x
+      secrets: [ES_USER]
+      tool: ES_RO`))); err == nil {
+		t.Fatal("expected error: tool name must match slug pattern")
+	}
+}
+
+func TestLoad_Sidecar_BadSecretKeyRejected(t *testing.T) {
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      command: /bin/x
+      secrets: ["es-user"]`))); err == nil {
+		t.Fatal("expected error: secret key with hyphen is not a valid env-var name")
+	}
+}
+
+// portYAML builds a config with one sidecar and one agent whose web_terminal_port
+// and the sidecar base_port can be set to provoke overflow/collision.
+func portYAML(basePort, webPort int, identity string) string {
+	return fmt.Sprintf(`
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+mcp_sidecars:
+  base_port: %d
+  servers:
+    - name: es-ro
+      identity: %s
+      command: /bin/x
+      secrets: [ES_USER]
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    web_terminal_port: %d
+    sidecars: [es-ro]
+  worker:
+    name: "Worker"
+    model: "claude-sonnet-4-6"
+    sidecars: [es-ro]
+`, basePort, identity, webPort)
+}
+
+func TestLoad_Sidecar_PortOverflow(t *testing.T) {
+	// per-agent sidecar with 2 subscribers at base_port 65535 → 2 listeners overflow.
+	if _, err := Load(writeYAML(t, portYAML(65535, 7681, "per-agent"))); err == nil {
+		t.Fatal("expected error: sidecar listener ports overflow past 65535")
+	}
+}
+
+func TestLoad_Sidecar_PortCollidesWithWebTerminal(t *testing.T) {
+	// shared sidecar at base_port 14500, agent web_terminal_port 14500 → collision.
+	if _, err := Load(writeYAML(t, portYAML(14500, 14500, "shared"))); err == nil {
+		t.Fatal("expected error: sidecar port collides with web_terminal_port")
+	}
+}
+
+func TestSidecarPort_Deterministic(t *testing.T) {
+	m := MCPSidecarsConfig{BasePort: 14500}
+	if m.SidecarPort(0) != 14500 || m.SidecarPort(3) != 14503 {
+		t.Errorf("got %d %d", m.SidecarPort(0), m.SidecarPort(3))
+	}
+	if (MCPSidecarsConfig{}).SidecarPort(0) != 14500 {
+		t.Errorf("default base wrong: %d", (MCPSidecarsConfig{}).SidecarPort(0))
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1271,3 +1271,93 @@ agents:
 		t.Fatal("expected error: vault_broker + egress containment on same agent")
 	}
 }
+
+// --- mcp_sidecars (privileged sidecar) schema/validation ---
+
+func sidecarYAML(block string) string {
+	return `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+` + block + `
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    sidecars: [es-ro]
+`
+}
+
+func TestLoad_Sidecar_Valid(t *testing.T) {
+	cfg, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      identity: shared
+      command: /usr/local/bin/clem-mcp-http
+      secrets: [ES_USER, ES_PASSWORD]
+      secrets_vault: clem-vault`)))
+	if err != nil {
+		t.Fatalf("valid sidecar should load: %v", err)
+	}
+	s := cfg.MCPSidecars.Servers[0]
+	if cfg.MCPSidecars.SystemUserOrDefault() != "clem-mcp" || cfg.MCPSidecars.BasePortOrDefault() != 14500 {
+		t.Errorf("defaults wrong: %q %d", cfg.MCPSidecars.SystemUserOrDefault(), cfg.MCPSidecars.BasePortOrDefault())
+	}
+	if s.IdentityKind() != "shared" || s.TransportKind() != "http" || s.ToolName() != "es-ro" {
+		t.Errorf("normalizers wrong: %q %q %q", s.IdentityKind(), s.TransportKind(), s.ToolName())
+	}
+}
+
+func TestLoad_Sidecar_UndefinedSubscriptionRejected(t *testing.T) {
+	// agent subscribes to es-ro but no servers defined
+	if _, err := Load(writeYAML(t, sidecarYAML(``))); err == nil {
+		t.Fatal("expected error: agent subscribes to undefined sidecar")
+	}
+}
+
+func TestLoad_Sidecar_RequiresCommandAndSecret(t *testing.T) {
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      command: /bin/x`))); err == nil {
+		t.Fatal("expected error: sidecar with no secrets")
+	}
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      secrets: [ES_USER]`))); err == nil {
+		t.Fatal("expected error: sidecar with no command")
+	}
+}
+
+func TestLoad_Sidecar_BadIdentityRejected(t *testing.T) {
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      identity: wat
+      command: /bin/x
+      secrets: [ES_USER]`))); err == nil {
+		t.Fatal("expected error: bad identity")
+	}
+}
+
+func TestLoad_Sidecar_PerAgentAndToolOverride(t *testing.T) {
+	cfg, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      identity: per-agent
+      command: /bin/x
+      secrets: [DISCORD_TOKEN]
+      tool: discord-bot`)))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	s := cfg.MCPSidecars.Servers[0]
+	if s.IdentityKind() != "per-agent" || s.ToolName() != "discord-bot" {
+		t.Errorf("got %q / %q", s.IdentityKind(), s.ToolName())
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1425,6 +1425,7 @@ mcp_sidecars:
       identity: %s
       command: /bin/x
       secrets: [ES_USER]
+      secrets_vault: infra
 agents:
   lead:
     name: "Lead"
@@ -1449,6 +1450,45 @@ func TestLoad_Sidecar_PortCollidesWithWebTerminal(t *testing.T) {
 	// shared sidecar at base_port 14500, agent web_terminal_port 14500 → collision.
 	if _, err := Load(writeYAML(t, portYAML(14500, 14500, "shared"))); err == nil {
 		t.Fatal("expected error: sidecar port collides with web_terminal_port")
+	}
+}
+
+func TestLoad_Sidecar_SharedRequiresSecretsVault(t *testing.T) {
+	if _, err := Load(writeYAML(t, sidecarYAML(`mcp_sidecars:
+  servers:
+    - name: es-ro
+      command: /bin/x
+      secrets: [ES_USER]`))); err == nil {
+		t.Fatal("expected error: shared sidecar requires secrets_vault")
+	}
+}
+
+func TestValidateMCPSidecars_OpencodeRejected(t *testing.T) {
+	cfg := &Config{
+		Project: "t",
+		MCPSidecars: MCPSidecarsConfig{Servers: []SidecarServer{
+			{Name: "es-ro", Identity: "shared", Command: "/bin/x", Secrets: []string{"K"}, SecretsVault: "infra"},
+		}},
+		Agents: map[string]AgentConfig{
+			"lead": {Name: "L", Runtime: "opencode", Sidecars: []string{"es-ro"}},
+		},
+	}
+	if err := cfg.validateMCPSidecars(); err == nil {
+		t.Fatal("expected error: sidecars unsupported with runtime opencode")
+	}
+}
+
+func TestValidateMCPSidecars_AgentVaultPortCollision(t *testing.T) {
+	cfg := &Config{
+		Project: "t",
+		Vault:   VaultBackend{Backend: "agent-vault"},
+		MCPSidecars: MCPSidecarsConfig{BasePort: 14321, Servers: []SidecarServer{
+			{Name: "es-ro", Identity: "shared", Command: "/bin/x", Secrets: []string{"K"}, SecretsVault: "infra"},
+		}},
+		Agents: map[string]AgentConfig{"lead": {Name: "L", Sidecars: []string{"es-ro"}}},
+	}
+	if err := cfg.validateMCPSidecars(); err == nil {
+		t.Fatal("expected error: sidecar port collides with agent-vault management port")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1452,6 +1452,67 @@ func TestLoad_Sidecar_PortCollidesWithWebTerminal(t *testing.T) {
 	}
 }
 
+func TestSidecarListeners_SharedAndUnsubscribed(t *testing.T) {
+	cfg := &Config{
+		Project:     "myteam",
+		MCPSidecars: MCPSidecarsConfig{BasePort: 14500, Servers: []SidecarServer{
+			{Name: "es-ro", Identity: "shared", Command: "/bin/x", Secrets: []string{"K"}},
+			{Name: "unused", Identity: "shared", Command: "/bin/x", Secrets: []string{"K"}},
+		}},
+		Agents: map[string]AgentConfig{
+			"worker": {Name: "W", Sidecars: []string{"es-ro"}},
+			"lead":   {Name: "L", Sidecars: []string{"es-ro"}},
+		},
+	}
+	ls := cfg.SidecarListeners()
+	if len(ls) != 1 { // "unused" has no subscriber → no listener
+		t.Fatalf("want 1 listener, got %d", len(ls))
+	}
+	if ls[0].Port != 14500 || ls[0].AgentKey != "" {
+		t.Errorf("shared listener wrong: port=%d agentKey=%q", ls[0].Port, ls[0].AgentKey)
+	}
+	if len(ls[0].Subscribers) != 2 || ls[0].Subscribers[0] != "lead" || ls[0].Subscribers[1] != "worker" {
+		t.Errorf("subscribers not sorted/complete: %v", ls[0].Subscribers)
+	}
+}
+
+func TestSidecarListeners_PerAgentOnePortEach(t *testing.T) {
+	cfg := &Config{
+		Project:     "myteam",
+		MCPSidecars: MCPSidecarsConfig{BasePort: 14500, Servers: []SidecarServer{
+			{Name: "disc", Identity: "per-agent", Command: "/bin/x", Secrets: []string{"DISCORD_TOKEN"}},
+		}},
+		Agents: map[string]AgentConfig{
+			"worker": {Name: "W", Sidecars: []string{"disc"}},
+			"lead":   {Name: "L", Sidecars: []string{"disc"}},
+		},
+	}
+	ls := cfg.SidecarListeners()
+	if len(ls) != 2 {
+		t.Fatalf("want 2 per-agent listeners, got %d", len(ls))
+	}
+	// Sorted subscribers: lead@14500, worker@14501.
+	if ls[0].AgentKey != "lead" || ls[0].Port != 14500 {
+		t.Errorf("listener[0] = %q@%d", ls[0].AgentKey, ls[0].Port)
+	}
+	if ls[1].AgentKey != "worker" || ls[1].Port != 14501 {
+		t.Errorf("listener[1] = %q@%d", ls[1].AgentKey, ls[1].Port)
+	}
+}
+
+func TestSidecarServiceNames(t *testing.T) {
+	c := &Config{Project: "cdev"}
+	if got := c.SidecarServiceName("es-ro", ""); got != "clem-mcp-cdev-es-ro.service" {
+		t.Errorf("shared service name: %q", got)
+	}
+	if got := c.SidecarServiceName("disc", "lead"); got != "clem-mcp-cdev-disc-lead.service" {
+		t.Errorf("per-agent service name: %q", got)
+	}
+	if got := c.SidecarNftablesServiceName(); got != "clem-sidecar-nft-cdev.service" {
+		t.Errorf("sidecar nft service name: %q", got)
+	}
+}
+
 func TestSidecarPort_Deterministic(t *testing.T) {
 	m := MCPSidecarsConfig{BasePort: 14500}
 	if m.SidecarPort(0) != 14500 || m.SidecarPort(3) != 14503 {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -61,6 +61,38 @@ func nftTableName(project string) string {
 	return "clem_egress_" + strings.ReplaceAll(project, "-", "_")
 }
 
+// sidecarNftTableName returns the nftables table identifier for a project's
+// sidecar loopback firewall (separate from the egress table so it applies even
+// on hosts with no egress containment).
+func sidecarNftTableName(project string) string {
+	return "clem_sidecar_" + strings.ReplaceAll(project, "-", "_")
+}
+
+// SidecarNftablesPath returns the path to a project's sidecar firewall ruleset.
+func SidecarNftablesPath(project string) string {
+	return fmt.Sprintf("/etc/clem/clem-sidecar-%s.nft", project)
+}
+
+// SidecarEnvFile returns the root-owned (0600) EnvironmentFile holding a sidecar
+// listener's upstream secret(s). systemd reads it as root and injects it into
+// the service env before dropping to the mcp user; the secret never reaches an
+// agent .env and never appears in the process argv.
+func SidecarEnvFile(project, name, agentKey string) string {
+	if agentKey != "" {
+		return fmt.Sprintf("/etc/clem/clem-mcp-%s-%s-%s.env", project, name, agentKey)
+	}
+	return fmt.Sprintf("/etc/clem/clem-mcp-%s-%s.env", project, name)
+}
+
+// MCPProxyBin is the stdio→streamable-HTTP bridge clem installs (pipx-global,
+// reachable by the mcp user). Sidecar listeners run a wrapped stdio MCP server
+// behind it on loopback.
+const MCPProxyBin = "/opt/pipx/bin/mcp-proxy"
+
+// SidecarStateDir is the writable HOME/scratch dir for the mcp user, so wrapped
+// stdio servers (node/python) that touch a cache dir work under ProtectSystem=strict.
+const SidecarStateDir = "/var/lib/clem-mcp"
+
 // GeneratePipelockConfig renders pipelock.yaml for a project. Phase 1 is
 // CONNECT-only (tls_interception off) so no CA distribution is needed; the
 // forward proxy still enforces the api_allowlist by SNI/CONNECT host and writes
@@ -243,16 +275,31 @@ func GenerateNftables(cfg *config.Config) (string, error) {
 	basePorts = append(basePorts, cfg.Egress.AllowLocalhostPorts...)
 	avPort := agentVaultPort(cfg) // 0 unless agent-vault backend active
 
+	// Sidecar loopback ports each agent subscribes to. A contained agent reaches
+	// its sidecar over loopback, so those ports must be in its allowed set or the
+	// per-UID reject below would block them. (Cross-agent isolation on those
+	// ports is enforced separately by GenerateSidecarNftables.)
+	sidecarPortsByAgent := map[string][]int{}
+	for _, l := range cfg.SidecarListeners() {
+		for _, ak := range l.Subscribers {
+			sidecarPortsByAgent[ak] = append(sidecarPortsByAgent[ak], l.Port)
+		}
+	}
+
 	// portListFor returns the deduped, sorted "p1, p2" loopback port set for an
 	// agent: the base ports, plus agent-vault's MITM port for brokered agents
-	// (their HTTPS_PROXY points at agent-vault, not pipelock).
-	portListFor := func(ac config.AgentConfig) string {
+	// (their HTTPS_PROXY points at agent-vault, not pipelock), plus any sidecar
+	// ports the agent subscribes to.
+	portListFor := func(key string, ac config.AgentConfig) string {
 		set := map[int]struct{}{}
 		for _, p := range basePorts {
 			set[p] = struct{}{}
 		}
 		if avPort > 0 && ac.VaultBroker {
 			set[avPort] = struct{}{}
+		}
+		for _, p := range sidecarPortsByAgent[key] {
+			set[p] = struct{}{}
 		}
 		ports := make([]int, 0, len(set))
 		for p := range set {
@@ -314,7 +361,7 @@ func GenerateNftables(cfg *config.Config) (string, error) {
 		if ac.WebTerminalPort > 0 {
 			fmt.Fprintf(&b, "\t\tmeta skuid %d tcp sport %d ct state established,related accept\n", a.uid, ac.WebTerminalPort)
 		}
-		portList := portListFor(ac)
+		portList := portListFor(a.key, ac)
 		fmt.Fprintf(&b, "\t\tmeta skuid %d ip daddr 127.0.0.1 tcp dport { %s } accept\n", a.uid, portList)
 		fmt.Fprintf(&b, "\t\tmeta skuid %d ip6 daddr ::1 tcp dport { %s } accept\n", a.uid, portList)
 		fmt.Fprintf(&b, "\t\tmeta skuid %d reject with icmpx type admin-prohibited\n", a.uid)
@@ -322,4 +369,124 @@ func GenerateNftables(cfg *config.Config) (string, error) {
 	b.WriteString("\t}\n")
 	b.WriteString("}\n")
 	return b.String(), nil
+}
+
+const sidecarServiceTemplate = `[Unit]
+Description=clem MCP sidecar {{.Name}} ({{.Project}})
+After=network-online.target {{.SidecarNftService}}
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{.MCPUser}}
+# clem-mcp has no home; point HOME at a writable scratch dir so node/python
+# wrapped servers can use their cache under ProtectSystem=strict.
+Environment=HOME={{.StateDir}}
+# Upstream secret(s) loaded root-side, injected into the spawned stdio server
+# via --pass-environment. Never on the command line (argv is world-readable).
+EnvironmentFile={{.EnvFile}}
+ExecStart={{.ExecStart}}
+Restart=always
+RestartSec=2
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths={{.StateDir}}
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target
+`
+
+// GenerateSidecarService renders the systemd unit running one sidecar listener:
+// mcp-proxy exposes the wrapped stdio MCP server over loopback streamable-HTTP
+// on the listener's port, as the dedicated mcp system user. The upstream secret
+// arrives via EnvironmentFile + --pass-environment, so it is neither in any
+// agent .env nor in the process argv.
+func GenerateSidecarService(cfg *config.Config, l config.SidecarListener) string {
+	args := []string{
+		MCPProxyBin,
+		"--host", "127.0.0.1",
+		"--port", strconv.Itoa(l.Port),
+		"--stateless",
+		"--pass-environment",
+		"--",
+		l.Server.Command,
+	}
+	args = append(args, l.Server.Args...)
+	r := strings.NewReplacer(
+		"{{.Name}}", l.Server.Name,
+		"{{.Project}}", cfg.Project,
+		"{{.MCPUser}}", cfg.MCPSidecars.SystemUserOrDefault(),
+		"{{.StateDir}}", SidecarStateDir,
+		"{{.EnvFile}}", SidecarEnvFile(cfg.Project, l.Server.Name, l.AgentKey),
+		"{{.ExecStart}}", strings.Join(args, " "),
+		"{{.SidecarNftService}}", cfg.SidecarNftablesServiceName(),
+	)
+	return r.Replace(sidecarServiceTemplate)
+}
+
+// GenerateSidecarNftables renders the loopback firewall for sidecar listeners:
+// for each listener's port, only the subscribing agent UID(s) may open a
+// connection; every other UID (including other agents and root) is dropped.
+// This is the containment boundary on hosts without egress firewalling, where
+// agents would otherwise reach each other's sidecar ports freely on loopback.
+// Idempotent reload: ensure-then-delete-then-create the table.
+func GenerateSidecarNftables(cfg *config.Config) (string, error) {
+	listeners := cfg.SidecarListeners()
+	table := sidecarNftTableName(cfg.Project)
+	var b strings.Builder
+	b.WriteString("#!/usr/sbin/nft -f\n")
+	b.WriteString("# Generated by clem provision — sidecar loopback containment for " + cfg.Project + ".\n")
+	b.WriteString("# Each sidecar port is reachable only by its subscribing agent UID(s).\n")
+	fmt.Fprintf(&b, "table inet %s { }\n", table)
+	fmt.Fprintf(&b, "delete table inet %s\n", table)
+	fmt.Fprintf(&b, "table inet %s {\n", table)
+	b.WriteString("\tchain output {\n")
+	b.WriteString("\t\ttype filter hook output priority 0; policy accept;\n")
+	for _, l := range listeners {
+		uids := make([]int, 0, len(l.Subscribers))
+		for _, ak := range l.Subscribers {
+			uid, err := userUIDLookup(cfg.OSUsername(ak))
+			if err != nil {
+				return "", fmt.Errorf("resolving sidecar %s subscriber %s: %w", l.Server.Name, ak, err)
+			}
+			uids = append(uids, uid)
+		}
+		sort.Ints(uids)
+		strs := make([]string, len(uids))
+		for i, u := range uids {
+			strs[i] = strconv.Itoa(u)
+		}
+		set := strings.Join(strs, ", ")
+		fmt.Fprintf(&b, "\t\t# sidecar %s on port %d — subscribers: %s\n", l.Server.Name, l.Port, strings.Join(l.Subscribers, ", "))
+		fmt.Fprintf(&b, "\t\tip daddr 127.0.0.1 tcp dport %d meta skuid != { %s } drop\n", l.Port, set)
+		fmt.Fprintf(&b, "\t\tip6 daddr ::1 tcp dport %d meta skuid != { %s } drop\n", l.Port, set)
+	}
+	b.WriteString("\t}\n")
+	b.WriteString("}\n")
+	return b.String(), nil
+}
+
+const sidecarNftablesServiceTemplate = `[Unit]
+Description=clem sidecar loopback firewall (nftables) for {{.Project}}
+After=nftables.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/nft -f {{.NftPath}}
+
+[Install]
+WantedBy=multi-user.target
+`
+
+// GenerateSidecarNftablesService renders the oneshot unit that applies the
+// sidecar firewall ruleset (before agent + sidecar units, which order After it).
+func GenerateSidecarNftablesService(cfg *config.Config) string {
+	r := strings.NewReplacer(
+		"{{.Project}}", cfg.Project,
+		"{{.NftPath}}", SidecarNftablesPath(cfg.Project),
+	)
+	return r.Replace(sidecarNftablesServiceTemplate)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -373,6 +373,11 @@ func GenerateNftables(cfg *config.Config) (string, error) {
 
 const sidecarServiceTemplate = `[Unit]
 Description=clem MCP sidecar {{.Name}} ({{.Project}})
+# Fail-closed: the loopback firewall is the ONLY thing keeping non-subscriber
+# agents off this credential-holding port (mcp-proxy has no incoming auth), so a
+# listener must NOT start if the firewall failed to load — mirrors the egress
+# agent unit's Requires= on its nftables service.
+Requires={{.SidecarNftService}}
 After=network-online.target {{.SidecarNftService}}
 Wants=network-online.target
 
@@ -443,7 +448,10 @@ func GenerateSidecarNftables(cfg *config.Config) (string, error) {
 	fmt.Fprintf(&b, "delete table inet %s\n", table)
 	fmt.Fprintf(&b, "table inet %s {\n", table)
 	b.WriteString("\tchain output {\n")
-	b.WriteString("\t\ttype filter hook output priority 0; policy accept;\n")
+	// priority -10 evaluates before the egress table (priority 0) so the
+	// cross-UID drop is guaranteed to run first rather than relying on the
+	// undefined ordering between two base chains at the same hook+priority.
+	b.WriteString("\t\ttype filter hook output priority -10; policy accept;\n")
 	for _, l := range listeners {
 		uids := make([]int, 0, len(l.Subscribers))
 		for _, ak := range l.Subscribers {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -284,7 +284,7 @@ func TestGenerateSidecarNftables(t *testing.T) {
 	for _, want := range []string{
 		"table inet clem_sidecar_myteam {",
 		"delete table inet clem_sidecar_myteam",
-		"type filter hook output priority 0; policy accept;",
+		"type filter hook output priority -10; policy accept;",
 		// Only the two subscriber UIDs may reach port 14500; everyone else dropped.
 		"ip daddr 127.0.0.1 tcp dport 14500 meta skuid != { 1001, 1002 } drop",
 		"ip6 daddr ::1 tcp dport 14500 meta skuid != { 1001, 1002 } drop",

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -228,6 +228,126 @@ func TestGenerateNftables_BrokeredAgentAllowsAgentVaultPort(t *testing.T) {
 	}
 }
 
+// sidecarCfg builds a project with one shared sidecar (es-ro) subscribed by
+// both agents and a custom base_port.
+func sidecarCfg() *config.Config {
+	return &config.Config{
+		Project: "myteam",
+		MCPSidecars: config.MCPSidecarsConfig{
+			BasePort: 14500,
+			Servers: []config.SidecarServer{{
+				Name:         "es-ro",
+				Identity:     "shared",
+				Command:      "/usr/local/bin/es-mcp",
+				Args:         []string{"--read-only"},
+				Secrets:      []string{"ES_USER", "ES_PASSWORD"},
+				SecretsVault: "infra",
+			}},
+		},
+		Agents: map[string]config.AgentConfig{
+			"lead":   {Name: "Lead", Sidecars: []string{"es-ro"}},
+			"worker": {Name: "Worker", Sidecars: []string{"es-ro"}},
+		},
+	}
+}
+
+func TestGenerateSidecarService(t *testing.T) {
+	cfg := sidecarCfg()
+	l := cfg.SidecarListeners()[0]
+	out := GenerateSidecarService(cfg, l)
+	for _, want := range []string{
+		"Description=clem MCP sidecar es-ro (myteam)",
+		"User=clem-mcp",
+		"Environment=HOME=/var/lib/clem-mcp",
+		"EnvironmentFile=/etc/clem/clem-mcp-myteam-es-ro.env",
+		"ExecStart=/opt/pipx/bin/mcp-proxy --host 127.0.0.1 --port 14500 --stateless --pass-environment -- /usr/local/bin/es-mcp --read-only",
+		"ReadWritePaths=/var/lib/clem-mcp",
+		"After=network-online.target clem-sidecar-nft-myteam.service",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("sidecar service missing %q\n---\n%s", want, out)
+		}
+	}
+	// The secret must never appear on the command line (argv is world-readable).
+	if strings.Contains(out, "ES_PASSWORD=") {
+		t.Errorf("secret leaked into the unit:\n%s", out)
+	}
+}
+
+func TestGenerateSidecarNftables(t *testing.T) {
+	stubUIDs(t, map[string]int{"myteam-lead": 1001, "myteam-worker": 1002})
+	cfg := sidecarCfg()
+	out, err := GenerateSidecarNftables(cfg)
+	if err != nil {
+		t.Fatalf("GenerateSidecarNftables: %v", err)
+	}
+	for _, want := range []string{
+		"table inet clem_sidecar_myteam {",
+		"delete table inet clem_sidecar_myteam",
+		"type filter hook output priority 0; policy accept;",
+		// Only the two subscriber UIDs may reach port 14500; everyone else dropped.
+		"ip daddr 127.0.0.1 tcp dport 14500 meta skuid != { 1001, 1002 } drop",
+		"ip6 daddr ::1 tcp dport 14500 meta skuid != { 1001, 1002 } drop",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("sidecar nftables missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerateSidecarNftables_PerAgentDistinctPortsAndUIDs(t *testing.T) {
+	stubUIDs(t, map[string]int{"myteam-lead": 1001, "myteam-worker": 1002})
+	cfg := sidecarCfg()
+	cfg.MCPSidecars.Servers[0].Identity = "per-agent"
+	out, err := GenerateSidecarNftables(cfg)
+	if err != nil {
+		t.Fatalf("GenerateSidecarNftables: %v", err)
+	}
+	// per-agent → one listener per subscriber on successive ports, each locked to
+	// that single subscriber's UID. Sorted subscribers: lead(14500), worker(14501).
+	for _, want := range []string{
+		"tcp dport 14500 meta skuid != { 1001 } drop",
+		"tcp dport 14501 meta skuid != { 1002 } drop",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("per-agent sidecar nftables missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerateSidecarNftablesService(t *testing.T) {
+	cfg := sidecarCfg()
+	out := GenerateSidecarNftablesService(cfg)
+	for _, want := range []string{
+		"Type=oneshot",
+		"ExecStart=/usr/sbin/nft -f /etc/clem/clem-sidecar-myteam.nft",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("sidecar nft service missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// A contained agent that subscribes to a sidecar must be allowed (by the egress
+// firewall) to reach the sidecar's loopback port, or egress's per-UID reject
+// would block it before the sidecar firewall even applies.
+func TestGenerateNftables_AllowsSidecarPortForContainedSubscriber(t *testing.T) {
+	stubUIDs(t, map[string]int{"clem-proxy": 900, "myteam-lead": 1001})
+	cfg := sidecarCfg()
+	cfg.Egress = config.EgressConfig{Enabled: true, Posture: "strict", ProxyPort: 8888}
+	cfg.Agents = map[string]config.AgentConfig{
+		"lead": {Name: "Lead", Sidecars: []string{"es-ro"}},
+	}
+	out, err := GenerateNftables(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNftables: %v", err)
+	}
+	want := "meta skuid 1001 ip daddr 127.0.0.1 tcp dport { 8888, 14500 } accept"
+	if !strings.Contains(out, want) {
+		t.Errorf("contained subscriber should be allowed to its sidecar port\nwant %q\n---\n%s", want, out)
+	}
+}
+
 func TestPortOf(t *testing.T) {
 	cases := []struct{ in, def, want string }{
 		{"http://127.0.0.1:14321", "x", "14321"},

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -109,6 +109,11 @@ if os.environ.get('TYPEFULLY_API_KEY'):
         'command': _mcp_bin('social-mcp'),
         'env': {'TYPEFULLY_API_KEY': os.environ['TYPEFULLY_API_KEY']}
     }
+# Privileged MCP sidecars: reached over loopback streamable-HTTP (never stdio),
+# so the upstream secret stays in the separate-UID mcp-proxy process, never here.
+# A kernel nftables rule restricts each port to this agent's UID.
+for _name, _port in {{.SidecarServers}}:
+    cfg['mcpServers'][_name] = {'type': 'http', 'url': 'http://127.0.0.1:%d/mcp' % _port}
 print(json.dumps(cfg, indent=2))
 " > "$WORKDIR/.mcp.json"
 
@@ -376,6 +381,9 @@ type RunnerParams struct {
 	// MCP server's gateway watcher should observe. Empty disables the watcher
 	// even when DISCORD_TOKEN is set, preserving the original tool-only mode.
 	WatchChannelIDs   string
+	// SidecarServers is a Python/JSON list literal of [toolName, port] pairs for
+	// the privileged MCP sidecars this agent subscribes to. "[]" when none.
+	SidecarServers string
 }
 
 // Generate renders the runner.sh content for an agent. Dispatches on the
@@ -431,6 +439,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 		AlertCurl:       alertCurl,
 		WatchChannelIDs: discordWatchChannels(cfg),
 		ProxyExport:     proxyExportBlock(cfg, agentKey),
+		SidecarServers:  sidecarServersLiteral(cfg, agentKey),
 	}
 	switch ac.RuntimeKind() {
 	case "opencode":
@@ -586,8 +595,25 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.WatchChannelIDs}}", p.WatchChannelIDs,
 		"{{.ProxyExport}}", p.ProxyExport,
 		"{{.ProxyUnitDeps}}", p.ProxyUnitDeps,
+		"{{.SidecarServers}}", p.SidecarServers,
 	)
 	return r.Replace(tmpl)
+}
+
+// sidecarServersLiteral renders the Python list literal of [toolName, port]
+// pairs for the sidecars this agent subscribes to — consumed by the .mcp.json
+// generator in the runner template. "[]" when the agent subscribes to none.
+func sidecarServersLiteral(cfg *config.Config, agentKey string) string {
+	var parts []string
+	for _, l := range cfg.SidecarListeners() {
+		for _, ak := range l.Subscribers {
+			if ak == agentKey {
+				parts = append(parts, fmt.Sprintf("[%q, %d]", l.Server.ToolName(), l.Port))
+				break
+			}
+		}
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }
 
 // discordWatchChannels returns a deterministic comma-separated list of

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -565,3 +565,53 @@ func TestGenerateService_MissingUserFails(t *testing.T) {
 		t.Fatal("expected error for missing user, got nil")
 	}
 }
+
+func sidecarRunnerCfg() *config.Config {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-opus-4-8", Iteration: "1m", Prompt: "go",
+		Sidecars: []string{"es-ro"},
+	})
+	cfg.Agents["solo"] = config.AgentConfig{ // subscribes to nothing
+		Name: "Solo", Model: "claude-opus-4-8", Iteration: "1m", Prompt: "go",
+	}
+	cfg.MCPSidecars = config.MCPSidecarsConfig{
+		BasePort: 14500,
+		Servers: []config.SidecarServer{{
+			Name: "es-ro", Identity: "shared", Command: "/bin/x",
+			Secrets: []string{"K"}, SecretsVault: "infra",
+		}},
+	}
+	return cfg
+}
+
+func TestGenerate_SidecarHTTPEntryForSubscriber(t *testing.T) {
+	cfg := sidecarRunnerCfg()
+	out := Generate(cfg, "lead")
+	for _, want := range []string{
+		`for _name, _port in [["es-ro", 14500]]:`,
+		`'type': 'http'`,
+		`'url': 'http://127.0.0.1:%d/mcp' % _port`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("subscriber runner missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerate_NoSidecarEntryForNonSubscriber(t *testing.T) {
+	cfg := sidecarRunnerCfg()
+	out := Generate(cfg, "solo")
+	if !strings.Contains(out, `for _name, _port in []:`) {
+		t.Errorf("non-subscriber should get an empty sidecar list\n---\n%s", out)
+	}
+}
+
+func TestSidecarServersLiteral(t *testing.T) {
+	cfg := sidecarRunnerCfg()
+	if got := sidecarServersLiteral(cfg, "lead"); got != `[["es-ro", 14500]]` {
+		t.Errorf("subscriber literal = %q", got)
+	}
+	if got := sidecarServersLiteral(cfg, "solo"); got != `[]` {
+		t.Errorf("non-subscriber literal = %q", got)
+	}
+}


### PR DESCRIPTION
## Privileged MCP sidecars

Some credentials can't be HTTP-brokered (non-HTTP protocols, or a scoped/read-only gateway you don't want the agent to hold). For those, clem runs the underlying **stdio MCP server behind `mcp-proxy` as a dedicated non-login user (`clem-mcp`)**, exposing it over loopback streamable-HTTP. The agent speaks HTTP and **never sees the secret**, which lives only in the sidecar process.

This completes the four-disposition secret model: **broker** (agent's own HTTP calls) → **sidecar** (what broker can't reach) → **egress firewall** → **remove**. Broker stays preferred whenever the credential is HTTP and the agent uses the full API; sidecar is for what broker can't reach.

### How it works
- `mcp-proxy --host 127.0.0.1 --port <P> --stateless --pass-environment -- <stdio cmd>` runs as `clem-mcp`; the upstream secret is supplied root-side via a 0600 `EnvironmentFile` + `--pass-environment` (never in argv, never in any agent `.env`).
- The agent's `.mcp.json` gets `{"type":"http","url":"http://127.0.0.1:<P>/mcp"}` — nothing else.
- **The isolation boundary is the kernel**: `mcp-proxy` has no incoming auth, so a per-sidecar nftables rule (`clem_sidecar_<project>` table) allows only each listener's subscribing agent UID(s) to reach its loopback port; every other UID is dropped. Fail-closed: a listener `Requires=` the firewall unit and won't start if it failed to load.

### Empirically verified on the target host
- `mcp-proxy` 0.12.0 (pipx) serves the wrapped stdio server's streamable-HTTP at **`/mcp`** (`initialize` → HTTP 200); `--stateless` needs no session id.
- nftables loopback `meta skuid` match gates a port by connecting UID — allowed UID reaches it, every other UID is dropped; generated ruleset parses (`nft -c -f`).
- Claude Code `.mcp.json` supports `{type:"http", url}` for a loopback server (SSE deprecated).

### Layers
- **config**: `SidecarListeners()` (single source of truth for deterministic port allocation), service-name helpers, validation (absolute command, tool name vs builtins, env-var secret keys, port overflow/collision incl. egress + agent-vault ports, shared-requires-`secrets_vault`, reject opencode+sidecars).
- **proxy**: `GenerateSidecarService`, `GenerateSidecarNftables` (priority -10), `GenerateSidecarNftablesService`; egress firewall now allows a contained subscriber to reach its sidecar port.
- **agent**: `InstallMCPProxy` (pinned 0.12.0, pipx-global), `WriteSystemdEnvFile`, `RestartService`.
- **provision**: `provisionMCPSidecars` — pre-flight secret resolution, then units → firewall → listeners (restart-based, idempotent). No-op unless an agent subscribes — inert for the live fleet until configured.
- **runner**: emits the http MCP entry per subscription.

### Review
Two independent adversarial reviews (security boundary; Go/provision correctness) converged on two HIGH fixes — fail-closed `Requires=` and the partial-failure/re-provision window — both addressed in `704cc2f`, plus idempotent `restart`, distinct nft priority, and validation hardening. The reviewer's CRITICAL "wrong endpoint" claim was empirically refuted (Python `mcp-proxy` 0.12.0 does serve `/mcp`).

### Out of scope / follow-ups
- Live agent↔sidecar end-to-end (operator step on a real fleet).
- Discord stays stdio-default (a per-agent Discord sidecar would break the tmux gateway watcher).
- `mcp-proxy` supply-chain hardening beyond the version pin — matches the existing pipelock/agent-vault TOFU caveat.
- Threat-model doc update (lives on the docs PR).

All tests pass under `-race`; `go vet` clean.
