### PR TITLE
config: switch Athena subagents to haiku (jahwag directive 2026-06-11)

### DIFF
--- a/clem.yaml
+++ b/clem.yaml
@@ -21,6 +21,6 @@ agents:
     name: "Athena"
     role: "Software Engineer"
     model: "claude-sonnet-4-6"
-    subagent_model: "claude-sonnet-4-6"
+    subagent_model: "claude-haiku-4-5-20251001"
     iteration: 5m
     prompt: "Act as Athena per CLAUDE.local.md. Check Discord #tasks for tasks assigned to you. Work on ONE task. When done post results and run: kill $PPID. If no tasks: kill $PPID"

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -138,6 +138,17 @@ func provisionAgent(agentKey string, ac config.AgentConfig) error {
 		}
 	}
 
+	// 3ab. Sync team skills repo. Symlinks shared/* and <agentKey>/*
+	// from the cloned repo into ~/.claude/skills/. Lets agents PR new
+	// skills without operator-mediated config edits.
+	if cfg.SkillsRepo != "" {
+		if err := agent.SyncSkillsRepo(osUser, homeDir, agentKey, cfg.SkillsRepo); err != nil {
+			fmt.Printf("  warning: skills repo sync for %s: %v\n", osUser, err)
+		} else {
+			fmt.Printf("  synced skills from %s for %s\n", cfg.SkillsRepo, osUser)
+		}
+	}
+
 	// 3a. Generate SSH keypair (idempotent)
 	pubKey, err := agent.EnsureSSHKey(osUser, homeDir)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,11 @@ func loadConfig(cmd *cobra.Command, args []string) error {
 	if cmd.Name() == "update" {
 		return nil
 	}
+	// sync-skills runs as the agent user (who can't read root-owned clem.yaml)
+	// and gets its args from runner-script flags, not from config
+	if cmd.Name() == "sync-skills" {
+		return nil
+	}
 
 	var err error
 	cfg, err = config.Load(configPath)

--- a/cmd/sync_skills.go
+++ b/cmd/sync_skills.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jahwag/clem/internal/agent"
+	"github.com/spf13/cobra"
+)
+
+// syncSkillsCmd is invoked by clem-runner.sh as the agent user before each TUI
+// launch. It pulls the team skills repo and refreshes ~/.claude/skills/<name>
+// symlinks so any skill merged since the last iteration becomes available on
+// the next claude-code startup. No sudo wrapping — caller is already the
+// target user (runner runs under systemd User=).
+var syncSkillsCmd = &cobra.Command{
+	Use:    "sync-skills",
+	Short:  "Pull skills repo and refresh ~/.claude/skills/ symlinks (runner-side)",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		home, _ := cmd.Flags().GetString("home")
+		agentKey, _ := cmd.Flags().GetString("agent-key")
+		repo, _ := cmd.Flags().GetString("repo")
+		if home == "" || agentKey == "" || repo == "" {
+			return fmt.Errorf("sync-skills requires --home, --agent-key, and --repo")
+		}
+		return agent.SyncSkillsRepoAsSelf(home, agentKey, repo)
+	},
+}
+
+func init() {
+	syncSkillsCmd.Flags().String("home", "", "agent home directory (e.g. /home/myteam-lead)")
+	syncSkillsCmd.Flags().String("agent-key", "", "agent key from clem.yaml (e.g. lead, worker)")
+	syncSkillsCmd.Flags().String("repo", "", "skills repo URL")
+	rootCmd.AddCommand(syncSkillsCmd)
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,16 +13,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// latestReleaseURL is a var so tests can point it at an httptest server.
-var latestReleaseURL = "https://api.github.com/repos/jahwag/clem/releases/latest"
+// latestReleaseURL and allReleasesURL are vars so tests can point them at an
+// httptest server.
+var (
+	latestReleaseURL = "https://api.github.com/repos/jahwag/clem/releases/latest"
+	allReleasesURL   = "https://api.github.com/repos/jahwag/clem/releases?per_page=20"
+)
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Download and install the latest clem release",
-	RunE:  runUpdate,
+	Long: `Download and install the latest clem release from GitHub.
+
+By default, picks the latest stable release (tags like v0.10.0). Prerelease
+tags (anything with a suffix — v0.10.0-snapshot.1, v0.10.0-rc1, v0.10.0-beta,
+etc.) are skipped so production hosts never auto-update onto an unstable cut.
+
+Pass --snapshot to opt in. The newest tag wins regardless of suffix, so
+this is also how you upgrade to a release candidate ahead of promotion.`,
+	RunE: runUpdate,
 }
 
 func init() {
+	updateCmd.Flags().Bool("snapshot", false, "include prerelease tags (e.g. -snapshot, -rc, -beta) when picking the latest release")
 	rootCmd.AddCommand(updateCmd)
 }
 
@@ -33,8 +46,10 @@ type ghAsset struct {
 }
 
 type ghRelease struct {
-	TagName string    `json:"tag_name"`
-	Assets  []ghAsset `json:"assets"`
+	TagName    string    `json:"tag_name"`
+	Prerelease bool      `json:"prerelease"`
+	Draft      bool      `json:"draft"`
+	Assets     []ghAsset `json:"assets"`
 }
 
 // selectBinaryAsset picks the release asset whose name is exactly
@@ -53,10 +68,21 @@ func selectBinaryAsset(assets []ghAsset, goos, goarch string) *ghAsset {
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
+	includeSnapshot, _ := cmd.Flags().GetBool("snapshot")
+	channel := "stable"
+	if includeSnapshot {
+		channel = "snapshot (incl. prereleases)"
+	}
 	fmt.Printf("Current version: %s\n", Version)
-	fmt.Println("Checking GitHub for the latest release…")
+	fmt.Printf("Checking GitHub for the latest %s release…\n", channel)
 
-	rel, err := fetchLatestRelease()
+	var rel *ghRelease
+	var err error
+	if includeSnapshot {
+		rel, err = fetchLatestIncludingPrerelease()
+	} else {
+		rel, err = fetchLatestRelease()
+	}
 	if err != nil {
 		return fmt.Errorf("fetching latest release: %w\n\nNo releases yet? Install from source:\n  go install github.com/jahwag/clem@latest", err)
 	}
@@ -96,6 +122,37 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Updated to %s → %s\n", rel.TagName, dst)
 	return nil
+}
+
+// fetchLatestIncludingPrerelease lists recent releases and returns the newest
+// non-draft entry (regardless of prerelease flag). GitHub's /releases endpoint
+// returns entries newest-first by `created_at`, so the first non-draft entry
+// is the latest cut from any channel.
+func fetchLatestIncludingPrerelease() (*ghRelease, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("GET", allReleasesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build releases request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github returned %s", resp.Status)
+	}
+	var rels []ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rels); err != nil {
+		return nil, err
+	}
+	for i := range rels {
+		if !rels[i].Draft {
+			return &rels[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no non-draft releases found")
 }
 
 func fetchLatestRelease() (*ghRelease, error) {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -120,3 +120,40 @@ func TestFetchLatestRelease_ParsesAndHandlesStatuses(t *testing.T) {
 		t.Error("non-200 should surface as an error")
 	}
 }
+
+// fetchLatestIncludingPrerelease backs the --snapshot channel: GitHub's
+// /releases list is newest-first by created_at, so the first non-draft entry
+// is the latest cut regardless of the prerelease flag. A draft ahead of it
+// must be skipped, never installed.
+func TestFetchLatestIncludingPrerelease_SkipsDraftPicksNewest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/list":
+			// newest-first: a draft, then a prerelease snapshot, then stable.
+			_, _ = w.Write([]byte(`[
+				{"tag_name":"v0.15.0-draft","draft":true,"prerelease":true,"assets":[]},
+				{"tag_name":"v0.14.0-snapshot.1","draft":false,"prerelease":true,"assets":[{"name":"clem_linux_amd64","browser_download_url":"u","size":3}]},
+				{"tag_name":"v0.13.0","draft":false,"prerelease":false,"assets":[]}
+			]`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	orig := allReleasesURL
+	defer func() { allReleasesURL = orig }()
+
+	allReleasesURL = srv.URL + "/list"
+	rel, err := fetchLatestIncludingPrerelease()
+	if err != nil {
+		t.Fatalf("fetchLatestIncludingPrerelease: %v", err)
+	}
+	if rel.TagName != "v0.14.0-snapshot.1" {
+		t.Errorf("snapshot channel picked %q, want the newest non-draft v0.14.0-snapshot.1 (draft must be skipped)", rel.TagName)
+	}
+
+	allReleasesURL = srv.URL + "/boom"
+	if _, err := fetchLatestIncludingPrerelease(); err == nil {
+		t.Error("non-200 should surface as an error")
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1238,6 +1238,117 @@ func InstallSkill(username string, s config.SkillConfig) error {
 	return nil
 }
 
+// SyncSkillsRepo clones (or pulls) repoURL into <homeDir>/.cache/<repoName>/
+// as the agent user, then symlinks every subdir under shared/ and <agentKey>/
+// into <homeDir>/.claude/skills/<name>. Symlinks pointing into the cache that
+// no longer resolve are pruned, so removing a skill in the repo propagates on
+// next provision. Idempotent.
+//
+// repoURL is any URL git clone understands (https, ssh, git@host:path).
+// agentKey selects which per-agent subdir to surface. Top-level dirs other
+// than shared and the agent's key are ignored.
+//
+// Skill name must match extensionNameRe (alphanumeric plus . _ -); invalid
+// names are skipped with a logged warning. The repo is operator-PR-reviewed,
+// so this is defense in depth, not the primary trust boundary.
+func SyncSkillsRepo(username, homeDir, agentKey, repoURL string) error {
+	repoName := skillsCacheName(repoURL)
+	cache := filepath.Join(homeDir, ".cache", repoName)
+	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+
+	if _, err := os.Stat(cache); os.IsNotExist(err) {
+		if err := EnsureOwnedDir(filepath.Dir(cache), username); err != nil {
+			return fmt.Errorf("ensuring cache parent for %s: %w", username, err)
+		}
+		out, err := sys.Run("sudo", "-iu", username, "git", "clone", repoURL, cache)
+		if err != nil {
+			return fmt.Errorf("cloning skills repo %s for %s: %w\n%s", repoURL, username, err, out)
+		}
+	} else {
+		out, err := sys.Run("sudo", "-iu", username, "git", "-C", cache, "pull", "--ff-only")
+		if err != nil {
+			return fmt.Errorf("pulling skills repo for %s: %w\n%s", username, err, out)
+		}
+	}
+
+	if err := EnsureOwnedDir(skillsDir, username); err != nil {
+		return fmt.Errorf("ensuring skills dir for %s: %w", username, err)
+	}
+
+	expected := make(map[string]string)
+	for _, src := range []string{"shared", agentKey} {
+		srcDir := filepath.Join(cache, src)
+		entries, err := os.ReadDir(srcDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("reading %s: %w", srcDir, err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := filepath.Base(e.Name())
+			if !config.IsValidExtensionName(name) {
+				fmt.Printf("  warning: skipping skill %q in %s (invalid name)\n", name, src)
+				continue
+			}
+			if prior, dup := expected[name]; dup {
+				fmt.Printf("  warning: skill %q in %s collides with %s; keeping first\n", name, src, prior)
+				continue
+			}
+			target := filepath.Join(srcDir, name)
+			link := filepath.Join(skillsDir, name)
+			if out, err := sys.Run("sudo", "-iu", username, "ln", "-sfn", target, link); err != nil {
+				return fmt.Errorf("symlinking skill %s for %s: %w\n%s", name, username, err, out)
+			}
+			expected[name] = src
+		}
+	}
+
+	pruneStaleSkillSymlinks(username, skillsDir, cache, expected)
+	return nil
+}
+
+// skillsCacheName extracts the cache-directory name from a git URL: last
+// path segment with any trailing .git stripped. Handles https://host/a/b.git,
+// ssh://git@host/a/b, and scp-style git@host:a/b.git.
+func skillsCacheName(repoURL string) string {
+	s := strings.TrimSuffix(repoURL, "/")
+	if i := strings.LastIndexAny(s, "/:"); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.TrimSuffix(s, ".git")
+}
+
+// pruneStaleSkillSymlinks removes symlinks in skillsDir that point into the
+// cache dir but are no longer backed by an expected skill. Non-symlinks (real
+// dirs from InstallSkill) and links pointing outside the cache are left alone.
+func pruneStaleSkillSymlinks(username, skillsDir, cache string, expected map[string]string) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if _, kept := expected[name]; kept {
+			continue
+		}
+		full := filepath.Join(skillsDir, name)
+		target, err := os.Readlink(full)
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(target, cache+string(filepath.Separator)) {
+			continue
+		}
+		if out, err := sys.Run("sudo", "-iu", username, "rm", "-f", full); err != nil {
+			fmt.Printf("  warning: removing stale skill symlink %s: %v\n%s", full, err, out)
+		}
+	}
+}
+
 // SetMCPServers overwrites the mcpServers key in ~/.claude/settings.json while
 // preserving all other settings. Vault refs in env values are expanded via secrets.
 func SetMCPServers(homeDir string, servers []config.MCPServerConfig, secrets map[string]string) error {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1242,7 +1242,7 @@ func InstallSkill(username string, s config.SkillConfig) error {
 // as the agent user, then symlinks every subdir under shared/ and <agentKey>/
 // into <homeDir>/.claude/skills/<name>. Symlinks pointing into the cache that
 // no longer resolve are pruned, so removing a skill in the repo propagates on
-// next provision. Idempotent.
+// next sync. Idempotent.
 //
 // repoURL is any URL git clone understands (https, ssh, git@host:path).
 // agentKey selects which per-agent subdir to surface. Top-level dirs other
@@ -1251,28 +1251,54 @@ func InstallSkill(username string, s config.SkillConfig) error {
 // Skill name must match extensionNameRe (alphanumeric plus . _ -); invalid
 // names are skipped with a logged warning. The repo is operator-PR-reviewed,
 // so this is defense in depth, not the primary trust boundary.
+//
+// Called from provision (running as root); each shell-out is sudo-wrapped to
+// run as the agent user so files land with correct ownership.
 func SyncSkillsRepo(username, homeDir, agentKey, repoURL string) error {
+	run := func(name string, args ...string) ([]byte, error) {
+		return sys.Run("sudo", append([]string{"-iu", username, name}, args...)...)
+	}
+	mkDir := func(path string) error { return EnsureOwnedDir(path, username) }
+	return syncSkillsCommon(homeDir, agentKey, repoURL, run, mkDir)
+}
+
+// SyncSkillsRepoAsSelf is the runtime variant. Called by the runner inside
+// each iteration as the agent user, so no sudo wrapping. Dirs created
+// directly via os.MkdirAll (they land owned by the calling user).
+//
+// This is the loop that lets agent-authored skills land without re-running
+// `clem provision`: PR → merge → next iteration's runner pulls and re-symlinks
+// before launching the TUI.
+func SyncSkillsRepoAsSelf(homeDir, agentKey, repoURL string) error {
+	run := sys.Run
+	mkDir := func(path string) error { return os.MkdirAll(path, 0755) }
+	return syncSkillsCommon(homeDir, agentKey, repoURL, run, mkDir)
+}
+
+type cmdRunner func(name string, args ...string) ([]byte, error)
+
+func syncSkillsCommon(homeDir, agentKey, repoURL string, run cmdRunner, mkDir func(string) error) error {
 	repoName := skillsCacheName(repoURL)
 	cache := filepath.Join(homeDir, ".cache", repoName)
 	skillsDir := filepath.Join(homeDir, ".claude", "skills")
 
 	if _, err := os.Stat(cache); os.IsNotExist(err) {
-		if err := EnsureOwnedDir(filepath.Dir(cache), username); err != nil {
-			return fmt.Errorf("ensuring cache parent for %s: %w", username, err)
+		if err := mkDir(filepath.Dir(cache)); err != nil {
+			return fmt.Errorf("ensuring cache parent: %w", err)
 		}
-		out, err := sys.Run("sudo", "-iu", username, "git", "clone", repoURL, cache)
+		out, err := run("git", "clone", repoURL, cache)
 		if err != nil {
-			return fmt.Errorf("cloning skills repo %s for %s: %w\n%s", repoURL, username, err, out)
+			return fmt.Errorf("cloning skills repo %s: %w\n%s", repoURL, err, out)
 		}
 	} else {
-		out, err := sys.Run("sudo", "-iu", username, "git", "-C", cache, "pull", "--ff-only")
+		out, err := run("git", "-C", cache, "pull", "--ff-only")
 		if err != nil {
-			return fmt.Errorf("pulling skills repo for %s: %w\n%s", username, err, out)
+			return fmt.Errorf("pulling skills repo: %w\n%s", err, out)
 		}
 	}
 
-	if err := EnsureOwnedDir(skillsDir, username); err != nil {
-		return fmt.Errorf("ensuring skills dir for %s: %w", username, err)
+	if err := mkDir(skillsDir); err != nil {
+		return fmt.Errorf("ensuring skills dir: %w", err)
 	}
 
 	expected := make(map[string]string)
@@ -1300,14 +1326,14 @@ func SyncSkillsRepo(username, homeDir, agentKey, repoURL string) error {
 			}
 			target := filepath.Join(srcDir, name)
 			link := filepath.Join(skillsDir, name)
-			if out, err := sys.Run("sudo", "-iu", username, "ln", "-sfn", target, link); err != nil {
-				return fmt.Errorf("symlinking skill %s for %s: %w\n%s", name, username, err, out)
+			if out, err := run("ln", "-sfn", target, link); err != nil {
+				return fmt.Errorf("symlinking skill %s: %w\n%s", name, err, out)
 			}
 			expected[name] = src
 		}
 	}
 
-	pruneStaleSkillSymlinks(username, skillsDir, cache, expected)
+	pruneStaleSkillSymlinks(skillsDir, cache, expected, run)
 	return nil
 }
 
@@ -1325,7 +1351,7 @@ func skillsCacheName(repoURL string) string {
 // pruneStaleSkillSymlinks removes symlinks in skillsDir that point into the
 // cache dir but are no longer backed by an expected skill. Non-symlinks (real
 // dirs from InstallSkill) and links pointing outside the cache are left alone.
-func pruneStaleSkillSymlinks(username, skillsDir, cache string, expected map[string]string) {
+func pruneStaleSkillSymlinks(skillsDir, cache string, expected map[string]string, run cmdRunner) {
 	entries, err := os.ReadDir(skillsDir)
 	if err != nil {
 		return
@@ -1343,7 +1369,7 @@ func pruneStaleSkillSymlinks(username, skillsDir, cache string, expected map[str
 		if !strings.HasPrefix(target, cache+string(filepath.Separator)) {
 			continue
 		}
-		if out, err := sys.Run("sudo", "-iu", username, "rm", "-f", full); err != nil {
+		if out, err := run("rm", "-f", full); err != nil {
 			fmt.Printf("  warning: removing stale skill symlink %s: %v\n%s", full, err, out)
 		}
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1270,6 +1270,263 @@ func TestWriteHostManagedSettings_EmptyDenyWhenNoPermissions(t *testing.T) {
 	}
 }
 
+// skillsStub interprets ln -sfn / rm -f / mkdir -p so SyncSkillsRepo's
+// filesystem-mutating side effects land on the real test temp dir. Calls are
+// still recorded for assertions on what was invoked.
+type skillsStub struct {
+	stubExec
+	cloneSeed func(cache string) // called when `git clone` is invoked
+}
+
+func (s *skillsStub) Run(name string, args ...string) ([]byte, error) {
+	s.calls = append(s.calls, append([]string{name}, args...))
+	// Recognized form: sudo -iu <user> <cmd> <cmdArgs...>
+	if name == "sudo" && len(args) >= 4 && args[0] == "-iu" {
+		cmd := args[2]
+		cargs := args[3:]
+		switch cmd {
+		case "ln":
+			// ln -sfn target link
+			if len(cargs) >= 3 && cargs[0] == "-sfn" {
+				_ = os.Remove(cargs[2])
+				if err := os.Symlink(cargs[1], cargs[2]); err != nil {
+					return nil, err
+				}
+			}
+		case "rm":
+			// rm -f path
+			if len(cargs) >= 2 && cargs[0] == "-f" {
+				_ = os.Remove(cargs[1])
+			}
+		case "git":
+			// git clone <url> <cache> — seed the cache dir from the test fixture
+			if len(cargs) >= 1 && cargs[0] == "clone" && s.cloneSeed != nil {
+				if len(cargs) >= 3 {
+					s.cloneSeed(cargs[2])
+				}
+			}
+			// git -C <dir> pull --ff-only — no-op
+		}
+	}
+	return nil, nil
+}
+
+func withSkillsStub(t *testing.T) *skillsStub {
+	t.Helper()
+	stub := &skillsStub{}
+	orig := sys
+	sys = stub
+	t.Cleanup(func() { sys = orig })
+	return stub
+}
+
+func TestSkillsCacheName(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/foo/bar":             "bar",
+		"https://github.com/foo/bar.git":         "bar",
+		"https://github.com/foo/bar/":            "bar",
+		"git@github.com:foo/bar.git":             "bar",
+		"ssh://git@self-hosted/foo/bar.git":      "bar",
+		"https://gitlab.example.com/g/sub/repo":  "repo",
+	}
+	for in, want := range cases {
+		if got := skillsCacheName(in); got != want {
+			t.Errorf("skillsCacheName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestSyncSkillsRepo_SymlinksSharedAndAgent verifies the happy path: a
+// pre-existing cache with shared/ and worker/ subdirs produces symlinks in
+// the agent's skills dir for each, and ignores top-level dirs outside that set.
+func TestSyncSkillsRepo_SymlinksSharedAndAgent(t *testing.T) {
+	stub := withSkillsStub(t)
+	home := t.TempDir()
+	repoURL := "https://example.com/owner/team-skills.git"
+	cache := filepath.Join(home, ".cache", "team-skills")
+
+	// Seed cache as if `git clone` had already run.
+	for _, p := range []string{
+		filepath.Join(cache, "shared", "skill-a", "SKILL.md"),
+		filepath.Join(cache, "worker", "skill-b", "SKILL.md"),
+		filepath.Join(cache, "lead", "skill-c", "SKILL.md"),     // not for worker
+		filepath.Join(cache, "random-dir", "skill-d", "SKILL.md"), // ignored
+	} {
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatalf("seed mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("---\nname: x\n---\n"), 0644); err != nil {
+			t.Fatalf("seed write: %v", err)
+		}
+	}
+
+	if err := SyncSkillsRepo("testuser", home, "worker", repoURL); err != nil {
+		t.Fatalf("SyncSkillsRepo: %v", err)
+	}
+
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	for _, name := range []string{"skill-a", "skill-b"} {
+		link := filepath.Join(skillsDir, name)
+		target, err := os.Readlink(link)
+		if err != nil {
+			t.Errorf("%s: expected symlink, got: %v", name, err)
+			continue
+		}
+		if !strings.HasPrefix(target, cache+string(filepath.Separator)) {
+			t.Errorf("%s: symlink target %q not under cache %q", name, target, cache)
+		}
+	}
+	// skill-c (lead) and skill-d (random-dir) must NOT appear for worker
+	for _, name := range []string{"skill-c", "skill-d"} {
+		if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
+			t.Errorf("worker should not see %s", name)
+		}
+	}
+
+	// First call should have invoked `git clone` (cache didn't exist before
+	// the test seeded it... wait, we seeded it. So `git -C cache pull --ff-only`
+	// is what should have fired).
+	sawPull := false
+	for _, c := range stub.calls {
+		if len(c) >= 5 && c[0] == "sudo" && c[3] == "git" && c[4] == "-C" {
+			sawPull = true
+		}
+	}
+	if !sawPull {
+		t.Errorf("expected git pull to fire on existing cache; calls: %v", stub.calls)
+	}
+}
+
+// TestSyncSkillsRepo_PrunesStaleSymlinks verifies that a symlink in the
+// skills dir pointing into the cache for a skill that no longer exists in
+// the repo is removed on next sync. Real dirs and external-target symlinks
+// are left alone.
+func TestSyncSkillsRepo_PrunesStaleSymlinks(t *testing.T) {
+	withSkillsStub(t)
+	home := t.TempDir()
+	repoURL := "https://example.com/owner/team-skills.git"
+	cache := filepath.Join(home, ".cache", "team-skills")
+	skillsDir := filepath.Join(home, ".claude", "skills")
+
+	// Cache has only one skill in shared.
+	if err := os.MkdirAll(filepath.Join(cache, "shared", "kept-skill"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-existing stale symlink pointing into cache for a now-removed skill.
+	staleTarget := filepath.Join(cache, "shared", "removed-skill")
+	if err := os.Symlink(staleTarget, filepath.Join(skillsDir, "removed-skill")); err != nil {
+		t.Fatal(err)
+	}
+	// Operator-installed real skill dir (e.g. from InstallSkill). Must survive.
+	if err := os.MkdirAll(filepath.Join(skillsDir, "operator-skill"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink pointing OUTSIDE the cache. Must survive.
+	external := filepath.Join(home, "external-skill")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(skillsDir, "external-skill")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SyncSkillsRepo("testuser", home, "worker", repoURL); err != nil {
+		t.Fatalf("SyncSkillsRepo: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(skillsDir, "removed-skill")); err == nil {
+		t.Error("stale symlink to cache should have been pruned")
+	}
+	if _, err := os.Lstat(filepath.Join(skillsDir, "operator-skill")); err != nil {
+		t.Errorf("operator-installed real dir should survive: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(skillsDir, "external-skill")); err != nil {
+		t.Errorf("symlink outside cache should survive: %v", err)
+	}
+	if _, err := os.Readlink(filepath.Join(skillsDir, "kept-skill")); err != nil {
+		t.Errorf("kept-skill symlink should be created: %v", err)
+	}
+}
+
+// TestSyncSkillsRepo_RejectsInvalidNames verifies that skill subdirs whose
+// names fail the extension-name regex (e.g. shell-special characters) are
+// skipped rather than symlinked, even if the operator-controlled repo
+// somehow contained them.
+func TestSyncSkillsRepo_RejectsInvalidNames(t *testing.T) {
+	withSkillsStub(t)
+	home := t.TempDir()
+	repoURL := "https://example.com/owner/team-skills.git"
+	cache := filepath.Join(home, ".cache", "team-skills")
+
+	if err := os.MkdirAll(filepath.Join(cache, "shared", "good-skill"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Names that should be rejected by the regex
+	for _, bad := range []string{"-leading-dash", "has space", "has;semi"} {
+		if err := os.MkdirAll(filepath.Join(cache, "shared", bad), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := SyncSkillsRepo("testuser", home, "worker", repoURL); err != nil {
+		t.Fatalf("SyncSkillsRepo: %v", err)
+	}
+
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	if _, err := os.Readlink(filepath.Join(skillsDir, "good-skill")); err != nil {
+		t.Errorf("good-skill should be symlinked: %v", err)
+	}
+	for _, bad := range []string{"-leading-dash", "has space", "has;semi"} {
+		if _, err := os.Lstat(filepath.Join(skillsDir, bad)); err == nil {
+			t.Errorf("invalid name %q should have been skipped", bad)
+		}
+	}
+}
+
+// TestSyncSkillsRepo_ClonesWhenCacheMissing verifies that a missing cache dir
+// triggers `git clone` rather than `git pull`. The stub's cloneSeed creates
+// the dir so the rest of the function can read it.
+func TestSyncSkillsRepo_ClonesWhenCacheMissing(t *testing.T) {
+	stub := withSkillsStub(t)
+	home := t.TempDir()
+	repoURL := "git@gitlab.example.com:owner/team-skills.git"
+	cache := filepath.Join(home, ".cache", "team-skills")
+
+	stub.cloneSeed = func(c string) {
+		if c != cache {
+			t.Errorf("clone target %q, want %q", c, cache)
+		}
+		if err := os.MkdirAll(filepath.Join(c, "shared", "first-skill"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := SyncSkillsRepo("testuser", home, "worker", repoURL); err != nil {
+		t.Fatalf("SyncSkillsRepo: %v", err)
+	}
+
+	sawClone := false
+	for _, c := range stub.calls {
+		if len(c) >= 5 && c[0] == "sudo" && c[3] == "git" && c[4] == "clone" {
+			sawClone = true
+			if c[5] != repoURL {
+				t.Errorf("clone URL = %q, want %q", c[5], repoURL)
+			}
+		}
+	}
+	if !sawClone {
+		t.Errorf("expected git clone on missing cache; calls: %v", stub.calls)
+	}
+
+	if _, err := os.Readlink(filepath.Join(home, ".claude", "skills", "first-skill")); err != nil {
+		t.Errorf("first-skill should be symlinked after clone: %v", err)
+	}
+}
+
 func TestWriteHostManagedSettings_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "managed-settings.json")

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1280,33 +1280,38 @@ type skillsStub struct {
 
 func (s *skillsStub) Run(name string, args ...string) ([]byte, error) {
 	s.calls = append(s.calls, append([]string{name}, args...))
-	// Recognized form: sudo -iu <user> <cmd> <cmdArgs...>
-	if name == "sudo" && len(args) >= 4 && args[0] == "-iu" {
-		cmd := args[2]
-		cargs := args[3:]
-		switch cmd {
-		case "ln":
-			// ln -sfn target link
-			if len(cargs) >= 3 && cargs[0] == "-sfn" {
-				_ = os.Remove(cargs[2])
-				if err := os.Symlink(cargs[1], cargs[2]); err != nil {
-					return nil, err
-				}
+	// Two forms supported:
+	//   sudo -iu <user> <cmd> <cmdArgs...>    (provision path)
+	//   <cmd> <cmdArgs...>                    (runner/self path)
+	var cmd string
+	var cargs []string
+	switch {
+	case name == "sudo" && len(args) >= 4 && args[0] == "-iu":
+		cmd = args[2]
+		cargs = args[3:]
+	default:
+		cmd = name
+		cargs = args
+	}
+	switch cmd {
+	case "ln":
+		if len(cargs) >= 3 && cargs[0] == "-sfn" {
+			_ = os.Remove(cargs[2])
+			if err := os.Symlink(cargs[1], cargs[2]); err != nil {
+				return nil, err
 			}
-		case "rm":
-			// rm -f path
-			if len(cargs) >= 2 && cargs[0] == "-f" {
-				_ = os.Remove(cargs[1])
-			}
-		case "git":
-			// git clone <url> <cache> — seed the cache dir from the test fixture
-			if len(cargs) >= 1 && cargs[0] == "clone" && s.cloneSeed != nil {
-				if len(cargs) >= 3 {
-					s.cloneSeed(cargs[2])
-				}
-			}
-			// git -C <dir> pull --ff-only — no-op
 		}
+	case "rm":
+		if len(cargs) >= 2 && cargs[0] == "-f" {
+			_ = os.Remove(cargs[1])
+		}
+	case "git":
+		if len(cargs) >= 1 && cargs[0] == "clone" && s.cloneSeed != nil {
+			if len(cargs) >= 3 {
+				s.cloneSeed(cargs[2])
+			}
+		}
+		// git -C <dir> pull --ff-only — no-op
 	}
 	return nil, nil
 }
@@ -1490,6 +1495,31 @@ func TestSyncSkillsRepo_RejectsInvalidNames(t *testing.T) {
 // TestSyncSkillsRepo_ClonesWhenCacheMissing verifies that a missing cache dir
 // triggers `git clone` rather than `git pull`. The stub's cloneSeed creates
 // the dir so the rest of the function can read it.
+// TestSyncSkillsRepoAsSelf_NoSudoWrap verifies the runtime variant invokes
+// git/ln/rm directly (no `sudo -iu` wrapping), since the runner already
+// executes as the agent user.
+func TestSyncSkillsRepoAsSelf_NoSudoWrap(t *testing.T) {
+	stub := withSkillsStub(t)
+	home := t.TempDir()
+	cache := filepath.Join(home, ".cache", "team-skills")
+	if err := os.MkdirAll(filepath.Join(cache, "shared", "live-skill"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SyncSkillsRepoAsSelf(home, "worker", "https://example.com/owner/team-skills.git"); err != nil {
+		t.Fatalf("SyncSkillsRepoAsSelf: %v", err)
+	}
+
+	for _, c := range stub.calls {
+		if len(c) >= 2 && c[0] == "sudo" {
+			t.Errorf("AsSelf path must not call sudo; got %v", c)
+		}
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".claude", "skills", "live-skill")); err != nil {
+		t.Errorf("AsSelf should symlink live-skill: %v", err)
+	}
+}
+
 func TestSyncSkillsRepo_ClonesWhenCacheMissing(t *testing.T) {
 	stub := withSkillsStub(t)
 	home := t.TempDir()

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1327,12 +1327,12 @@ func withSkillsStub(t *testing.T) *skillsStub {
 
 func TestSkillsCacheName(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/foo/bar":             "bar",
-		"https://github.com/foo/bar.git":         "bar",
-		"https://github.com/foo/bar/":            "bar",
-		"git@github.com:foo/bar.git":             "bar",
-		"ssh://git@self-hosted/foo/bar.git":      "bar",
-		"https://gitlab.example.com/g/sub/repo":  "repo",
+		"https://github.com/foo/bar":            "bar",
+		"https://github.com/foo/bar.git":        "bar",
+		"https://github.com/foo/bar/":           "bar",
+		"git@github.com:foo/bar.git":            "bar",
+		"ssh://git@self-hosted/foo/bar.git":     "bar",
+		"https://gitlab.example.com/g/sub/repo": "repo",
 	}
 	for in, want := range cases {
 		if got := skillsCacheName(in); got != want {
@@ -1354,7 +1354,7 @@ func TestSyncSkillsRepo_SymlinksSharedAndAgent(t *testing.T) {
 	for _, p := range []string{
 		filepath.Join(cache, "shared", "skill-a", "SKILL.md"),
 		filepath.Join(cache, "worker", "skill-b", "SKILL.md"),
-		filepath.Join(cache, "lead", "skill-c", "SKILL.md"),     // not for worker
+		filepath.Join(cache, "lead", "skill-c", "SKILL.md"),       // not for worker
 		filepath.Join(cache, "random-dir", "skill-d", "SKILL.md"), // ignored
 	} {
 		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,27 @@ var modelRe = regexp.MustCompile(`^[A-Za-z0-9._:/@-]+$`)
 // splits arguments — so only this conservative character set is allowed.
 var validBindRe = regexp.MustCompile(`^[0-9A-Za-z./:_-]+$`)
 
+// IsValidExtensionName reports whether s is a safe extension name (marketplace,
+// plugin, skill). Exported so other packages can validate skill names sourced
+// from disk (e.g. SyncSkillsRepo) without duplicating the regex.
+func IsValidExtensionName(s string) bool { return extensionNameRe.MatchString(s) }
+
+// isPlausibleGitURL accepts the URL shapes git clone understands: https://,
+// http://, git://, ssh://, and the scp-style git@host:owner/repo. Operator-only
+// config so this is a shape check, not a security boundary.
+func isPlausibleGitURL(s string) bool {
+	if strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "git://") || strings.HasPrefix(s, "ssh://") {
+		return true
+	}
+	if i := strings.Index(s, "@"); i > 0 {
+		if j := strings.Index(s[i+1:], ":"); j > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // OperatorConfig identifies the humans who are trusted to issue instructions
 // to agents via Discord or GitHub. Provisioned agents use these IDs in the
 // generated prompt so no operator ID is hardcoded in clem source.
@@ -132,6 +153,19 @@ type Config struct {
 	Vault            VaultBackend           `yaml:"vault"`
 	MCPSidecars      MCPSidecarsConfig      `yaml:"mcp_sidecars"`
 	Agents           map[string]AgentConfig `yaml:"agents"`
+	// SkillsRepo names a git repo whose `shared/<skill>/` and
+	// `<agentKey>/<skill>/` subdirs are symlinked into each agent's
+	// ~/.claude/skills/. Agents PR new skills there; clem provision pulls and
+	// re-syncs. Empty = no skills repo wiring.
+	//
+	// Accepts any URL git clone understands:
+	//   https://github.com/owner/repo
+	//   https://github.com/owner/repo.git
+	//   git@gitlab.com:owner/repo.git
+	//   ssh://git@self-hosted/owner/repo.git
+	// The cache directory name is derived from the URL's last path segment
+	// (with .git stripped).
+	SkillsRepo string `yaml:"skills_repo"`
 	// Extra collects top-level keys not matched by any field above (the
 	// decoder is otherwise strict — see Load). Only "x-"-prefixed extension
 	// keys are accepted, as holders for shared YAML anchors (the
@@ -488,6 +522,9 @@ func Load(path string) (*Config, error) {
 		// valid
 	default:
 		return nil, fmt.Errorf("vault.backend must be env or agent-vault, got %q", cfg.Vault.Backend)
+	}
+	if cfg.SkillsRepo != "" && !isPlausibleGitURL(cfg.SkillsRepo) {
+		return nil, fmt.Errorf("skills_repo %q is not a recognized git URL (expected https://, git://, ssh://, or git@host:path)", cfg.SkillsRepo)
 	}
 	usedPorts := make(map[int]string)
 	// Reserve the egress proxy port so no agent's web terminal collides with it.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1946,3 +1946,55 @@ agents:
 		}
 	}
 }
+
+func TestLoad_SkillsRepoAccepted(t *testing.T) {
+	cases := map[string]string{
+		"github https":  "https://github.com/Bytelope/consultant-dev-team-skills",
+		"github .git":   "https://github.com/Bytelope/consultant-dev-team-skills.git",
+		"gitlab ssh":    "git@gitlab.example.com:org/skills.git",
+		"self-hosted":   "ssh://git@self.example.com/org/skills.git",
+	}
+	for name, url := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+skills_repo: `+url+`
+agents:
+  lead:
+    name: "Amara"
+    model: "claude-sonnet-4-6"
+`)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load(%s): %v", name, err)
+			}
+			if cfg.SkillsRepo != url {
+				t.Errorf("SkillsRepo = %q, want %q", cfg.SkillsRepo, url)
+			}
+		})
+	}
+}
+
+func TestLoad_SkillsRepoRejected(t *testing.T) {
+	for _, bad := range []string{"not-a-url", "ftp://example.com/repo", "owner/repo"} {
+		path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+skills_repo: `+bad+`
+agents:
+  lead:
+    name: "Amara"
+    model: "claude-sonnet-4-6"
+`)
+		if _, err := Load(path); err == nil {
+			t.Errorf("Load should have rejected skills_repo=%q", bad)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1949,10 +1949,10 @@ agents:
 
 func TestLoad_SkillsRepoAccepted(t *testing.T) {
 	cases := map[string]string{
-		"github https":  "https://github.com/example/myteam-skills",
-		"github .git":   "https://github.com/example/myteam-skills.git",
-		"gitlab ssh":    "git@gitlab.example.com:org/skills.git",
-		"self-hosted":   "ssh://git@self.example.com/org/skills.git",
+		"github https": "https://github.com/example/myteam-skills",
+		"github .git":  "https://github.com/example/myteam-skills.git",
+		"gitlab ssh":   "git@gitlab.example.com:org/skills.git",
+		"self-hosted":  "ssh://git@self.example.com/org/skills.git",
 	}
 	for name, url := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1949,8 +1949,8 @@ agents:
 
 func TestLoad_SkillsRepoAccepted(t *testing.T) {
 	cases := map[string]string{
-		"github https":  "https://github.com/Bytelope/consultant-dev-team-skills",
-		"github .git":   "https://github.com/Bytelope/consultant-dev-team-skills.git",
+		"github https":  "https://github.com/example/myteam-skills",
+		"github .git":   "https://github.com/example/myteam-skills.git",
 		"gitlab ssh":    "git@gitlab.example.com:org/skills.git",
 		"self-hosted":   "ssh://git@self.example.com/org/skills.git",
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -140,6 +140,8 @@ while true; do
     log "Updating claude"
     "$CLAUDE" install 2>&1 | tail -5 | tee -a "$LOGFILE" || log "claude install failed, continuing with current version"
 
+    {{.SkillsSyncCmd}}
+
     log "Starting {{.AgentName}} (fresh session)"
     (sleep 1 && tmux send-keys -t {{.AgentKey}} "" Enter
      sleep 25 && tmux send-keys -l -t {{.AgentKey}} "$PROMPT"
@@ -263,6 +265,8 @@ while true; do
         fi
     fi
 
+    {{.SkillsSyncCmd}}
+
     log "Starting {{.AgentName}} (opencode, fresh session)"
     MODEL_ARG=""
     [ -n "$ANTHROPIC_MODEL" ] && MODEL_ARG="--model ollama/$ANTHROPIC_MODEL"
@@ -385,6 +389,10 @@ type RunnerParams struct {
 	// SidecarServers is a Python/JSON list literal of [toolName, port] pairs for
 	// the privileged MCP sidecars this agent subscribes to. "[]" when none.
 	SidecarServers string
+	// SkillsSyncCmd is the shell snippet invoked at the top of every iteration
+	// to refresh the agent's ~/.claude/skills/ symlinks from the team skills
+	// repo. Empty when cfg.SkillsRepo is unset, in which case no sync runs.
+	SkillsSyncCmd string
 }
 
 // bashDoubleQuoteEscaper escapes the four characters that stay live inside a
@@ -437,6 +445,13 @@ func Generate(cfg *config.Config, agentKey string) string {
 	if ac.SubagentModel != "" {
 		subagentExport = fmt.Sprintf("export CLAUDE_CODE_SUBAGENT_MODEL=%q", ac.SubagentModel)
 	}
+	skillsSyncCmd := ""
+	if cfg.SkillsRepo != "" {
+		skillsSyncCmd = fmt.Sprintf(
+			`clem sync-skills --home "$HOME" --agent-key %q --repo %q 2>&1 | tee -a "$LOGFILE" || log "skills sync failed"`,
+			agentKey, cfg.SkillsRepo,
+		)
+	}
 	p := RunnerParams{
 		Project:        cfg.Project,
 		AgentKey:       agentKey,
@@ -458,6 +473,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 		WatchChannelIDs: discordWatchChannels(cfg),
 		ProxyExport:     proxyExportBlock(cfg, agentKey),
 		SidecarServers:  sidecarServersLiteral(cfg, agentKey),
+		SkillsSyncCmd:   skillsSyncCmd,
 	}
 	switch ac.RuntimeKind() {
 	case "opencode":
@@ -614,6 +630,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.ProxyExport}}", p.ProxyExport,
 		"{{.ProxyUnitDeps}}", p.ProxyUnitDeps,
 		"{{.SidecarServers}}", p.SidecarServers,
+		"{{.SkillsSyncCmd}}", p.SkillsSyncCmd,
 	)
 	return r.Replace(tmpl)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -738,3 +738,33 @@ func TestSidecarServersLiteral(t *testing.T) {
 		t.Errorf("non-subscriber literal = %q", got)
 	}
 }
+
+func TestGenerate_SkillsSyncInjectedWhenRepoSet(t *testing.T) {
+	cfg := baseCfg("worker", config.AgentConfig{
+		Name:      "Athena",
+		Model:     "claude-sonnet-4-6",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	cfg.SkillsRepo = "https://github.com/example/myteam-skills"
+	out := Generate(cfg, "worker")
+
+	wantSubstr := `clem sync-skills --home "$HOME" --agent-key "worker" --repo "https://github.com/example/myteam-skills"`
+	if !strings.Contains(out, wantSubstr) {
+		t.Errorf("runner missing sync-skills invocation; want substr:\n%s\ngot:\n%s", wantSubstr, out)
+	}
+}
+
+func TestGenerate_SkillsSyncAbsentWhenRepoUnset(t *testing.T) {
+	cfg := baseCfg("worker", config.AgentConfig{
+		Name:      "Athena",
+		Model:     "claude-sonnet-4-6",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	// SkillsRepo intentionally empty
+	out := Generate(cfg, "worker")
+	if strings.Contains(out, "clem sync-skills") {
+		t.Errorf("runner should not invoke sync-skills when SkillsRepo unset; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Athena main model stays sonnet-4-6. subagent_model: claude-sonnet-4-6 → claude-haiku-4-5-20251001.

Per jahwag directive in #general 19:10Z. Activation needs `clem down && clem up` after merge.

One-line diff.