### PR TITLE
fix(update): select release asset by exact name, not prefix

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -26,13 +25,30 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 }
 
+type ghAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
 type ghRelease struct {
-	TagName string `json:"tag_name"`
-	Assets  []struct {
-		Name               string `json:"name"`
-		BrowserDownloadURL string `json:"browser_download_url"`
-		Size               int64  `json:"size"`
-	} `json:"assets"`
+	TagName string    `json:"tag_name"`
+	Assets  []ghAsset `json:"assets"`
+}
+
+// selectBinaryAsset picks the release asset whose name is exactly
+// clem_<os>_<arch>. Prefix matching is not safe here: the GitHub API does not
+// guarantee asset order, and any sibling asset that starts with the binary
+// name (a .sig/.pem, or the Syft SBOM if its naming ever drops the embedded
+// version) would be downloaded and renamed over the running binary.
+func selectBinaryAsset(assets []ghAsset, goos, goarch string) *ghAsset {
+	want := fmt.Sprintf("clem_%s_%s", goos, goarch)
+	for i := range assets {
+		if assets[i].Name == want {
+			return &assets[i]
+		}
+	}
+	return nil
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -50,18 +66,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Latest:          %s\n", rel.TagName)
 
-	assetName := fmt.Sprintf("clem_%s_%s", runtime.GOOS, runtime.GOARCH)
-	var asset *struct {
-		Name               string `json:"name"`
-		BrowserDownloadURL string `json:"browser_download_url"`
-		Size               int64  `json:"size"`
-	}
-	for i := range rel.Assets {
-		if strings.HasPrefix(rel.Assets[i].Name, assetName) {
-			asset = &rel.Assets[i]
-			break
-		}
-	}
+	asset := selectBinaryAsset(rel.Assets, runtime.GOOS, runtime.GOARCH)
 	if asset == nil {
 		return fmt.Errorf("no prebuilt binary for %s/%s in release %s — build from source", runtime.GOOS, runtime.GOARCH, rel.TagName)
 	}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import "testing"
+
+// selectBinaryAsset must match the bare clem_<os>_<arch> asset exactly.
+// The GitHub API does not guarantee asset order, and a prefix match would
+// pick up any sibling that starts with the binary name (.sig/.pem, or an
+// SBOM whose naming drops the embedded version) — replacing the running
+// binary with a non-executable artifact.
+func TestSelectBinaryAsset(t *testing.T) {
+	cases := []struct {
+		name     string
+		assets   []ghAsset
+		wantName string // "" means expect nil
+	}{
+		{
+			name: "sbom-listed-before-binary",
+			assets: []ghAsset{
+				{Name: "clem_linux_amd64.sbom.json"},
+				{Name: "clem_linux_amd64"},
+			},
+			wantName: "clem_linux_amd64",
+		},
+		{
+			name: "binary-first-still-binary",
+			assets: []ghAsset{
+				{Name: "clem_linux_amd64"},
+				{Name: "clem_linux_amd64.sbom.json"},
+			},
+			wantName: "clem_linux_amd64",
+		},
+		{
+			name: "only-prefix-siblings-no-binary",
+			assets: []ghAsset{
+				{Name: "clem_linux_amd64.sbom.json"},
+				{Name: "clem_linux_amd64.sig"},
+				{Name: "clem_linux_amd64.pem"},
+			},
+			wantName: "",
+		},
+		{
+			name: "other-arch-not-matched",
+			assets: []ghAsset{
+				{Name: "clem_linux_arm64"},
+				{Name: "checksums.txt"},
+			},
+			wantName: "",
+		},
+		{
+			name:     "empty-assets",
+			assets:   nil,
+			wantName: "",
+		},
+		{
+			// mirrors the actual v0.12.1 release asset list
+			name: "real-release-layout",
+			assets: []ghAsset{
+				{Name: "checksums.txt"},
+				{Name: "clem_0.12.1_linux_amd64.sbom.json"},
+				{Name: "clem_0.12.1_linux_arm64.sbom.json"},
+				{Name: "clem_linux_amd64"},
+				{Name: "clem_linux_arm64"},
+			},
+			wantName: "clem_linux_amd64",
+		},
+	}
+	for _, tc := range cases {
+		got := selectBinaryAsset(tc.assets, "linux", "amd64")
+		if tc.wantName == "" {
+			if got != nil {
+				t.Errorf("%s: got %q, want nil", tc.name, got.Name)
+			}
+			continue
+		}
+		if got == nil {
+			t.Errorf("%s: got nil, want %q", tc.name, tc.wantName)
+			continue
+		}
+		if got.Name != tc.wantName {
+			t.Errorf("%s: got %q, want %q", tc.name, got.Name, tc.wantName)
+		}
+	}
+}


### PR DESCRIPTION
Closes #194.

`runUpdate` matched the release asset with `strings.HasPrefix` and broke on the first hit, so selection depended on GitHub's unguaranteed asset ordering. Any sibling asset whose name starts with `clem_<os>_<arch>` would be downloaded and renamed over the running binary.

## Change
- Extract selection into `selectBinaryAsset` and match the asset name exactly (`==`) against `clem_<os>_<arch>`.
- Name the asset struct (`ghAsset`) so the selector is testable; no other callers exist.
- Table-driven tests: prefix siblings ordered first, prefix-only sets, wrong arch, empty list, and a fixture mirroring the actual v0.12.1 release asset layout.

## Notes
- Adversarial review ran (refute-style, against `.goreleaser.yaml` and the live v0.11.0–v0.12.1 release asset lists). It confirmed exact match is correct for every current/historical layout (linux-only builds, binary archive format, no `.exe` case) and caught one inaccuracy in my draft rationale: the published SBOM embeds the version (`clem_0.12.1_linux_amd64.sbom.json`), so it does **not** share the binary prefix today — the live risk is narrower (`.sig`/`.pem` siblings or a future SBOM naming change). Comments and this body were corrected accordingly.
- Checksum verification of the downloaded asset is deliberately out of scope — that is #126.