### PR TITLE
fix(init): use mcp__discord-bot__ tool prefix in CLAUDE.shared.md template

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -72,10 +72,10 @@ const claudeSharedTemplate = `# CLAUDE.local.md — runtime contract for all {{p
 The Discord server must be private. Only invite people you trust.
 
 Use these MCP tools directly — never use curl or bash to call Discord:
-  mcp__discord__send_message
-  mcp__discord__read_messages
-  mcp__discord__create_forum_post
-  mcp__discord__edit_thread
+  mcp__discord-bot__send_message
+  mcp__discord-bot__read_messages
+  mcp__discord-bot__create_forum_post
+  mcp__discord-bot__edit_thread
 
 Do NOT run ` + "`claude mcp list`" + ` — it only shows marketplace servers, not local ones.
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 )
 
-func TestInitTemplateContainsRunnerExitProtocol(t *testing.T) {
+// generateSharedMD runs clem init in a temp dir and returns the generated
+// CLAUDE.shared.md content. The working directory is restored when the
+// test finishes.
+func generateSharedMD(t *testing.T) string {
+	t.Helper()
+
 	tmp := t.TempDir()
 
 	prev, err := os.Getwd()
@@ -16,7 +21,7 @@ func TestInitTemplateContainsRunnerExitProtocol(t *testing.T) {
 	if err := os.Chdir(tmp); err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.Chdir(prev) }()
+	t.Cleanup(func() { _ = os.Chdir(prev) })
 
 	if err := runInit(nil, nil); err != nil {
 		t.Fatalf("runInit failed: %v", err)
@@ -26,7 +31,11 @@ func TestInitTemplateContainsRunnerExitProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading CLAUDE.shared.md: %v", err)
 	}
-	content := string(data)
+	return string(data)
+}
+
+func TestInitTemplateContainsRunnerExitProtocol(t *testing.T) {
+	content := generateSharedMD(t)
 
 	checks := []string{
 		"kill $PPID",
@@ -37,5 +46,27 @@ func TestInitTemplateContainsRunnerExitProtocol(t *testing.T) {
 		if !strings.Contains(content, want) {
 			t.Errorf("CLAUDE.shared.md missing %q", want)
 		}
+	}
+}
+
+func TestInitTemplateUsesDiscordBotToolPrefix(t *testing.T) {
+	content := generateSharedMD(t)
+
+	// The runner registers the Discord MCP server under the key
+	// "discord-bot", so Claude Code exposes its tools as
+	// mcp__discord-bot__<tool>. The bare mcp__discord__ prefix matches
+	// no server and the tool calls silently fail.
+	for _, want := range []string{
+		"mcp__discord-bot__send_message",
+		"mcp__discord-bot__read_messages",
+		"mcp__discord-bot__create_forum_post",
+		"mcp__discord-bot__edit_thread",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("CLAUDE.shared.md missing %q", want)
+		}
+	}
+	if strings.Contains(content, "mcp__discord__") {
+		t.Error("CLAUDE.shared.md still references the nonexistent mcp__discord__ tool prefix")
 	}
 }


### PR DESCRIPTION
Closes #160.

`clem init` generated `CLAUDE.shared.md` listing Discord MCP tools under the prefix `mcp__discord__`, but the runner registers the Discord MCP server under the key `discord-bot` (`internal/runner/runner.go:75` for the Claude runner, `:224` for opencode, canonical in `internal/coordination/coordination.go:33`). Claude Code derives tool names as `mcp__<server-key>__<tool>`, so the generated names matched no server and agents scaffolded by `clem init` silently failed every Discord tool call. The bundled samples already use the correct `mcp__discord-bot__` prefix; the init template was the lone outlier.

## Changes

- `cmd/init.go`: rename the four tool references in `claudeSharedTemplate` to `mcp__discord-bot__<tool>`.
- `cmd/init_test.go`: regression test asserting the generated file uses the `discord-bot` prefix and contains no bare `mcp__discord__` reference (the negative check cannot false-positive on the new names: after `mcp__discord` they diverge at `-` vs `_`). Extracted the shared chdir+`runInit`+read scaffolding into a `generateSharedMD` test helper used by both template tests.

## Verification

`go build ./...`, `go vet ./cmd/`, `go test ./cmd/` all pass.

Adversarial review ran before this PR (independent refute-style pass plus a 7-angle review): no correctness findings survived. It confirmed `discord-bot` is the server key in every generator path and that no other file references the old prefix. It did flag a deeper issue out of scope here: `claudeSharedTemplate` hardcodes a Discord-specific tool list even though `coordination.backend` is configurable (slack-backend scaffolds get misleading instructions). Filing that as a separate issue.