### PR TITLE
fix(config): reject whitespace and control characters in git_email at Load()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,15 @@ var serviceNameRe = regexp.MustCompile(`^[a-z0-9-]{3,64}$`)
 // avNameInvalid matches characters not allowed in an agent-vault vault name.
 var avNameInvalid = regexp.MustCompile(`[^a-z0-9-]+`)
 
+// gitEmailInvalid matches ASCII whitespace and control characters — the
+// characters that corrupt the line-delimited files git_email is written
+// into: ~/.ssh/allowed_signers uses a space-delimited principal field (a
+// space or newline injects a second principal mapped to the agent's signing
+// key), and ~/.gitconfig is newline-delimited. Unicode separators (U+2028,
+// NEL, NBSP) pass, but neither git config nor OpenSSH's allowed_signers
+// parser treats them as line or field breaks.
+var gitEmailInvalid = regexp.MustCompile(`[\s\x00-\x1f\x7f]`)
+
 // AgentVaultName maps a clem/sops vault name to an agent-vault-compatible vault
 // name: lowercased, with any run of characters outside [a-z0-9-] collapsed to a
 // single hyphen. sops vault names may contain '_' (e.g. dev_to) or uppercase,
@@ -972,6 +981,9 @@ func Load(path string) (*Config, error) {
 		}
 		if _, err := ac.ProviderEnv(); err != nil {
 			return nil, fmt.Errorf("agent %s: %w", key, err)
+		}
+		if ac.GitEmail != "" && gitEmailInvalid.MatchString(ac.GitEmail) {
+			return nil, fmt.Errorf("agent %s: git_email must not contain whitespace or control characters, got %q", key, ac.GitEmail)
 		}
 		if ac.WebTerminalPort != 0 {
 			if ac.WebTerminalPort < 1024 || ac.WebTerminalPort > 65535 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -402,6 +403,41 @@ func TestLoad_GitIdentityOptional(t *testing.T) {
 	ac := cfg.Agents["lead"]
 	if ac.GitName != "" || ac.GitEmail != "" {
 		t.Errorf("expected empty git identity when unset, got name=%q email=%q", ac.GitName, ac.GitEmail)
+	}
+}
+
+func TestLoad_GitEmailRejectsUnsafeCharacters(t *testing.T) {
+	cases := map[string]string{
+		"newline":         "ada@example.com\nevil@attacker.com",
+		"carriage return": "ada@example.com\revil@attacker.com",
+		"space":           "ada @example.com",
+		"tab":             "ada\t@example.com",
+		"control char":    "ada@example.com\x01",
+	}
+	for name, email := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Ada"
+    model: "claude-sonnet-4-6"
+    git_email: `+fmt.Sprintf("%q", email)+`
+`)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load accepted git_email %q, want error", email)
+			}
+			if !strings.Contains(err.Error(), "git_email") {
+				t.Errorf("error should name git_email, got: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #154.

## Problem

`git_email` from clem.yaml is written verbatim into two line-delimited files during provision (`ConfigureGit`, `internal/agent/manager.go`):

- `~/.ssh/allowed_signers` — space-delimited principal field. A newline in the value pushes the agent's pubkey onto a second line with an attacker-chosen principal; `ssh-keygen -Y verify` then validates commits authored as that principal against the agent's real signing key (reproduced during review: `ssh-keygen -Y verify -I evil@attacker.com` exits 0 against the injected file). A space corrupts the principal field and silently breaks verification.
- `~/.gitconfig` — newline-delimited `email = ` value.

## Fix

Validate at `Load()` time, consistent with the other per-agent field checks: reject any `git_email` containing ASCII whitespace or control characters, with an error naming the agent. `Load()` runs via `PersistentPreRunE` before every provision path, including remote provisioning (which SSHes `clem provision` → same binary → same gate). The empty-value default (`username@clem` fallback) is unaffected; `username` is already `validName`-constrained.

## Notes

- `git_name` has the analogous `.gitconfig` sink and remains unvalidated — that is #120's scope and is intentionally not touched here. A shared line-safety validator across the open injection issues (#120, #124, #125, #165) may be the right end state; flagged for #120.
- Adversarial review ran before this PR: skeptic agents reproduced the underlying attack, traced all `GitEmail` consumers for bypass paths (none — single `yaml.Unmarshal` entry point), and probed unicode-whitespace bypasses (U+2028/NEL/NBSP pass the ASCII-only `\s` class but are empirically not line/field separators for git config or OpenSSH's allowed_signers parser, so not exploitable). Review caught an imprecise code comment claiming blanket whitespace coverage; fixed to state ASCII scope explicitly.

## Testing

- New `TestLoad_GitEmailRejectsUnsafeCharacters` table test: newline, CR, space, tab, control char all rejected with errors naming `git_email`.
- Existing `TestLoad_GitIdentityParsed` confirms a real GitHub noreply address still loads.
- `go build ./...`, `go vet ./internal/config/`, full `go test ./...` green.