### PR TITLE
fix(runner): resolve coordination backend via Known() in discordWatchChannels

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -622,7 +622,13 @@ func sidecarServersLiteral(cfg *config.Config, agentKey string) string {
 // Go map-iteration orderings, which keeps generated runner.sh diffs
 // minimal between provisions.
 func discordWatchChannels(cfg *config.Config) string {
-	if cfg == nil || cfg.Coordination.Backend != "discord" {
+	if cfg == nil {
+		return ""
+	}
+	// Compare the resolved backend name, not the raw field: an omitted
+	// backend value defaults to discord (#153).
+	backend, _ := coordination.Known(cfg.Coordination.Backend) // validated at load time
+	if backend.Name != "discord" {
 		return ""
 	}
 	names := make([]string, 0, len(cfg.Coordination.Channels))

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -419,6 +419,25 @@ func TestGenerate_DiscordWatchSkippedForNonDiscordBackend(t *testing.T) {
 	}
 }
 
+func TestGenerate_DiscordWatchWiredWhenBackendOmitted(t *testing.T) {
+	// An empty backend field resolves to discord via coordination.Known, so
+	// the watcher must be wired exactly as if "discord" were written out.
+	cfg := baseCfg("worker", config.AgentConfig{
+		Name:      "Worker",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	cfg.Coordination.Backend = ""
+
+	out := Generate(cfg, "worker")
+
+	wantList := "111,333,222"
+	if !strings.Contains(out, wantList) {
+		t.Fatalf("expected channel list %q when backend omitted, got:\n%s", wantList, out)
+	}
+}
+
 func TestGenerateService_PullsTtydUp(t *testing.T) {
 	mockHome(t, "/home/test-worker")
 	cfg := baseCfg("worker", config.AgentConfig{


### PR DESCRIPTION
Closes #153.

An omitted `coordination.backend` field loads as an empty string, which `coordination.Known()` resolves to the discord backend — but `discordWatchChannels` compared the raw field against `"discord"`, so every config relying on the implicit default got an empty `DISCORD_WATCH_CHANNELS` and a silently disabled gateway watcher.

## Change
- `discordWatchChannels` now resolves the backend through `coordination.Known()` and compares the resolved name, matching the existing idiom at the alert-template call site in `Generate` and in the watchdog. Behavior for `slack`, unknown, and explicit `discord` backends is unchanged; only the omitted-field case now wires the watcher (the intended default).
- Regression test `TestGenerate_DiscordWatchWiredWhenBackendOmitted` — verified it fails on the previous code.

## Adversarial review
Ran multi-angle review (line-by-line, removed-behavior truth table, cross-file consumer trace, plus refute-prompted skeptic) before opening. It confirmed the truth table (only the `""` case changes) and caught a house-style divergence (redundant `err` check vs the `backend, _ :=` load-time-validated idiom), fixed before this PR. One pre-existing note: enabling the watcher for default-backend configs means their channel-ID values now reach the generated runner's `_watch` Python literal — the unvalidated-channel-ID surface tracked in #123. That validation belongs in `config.Load()` per #123, not here; this PR does not widen the injection class, only the set of configs reaching the existing path.