### PR TITLE
fix(cmd): honour [agent...] args in clem login

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
+	"strings"
 
 	"github.com/jahwag/clem/internal/agent"
+	"github.com/jahwag/clem/internal/config"
 	"github.com/jahwag/clem/internal/remote"
 	"github.com/spf13/cobra"
 )
@@ -25,10 +28,26 @@ func init() {
 
 func runLogin(cmd *cobra.Command, args []string) error {
 	if loginRemote != "" {
+		if len(args) > 0 {
+			return fmt.Errorf("agent args are not supported with --remote; run clem login %s on the remote host instead", strings.Join(args, " "))
+		}
 		return remote.Login(loginRemote)
 	}
 
-	for agentKey, ac := range cfg.Agents {
+	agents, err := selectAgents(cfg.Agents, args)
+	if err != nil {
+		return err
+	}
+
+	// Sort agent keys for consistent output (matches clem status).
+	keys := make([]string, 0, len(agents))
+	for key := range agents {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, agentKey := range keys {
+		ac := agents[agentKey]
 		osUser := cfg.OSUsername(agentKey)
 		fmt.Printf("[%s] %s (%s)\n", agentKey, ac.Name, osUser)
 
@@ -49,4 +68,21 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+// selectAgents narrows the configured agents to the keys given on the
+// command line. No keys means all agents.
+func selectAgents(all map[string]config.AgentConfig, keys []string) (map[string]config.AgentConfig, error) {
+	if len(keys) == 0 {
+		return all, nil
+	}
+	selected := make(map[string]config.AgentConfig, len(keys))
+	for _, key := range keys {
+		ac, ok := all[key]
+		if !ok {
+			return nil, fmt.Errorf("unknown agent: %s", key)
+		}
+		selected[key] = ac
+	}
+	return selected, nil
 }

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jahwag/clem/internal/config"
+)
+
+// selectAgents honours the [agent...] positional args of clem login:
+// no args targets every agent, named args target only those agents,
+// and an unknown key fails instead of silently logging in everyone.
+func TestSelectAgents(t *testing.T) {
+	all := map[string]config.AgentConfig{
+		"lead":   {Name: "Lead"},
+		"worker": {Name: "Worker"},
+	}
+
+	t.Run("no-args-returns-all", func(t *testing.T) {
+		got, err := selectAgents(all, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != len(all) {
+			t.Errorf("got %d agents, want %d", len(got), len(all))
+		}
+	})
+
+	t.Run("single-key-filters", func(t *testing.T) {
+		got, err := selectAgents(all, []string{"lead"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d agents, want 1", len(got))
+		}
+		if _, ok := got["lead"]; !ok {
+			t.Errorf("selected set missing %q: %v", "lead", got)
+		}
+	})
+
+	t.Run("multiple-keys-filter", func(t *testing.T) {
+		got, err := selectAgents(all, []string{"lead", "worker"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("got %d agents, want 2", len(got))
+		}
+	})
+
+	t.Run("unknown-key-errors", func(t *testing.T) {
+		_, err := selectAgents(all, []string{"lead", "nosuch"})
+		if err == nil {
+			t.Fatal("expected error for unknown agent key, got nil")
+		}
+		if !strings.Contains(err.Error(), "nosuch") {
+			t.Errorf("error %q does not name the unknown key", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #152.

`clem login` advertised `[agent...]` positional args in its Use string but `runLogin` never read them — every invocation looped all configured agents, so selective login was silently ignored.

## Changes
- New `selectAgents` helper filters `cfg.Agents` to the keys given on the command line; unknown keys return `unknown agent: <key>` (same convention as `clem logs`). No args keeps current behaviour (all agents).
- Agents are now iterated in sorted key order for deterministic interactive prompts, matching the sorted-output convention in `clem status`.
- Combining agent args with `--remote` now errors instead of silently dropping the selection: `remote.Login` only takes a host and cannot forward agent filtering, so an honest error beats logging in every remote agent against the operator's intent.

## Testing
- `go build ./...`, `go vet ./cmd/`, `go test ./cmd/` green.
- New `TestSelectAgents` covers no-args (all), single key, multiple keys, and unknown-key error.

Adversarial review ran before this PR (multi-angle finders + verifiers). It caught two confirmed issues that are fixed in this diff: the `--remote` + agent-args silent ignore, and nondeterministic map-iteration order for login prompts.