### PR TITLE
fix(config): validate resource_limits string fields at Load()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -648,8 +648,9 @@ type AgentConfig struct {
 // ResourceLimits maps directly to systemd cgroup directives. All fields
 // optional; empty values are omitted from the rendered service unit.
 //
-// Field strings are written verbatim into the [Service] section; validation
-// is delegated to systemd. Standard formats:
+// String fields are checked against resourceLimitValue at Load() time so a
+// value cannot break out of its directive line in the generated [Service]
+// section; semantic validation is delegated to systemd. Standard formats:
 //   - CPUQuota:   "150%" (1.5 cores), "50%" (half a core), "200ms/1s"
 //   - MemoryHigh: "8G", "512M" (soft throttle — process slowed but not killed)
 //   - MemoryMax:  "10G" (hard kill — fires before global OOM-killer)
@@ -661,6 +662,34 @@ type ResourceLimits struct {
 	MemoryMax  string `yaml:"memory_max"`
 	CPUWeight  int    `yaml:"cpu_weight"`
 	IOWeight   int    `yaml:"io_weight"`
+}
+
+// resourceLimitValue permits the documented value formats for CPUQuota,
+// MemoryHigh, and MemoryMax ("150%", "200ms/1s", "8G", "infinity") while
+// excluding newlines and every other character that would let a value span
+// directive lines in the rendered unit. Directives() concatenates these
+// strings into a newline-delimited [Service] section, so an embedded newline
+// would inject arbitrary directives (e.g. a second ExecStart=).
+var resourceLimitValue = regexp.MustCompile(`^[0-9A-Za-z%./]*$`)
+
+// validate rejects string field values that could escape their directive
+// line in the systemd unit rendered by Directives(). key names the agent
+// in error messages.
+func (r ResourceLimits) validate(key string) error {
+	fields := []struct {
+		name string
+		val  string
+	}{
+		{"cpu_quota", r.CPUQuota},
+		{"memory_high", r.MemoryHigh},
+		{"memory_max", r.MemoryMax},
+	}
+	for _, f := range fields {
+		if !resourceLimitValue.MatchString(f.val) {
+			return fmt.Errorf("agent %s: resource_limits.%s %q must match %s", key, f.name, f.val, resourceLimitValue.String())
+		}
+	}
+	return nil
 }
 
 // Directives renders the resource-limit block for injection into a systemd
@@ -1013,6 +1042,9 @@ func Load(path string) (*Config, error) {
 			// span multiple sops vaults — no first-vault constraint.
 		}
 		ac.normalizeSubagentModel()
+		if err := ac.ResourceLimits.validate(key); err != nil {
+			return nil, err
+		}
 		if err := ac.validateExtensions(key); err != nil {
 			return nil, err
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1560,5 +1561,69 @@ func TestSidecarPort_Deterministic(t *testing.T) {
 	}
 	if (MCPSidecarsConfig{}).SidecarPort(0) != 14500 {
 		t.Errorf("default base wrong: %d", (MCPSidecarsConfig{}).SidecarPort(0))
+	}
+}
+
+func TestLoad_ResourceLimitsValidValues(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    resource_limits:
+      cpu_quota: "150%"
+      memory_high: "512M"
+      memory_max: "8G"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	rl := cfg.Agents["lead"].ResourceLimits
+	if rl.CPUQuota != "150%" || rl.MemoryHigh != "512M" || rl.MemoryMax != "8G" {
+		t.Errorf("resource_limits not parsed: %+v", rl)
+	}
+}
+
+func TestLoad_ResourceLimitsRejectsUnsafeValues(t *testing.T) {
+	cases := []struct {
+		desc  string
+		field string
+		value string
+	}{
+		{"newline injects directive", "cpu_quota", `"150%\nExecStart=/bin/false"`},
+		{"carriage return", "memory_high", `"8G\rMemoryMax=1"`},
+		{"space", "memory_max", `"8G extra"`},
+		{"tab", "cpu_quota", `"150%\tx"`},
+		{"equals sign", "memory_max", `"8G=x"`},
+		{"unicode line separator", "memory_high", `"8G\u20288M"`},
+	}
+	for _, tc := range cases {
+		path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    resource_limits:
+      `+tc.field+`: `+tc.value+"\n")
+		if _, err := Load(path); err == nil {
+			t.Errorf("%s: Load accepted %s=%s, want error", tc.desc, tc.field, tc.value)
+		} else if !strings.Contains(err.Error(), "resource_limits."+tc.field) {
+			t.Errorf("%s: error %q does not name resource_limits.%s", tc.desc, err, tc.field)
+		}
 	}
 }


### PR DESCRIPTION
Closes #165.

## Problem

`ResourceLimits.Directives()` concatenates `cpu_quota`, `memory_high`, and `memory_max` verbatim into the agent service's systemd `[Service]` section. systemd splits the section on newlines and treats each line as a directive, so a YAML double-quoted value containing `\n` injects arbitrary directives — including a second `ExecStart=` that runs at service start. `Load()` validated other per-agent fields but had no `resource_limits` check.

## Fix

Allowlist validation at `Load()` time, alongside the existing per-agent checks: each string field must match `^[0-9A-Za-z%./]*$`. This covers every documented format for these directives (`150%`, `200ms/1s`, `8G`, `512M`, `infinity`) while excluding newlines, carriage returns, and all other separator/delimiter characters. Empty values remain valid (field omitted from the unit, as before). Errors name the agent and field. The stale struct comment claiming values are written verbatim with validation delegated to systemd is updated.

`cpu_weight`/`io_weight` are `int` fields rendered via `%d` and cannot inject; intentionally untouched.

## Notes

- Adversarial review ran before this PR. A skeptic agent traced all `ResourceLimits` consumers: single construction path (`yaml.Unmarshal` inside `Load()`), `Load()` runs via `PersistentPreRunE` before every provision path including remote (which SSHes `clem provision` → same gate), and no post-Load mutation touches these fields. Regex behavior verified empirically, including trailing-newline handling (Go `$` without `(?m)` matches end-of-text only) and unicode separators (U+2028/NEL rejected by the ASCII allowlist).
- One behavior change worth noting for review: values systemd would previously have tolerated or ignored (e.g. trailing space) now fail `Load()` hard. All documented formats pass; this is the intended effect of an allowlist.
- Same injection class as #124 (`name`/`role`) and #125 (`web_terminal_bind`) — those remain separate per one-issue-per-PR scope.

## Testing

- `TestLoad_ResourceLimitsValidValues`: documented formats parse and load.
- `TestLoad_ResourceLimitsRejectsUnsafeValues` table test: newline (with `ExecStart=` payload), CR, space, tab, `=`, and U+2028 all rejected with errors naming `resource_limits.<field>`.
- `go build ./...`, `go vet ./internal/config/`, full `go test ./...` green.