### PR TITLE
fix(down): stop watchdog timer so downed agents stay down

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -22,6 +22,19 @@ func runDown(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Stop the watchdog before the agents: the timer fires every 5 minutes and
+	// would otherwise restart every service stopped below. Stopping the timer
+	// only suppresses future activations, so also stop the oneshot service in
+	// case a watchdog run is mid-flight right now.
+	for _, wd := range []string{cfg.WatchdogTimerName(), cfg.WatchdogServiceName()} {
+		fmt.Printf("stopping %s... ", wd)
+		if err := agent.StopService(wd); err != nil {
+			fmt.Println("FAILED")
+			return err
+		}
+		fmt.Println("ok")
+	}
+
 	for agentKey, ac := range cfg.Agents {
 		if ac.WebTerminalPort > 0 {
 			ttydSvc := cfg.TtydServiceName(agentKey)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,6 +22,19 @@ func runUp(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Re-arm the watchdog timer on the way out even if an agent fails to
+	// start (clem down stops it to keep agents down): a partially started
+	// fleet should still get watchdog recovery rather than no protection.
+	defer func() {
+		timerName := cfg.WatchdogTimerName()
+		fmt.Printf("starting %s... ", timerName)
+		if err := agent.StartService(timerName); err != nil {
+			fmt.Printf("FAILED: %v\n", err)
+			return
+		}
+		fmt.Println("ok")
+	}()
+
 	for agentKey, ac := range cfg.Agents {
 		svcName := cfg.ServiceName(agentKey)
 		fmt.Printf("starting %s (%s)... ", ac.Name, svcName)


### PR DESCRIPTION
Closes #151.

`clem down` stopped agent services but left `clem-watchdog-<project>.timer` active; the watchdog fires every 5 minutes (`OnUnitActiveSec=5min`), finds the agents inactive, and restarts them — agents come back up within 5 minutes of an intentional shutdown.

**Changes**
- `clem down`: stops the watchdog timer **and** the oneshot `clem-watchdog-<project>.service` before stopping agents. Stopping only the timer suppresses future activations but not an in-flight run, which would still `systemctl restart` the agents being downed.
- `clem up`: re-arms the timer via `defer`, so a partial agent-start failure (agent 2 of 3 fails) still restores watchdog recovery for the agents that did start, instead of leaving them unprotected.

**Adversarial review (pre-PR)**: independent skeptic pass found two real gaps in my first cut — (1) in-flight oneshot watchdog run could still restart agents after the timer was stopped; (2) placing the timer start after the `up` loop meant a partial start failure left the fleet with no watchdog at all, worse than before the fix. Both addressed as described above. Missing-unit edge (down before provision) verified safe: `systemctl stop` is idempotent on not-loaded units, same regime the existing agent stops already rely on.

No new config, no new dependencies. `go build ./...`, `go vet`, full test suite green.