### PR TITLE
fix(vault): brokered git must trust the agent-vault CA for the proxy connection

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -298,6 +298,14 @@ func BrokeredEnv(av config.VaultBackend, ac config.AgentConfig, token, vaultName
 	env["REQUESTS_CA_BUNDLE"] = ca
 	env["CURL_CA_BUNDLE"] = ca
 	env["GIT_SSL_CAINFO"] = ca
+	// HTTPS_PROXY is an HTTPS (TLS) proxy, so git tunnels to it over TLS and must
+	// trust the agent-vault CA for the PROXY connection too — not just the
+	// upstream (GIT_SSL_CAINFO). git has no env var for http.proxySSLCAInfo, so
+	// inject it via GIT_CONFIG_*. Without this, EVERY git operation through the
+	// broker (push/pull/clone to any host) fails proxy certificate verification.
+	env["GIT_CONFIG_COUNT"] = "1"
+	env["GIT_CONFIG_KEY_0"] = "http.proxySSLCAInfo"
+	env["GIT_CONFIG_VALUE_0"] = ca
 	return env
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1320,6 +1320,13 @@ func TestBrokeredEnv_PlaceholdersAndConnection(t *testing.T) {
 	if env["NODE_EXTRA_CA_CERTS"] != "/etc/clem/agent-vault-ca.pem" {
 		t.Errorf("NODE_EXTRA_CA_CERTS=%q", env["NODE_EXTRA_CA_CERTS"])
 	}
+	// git tunnels through the TLS proxy, so it must trust the agent-vault CA for
+	// the proxy connection too (http.proxySSLCAInfo) — else every git op fails.
+	if env["GIT_CONFIG_COUNT"] != "1" || env["GIT_CONFIG_KEY_0"] != "http.proxySSLCAInfo" ||
+		env["GIT_CONFIG_VALUE_0"] != "/etc/clem/agent-vault-ca.pem" {
+		t.Errorf("git proxy CA config missing/wrong: COUNT=%q KEY_0=%q VALUE_0=%q",
+			env["GIT_CONFIG_COUNT"], env["GIT_CONFIG_KEY_0"], env["GIT_CONFIG_VALUE_0"])
+	}
 }
 
 func TestInstallAgentVault_PinnedDownload(t *testing.T) {


### PR DESCRIPTION
**Critical brokering fix, found live on cdev.** A brokered agent's `HTTPS_PROXY` is an *HTTPS* (TLS) proxy, so `git` tunnels to it over TLS and must trust the agent-vault CA for the **proxy** hop — not just the upstream (`GIT_SSL_CAINFO`). git has no env var for `http.proxySSLCAInfo`, so we inject it via `GIT_CONFIG_*`.

**Without this, *every* git operation (push/pull/clone, to any host) through the broker fails** with `server certificate verification failed` — which makes brokering unusable for coding agents (they push constantly).

- Verified live: brokering broke all agent git; with this fix a private-repo `git ls-remote` through the broker succeeds (returns refs).
- Unblocks `GH_TOKEN` brokering, which was deferred specifically on this.
- Adds a `BrokeredEnv` test asserting the proxy-CA git config.

Deployed to cdev as a branch build to restore the fleet; merging + releasing so `clem update` doesn't regress it.