### PR TITLE
fix(config): validate web_terminal_bind at Load()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,13 @@ func AgentVaultName(sopsVault string) string {
 // githubLoginRe matches a valid GitHub username per GitHub's own rules.
 var githubLoginRe = regexp.MustCompile(`^[a-zA-Z0-9-]{1,39}$`)
 
+// validBindRe matches a safe web_terminal_bind value: an interface name,
+// IPv4/IPv6 address, hostname, or unix socket path (everything ttyd -i
+// accepts). The value lands verbatim on the ExecStart= line of the ttyd
+// systemd unit, where a newline starts a new directive and whitespace
+// splits arguments — so only this conservative character set is allowed.
+var validBindRe = regexp.MustCompile(`^[0-9A-Za-z./:_-]+$`)
+
 // vaultRefRe matches ${vault:BUCKET.KEY} in MCP server env values.
 var vaultRefRe = regexp.MustCompile(`\$\{vault:([^.}]+)\.([^}]+)\}`)
 
@@ -981,6 +988,9 @@ func Load(path string) (*Config, error) {
 				return nil, fmt.Errorf("agents %s and %s have the same web_terminal_port %d", other, key, ac.WebTerminalPort)
 			}
 			usedPorts[ac.WebTerminalPort] = key
+		}
+		if ac.WebTerminalBind != "" && !validBindRe.MatchString(ac.WebTerminalBind) {
+			return nil, fmt.Errorf("agent %s: web_terminal_bind must be an interface, IP address, hostname, or socket path (characters [0-9A-Za-z./:_-]), got %q", key, ac.WebTerminalBind)
 		}
 		switch ac.Effort {
 		case "", "low", "medium", "high", "xhigh", "max":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1085,6 +1086,71 @@ agents:
 `)
 	if _, err := Load(path); err == nil {
 		t.Fatal("expected error for proxy_port colliding with web_terminal_port, got nil")
+	}
+}
+
+func TestLoad_WebTerminalBindValidValues(t *testing.T) {
+	for _, bind := range []string{
+		"127.0.0.1",
+		"0.0.0.0",
+		"::",
+		"::1",
+		"eth0",
+		"terminal.example-host.com",
+		"/var/run/ttyd.sock",
+	} {
+		path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    web_terminal_port: 7681
+    web_terminal_bind: "`+bind+`"
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("web_terminal_bind %q: unexpected error: %v", bind, err)
+		}
+		if got := cfg.Agents["lead"].WebTerminalBind; got != bind {
+			t.Fatalf("web_terminal_bind %q: parsed as %q", bind, got)
+		}
+	}
+}
+
+func TestLoad_WebTerminalBindRejectsUnsafeValues(t *testing.T) {
+	for name, bind := range map[string]string{
+		"newline directive injection": "127.0.0.1\\n[Service]\\nExecStart=/usr/bin/false",
+		"carriage return":             "127.0.0.1\\r",
+		"space splits args":           "127.0.0.1 --writable",
+		"tab":                         "127.0.0.1\\t",
+		"equals sign":                 "bind=0.0.0.0",
+		"command substitution":        "$(hostname)",
+	} {
+		path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    web_terminal_port: 7681
+    web_terminal_bind: "`+bind+`"
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatalf("%s: expected error, got nil", name)
+		}
+		if !strings.Contains(err.Error(), "web_terminal_bind") {
+			t.Fatalf("%s: error should name web_terminal_bind, got: %v", name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #125.

## Problem

`web_terminal_bind` is a free-form string from `clem.yaml` substituted verbatim into the ttyd systemd unit via `renderTemplate` (`internal/runner/runner.go:348`):

```
ExecStart=/usr/local/bin/ttyd -R -i {{.TtydBind}} -p {{.TtydPort}} ...
```

A value containing a newline terminates `ExecStart=` and injects an arbitrary `[Service]` directive (systemd merges repeated sections in one file). Embedded whitespace splits ttyd arguments — e.g. `127.0.0.1 --writable` silently turns the read-only terminal writable.

## Fix

Validate at `Load()` with a positive allowlist `^[0-9A-Za-z./:_-]+$`, covering everything `ttyd -i` accepts: interface names (`eth0`, `eth0.100`), IPv4/IPv6 (`0.0.0.0`, `::1`), hostnames, and unix socket paths (`/var/run/ttyd.sock`). Matches the issue's proposed fix, widened with `/` for socket paths. Same per-field pattern as the neighbouring `web_terminal_port` / `effort` / `github_login` validations.

Deliberate trade-offs:
- IPv6 zone IDs (`fe80::1%eth0`) are rejected: `%` is a systemd specifier character and cannot be safely admitted. Binding by interface name (`eth0`) covers the same need.
- Bracketed IPv6 (`[::1]`) is rejected: `[` opens a unit-file section header; ttyd takes the bare form (`::1`), which is accepted.

All three `samples/*/clem.yaml` use `web_terminal_bind: 0.0.0.0`, which passes. The empty-value default (`127.0.0.1` in `GenerateTtydService`) is a hardcoded constant and unaffected.

## Tests

- `TestLoad_WebTerminalBindValidValues`: IPv4, IPv6, interface, hostname, socket path round-trip through `Load()`.
- `TestLoad_WebTerminalBindRejectsUnsafeValues`: real control characters (the YAML double-quoted scalars decode `\n`/`\r`/`\t` to actual bytes — verified empirically), argument splitting, `=`, and `$()`.

## Review

Adversarial review ran before this PR: two independent skeptic passes plus a 7-angle review sweep. Both skeptics returned HOLDS. The sweep confirmed: single sink (`GenerateTtydService`, only caller `cmd/provision.go`, port-gated), no `Load()` bypass in production paths (remote provisioning re-runs `Load()` on the remote host), no sample/doc/test fixture breaks. One reviewer claimed the rejection fixtures were double-escaped and vacuous; refuted empirically — the YAML layer decodes the escapes to real control bytes. The underlying `renderTemplate` zero-escaping pattern (root cause shared with #124/#154/#165) is out of scope here; filing a separate design issue.