### PR TITLE
feat(runner): iteration_night, next-effort handshake, runner warnings, quota snapshot

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,7 +37,8 @@ agents:
     name: "Amara"                      # display name in Claude Code and Discord
     role: "Lead Software Engineer"     # used as {{agent.role}} in CLAUDE.shared.md
     model: "claude-sonnet-4-6"
-    iteration: 10m              # sleep between sessions (same day and night)
+    iteration: 10m              # sleep between sessions during active hours (07-22)
+    iteration_night: 30m        # night sleep (22-07); <=45m keeps prompt-cache starts warm (1h TTL)
     vaults: [github, discord-lead]     # vault names from secrets.sops.yaml merged into .env
     prompt: >-
       Act as {{agent.name}} per CLAUDE.local.md.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,9 +181,15 @@ type AgentConfig struct {
 	Role  string `yaml:"role"`
 	Model string `yaml:"model"`
 	// Iteration is a Go-style duration string (e.g. "30s", "1m30s", "2h").
-	// Parsed via time.ParseDuration. Sleep between agent sessions; same
-	// value applies day and night. Default 5m.
-	Iteration       string   `yaml:"iteration"`
+	// Parsed via time.ParseDuration. Sleep between agent sessions during
+	// active hours (07-22 host time). Default 5m.
+	Iteration string `yaml:"iteration"`
+	// IterationNight is the sleep between sessions during night hours
+	// (22:00-07:00 host time). Same format as Iteration. Empty = match
+	// Iteration. On a Claude subscription the prompt-cache TTL is 1h,
+	// refreshed on access, so values up to ~45m keep session starts warm;
+	// longer values trade one cold start per gap for fewer idle wakeups.
+	IterationNight  string   `yaml:"iteration_night"`
 	Vaults          []string `yaml:"vaults"`
 	Prompt          string   `yaml:"prompt"`
 	WebTerminalPort int      `yaml:"web_terminal_port"`
@@ -390,6 +396,22 @@ func (ac AgentConfig) IterationDuration() (time.Duration, error) {
 	return d, nil
 }
 
+// IterationNightDuration returns the parsed night iteration period, falling
+// back to IterationDuration when iteration_night is unset.
+func (ac AgentConfig) IterationNightDuration() (time.Duration, error) {
+	if ac.IterationNight == "" {
+		return ac.IterationDuration()
+	}
+	d, err := time.ParseDuration(ac.IterationNight)
+	if err != nil {
+		return 0, fmt.Errorf("invalid iteration_night %q: %w (expected Go duration like 30s, 1m30s, 2h)", ac.IterationNight, err)
+	}
+	if d < time.Second {
+		return 0, fmt.Errorf("iteration_night %q is too small (minimum 1s)", ac.IterationNight)
+	}
+	return d, nil
+}
+
 // ProviderEnv returns env vars that should be exported for this agent based on
 // its provider selection. These are merged into /home/<user>/.env alongside
 // vault secrets at provision time.
@@ -540,6 +562,9 @@ func Load(path string) (*Config, error) {
 			return nil, fmt.Errorf("agent %s: model %q must match %s (rendered into a quoted shell argument in runner.sh)", key, ac.Model, modelRe.String())
 		}
 		if _, err := ac.IterationDuration(); err != nil {
+			return nil, fmt.Errorf("agent %s: %w", key, err)
+		}
+		if _, err := ac.IterationNightDuration(); err != nil {
 			return nil, fmt.Errorf("agent %s: %w", key, err)
 		}
 		if _, err := ac.ProviderEnv(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func writeYAML(t *testing.T, content string) string {
@@ -1996,5 +1997,49 @@ agents:
 		if _, err := Load(path); err == nil {
 			t.Errorf("Load should have rejected skills_repo=%q", bad)
 		}
+	}
+}
+
+func TestIterationNightDuration_FallsBackToIteration(t *testing.T) {
+	ac := AgentConfig{Iteration: "7m"}
+	d, err := ac.IterationNightDuration()
+	if err != nil || d != 7*time.Minute {
+		t.Errorf("expected 7m fallback, got %v err=%v", d, err)
+	}
+	ac = AgentConfig{} // both unset -> 5m default
+	d, err = ac.IterationNightDuration()
+	if err != nil || d != 5*time.Minute {
+		t.Errorf("expected 5m default, got %v err=%v", d, err)
+	}
+}
+
+func TestIterationNightDuration_ParsesAndValidates(t *testing.T) {
+	ac := AgentConfig{Iteration: "4m", IterationNight: "30m"}
+	d, err := ac.IterationNightDuration()
+	if err != nil || d != 30*time.Minute {
+		t.Errorf("expected 30m, got %v err=%v", d, err)
+	}
+	for _, bad := range []string{"banana", "500ms"} {
+		ac.IterationNight = bad
+		if _, err := ac.IterationNightDuration(); err == nil {
+			t.Errorf("iteration_night %q should error", bad)
+		}
+	}
+}
+
+func TestLoad_RejectsInvalidIterationNight(t *testing.T) {
+	yaml := `
+project: t
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g", alerts: "a"}
+agents:
+  lead:
+    name: "Lead"
+    iteration_night: "nope"
+`
+	if _, err := Load(writeYAML(t, yaml)); err == nil || !strings.Contains(err.Error(), "iteration_night") {
+		t.Errorf("expected iteration_night validation error, got %v", err)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -126,6 +126,7 @@ MAX_LESSONS_MESSAGES=25
 while true; do
     START=$(date +%s)
     PROMPT='{{.Prompt}}'
+    RUNNER_WARNINGS=""
 
     # Guard: CLAUDE.local.md too large (token waste)
     if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
@@ -141,6 +142,58 @@ while true; do
     "$CLAUDE" install 2>&1 | tail -5 | tee -a "$LOGFILE" || log "claude install failed, continuing with current version"
 
     {{.SkillsSyncCmd}}
+
+    # Surface a near-expired OAuth token to the agent itself: a dead token
+    # mid-session shows up as opaque 401/407 API errors otherwise.
+    EXP_MS=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.claude/.credentials.json'))).get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo 0)
+    NOW_MS=$(( $(date +%s) * 1000 ))
+    if [ "$EXP_MS" -gt 0 ] 2>/dev/null && [ "$EXP_MS" -lt $(( NOW_MS + 3600000 )) ]; then
+        log "WARNING: OAuth token expires within 1h (or already expired)"
+        RUNNER_WARNINGS="${RUNNER_WARNINGS}[runner] Your OAuth token expires within 1h or is already expired; if you hit 401/407 API errors, escalate to the alerts channel. "
+    fi
+
+    # Per-agent quota snapshot (TTL 25m). Agents read this file instead of
+    # polling the OAuth usage endpoint every iteration, which rate-limits
+    # (429) when multiple agents on one host poll per-session.
+    QUOTA_FILE="$HOME/.claude/quota.json"
+    QUOTA_AGE=$(( $(date +%s) - $(stat -c %Y "$QUOTA_FILE" 2>/dev/null || echo 0) ))
+    if [ "$QUOTA_AGE" -gt 1500 ]; then
+        OAUTH_TOKEN=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.claude/.credentials.json')))['claudeAiOauth']['accessToken'])" 2>/dev/null)
+        if [ -n "$OAUTH_TOKEN" ]; then
+            HTTP_CODE=$(curl -sS -m 15 -o "$QUOTA_FILE.tmp" -w "%{http_code}" \
+                -H "Authorization: Bearer $OAUTH_TOKEN" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                https://api.anthropic.com/api/oauth/usage 2>>"$LOGFILE")
+            if [ "$HTTP_CODE" = "200" ]; then
+                mv "$QUOTA_FILE.tmp" "$QUOTA_FILE"
+                log "Quota snapshot refreshed"
+            else
+                rm -f "$QUOTA_FILE.tmp"
+                log "Quota snapshot fetch failed (HTTP ${HTTP_CODE}); keeping previous snapshot"
+            fi
+            unset OAUTH_TOKEN
+        fi
+    fi
+
+    # Per-iteration effort override: the agent writes low|medium|high|xhigh
+    # to ~/.claude/next-effort during an iteration; consumed (and deleted)
+    # here. CLAUDE_CODE_EFFORT_LEVEL is session-scoped and outranks settings
+    # files, so an absent file simply means settings.json effortLevel
+    # applies — no reset bookkeeping, no drift across iterations.
+    unset CLAUDE_CODE_EFFORT_LEVEL
+    if [ -f "$HOME/.claude/next-effort" ]; then
+        NEXT_EFFORT=$(tr -cd 'a-z' < "$HOME/.claude/next-effort" | head -c 16)
+        rm -f "$HOME/.claude/next-effort"
+        case "$NEXT_EFFORT" in
+            low|medium|high|xhigh)
+                export CLAUDE_CODE_EFFORT_LEVEL="$NEXT_EFFORT"
+                log "Effort override for this session: $NEXT_EFFORT" ;;
+            *)
+                log "Ignoring invalid next-effort value: $NEXT_EFFORT" ;;
+        esac
+    fi
+
+    [ -n "$RUNNER_WARNINGS" ] && PROMPT="${RUNNER_WARNINGS}${PROMPT}"
 
     log "Starting {{.AgentName}} (fresh session)"
     (sleep 1 && tmux send-keys -t {{.AgentKey}} "" Enter
@@ -254,6 +307,7 @@ MAX_LESSONS_MESSAGES=25
 while true; do
     START=$(date +%s)
     PROMPT='{{.Prompt}}'
+    RUNNER_WARNINGS=""
 
     # Guard: CLAUDE.local.md too large (token waste)
     if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
@@ -266,6 +320,8 @@ while true; do
     fi
 
     {{.SkillsSyncCmd}}
+
+    [ -n "$RUNNER_WARNINGS" ] && PROMPT="${RUNNER_WARNINGS}${PROMPT}"
 
     log "Starting {{.AgentName}} (opencode, fresh session)"
     MODEL_ARG=""
@@ -418,6 +474,8 @@ func Generate(cfg *config.Config, agentKey string) string {
 	ac := cfg.Agents[agentKey]
 	iterDur, _ := ac.IterationDuration() // validated at load time
 	iterSec := int(iterDur.Seconds())
+	nightDur, _ := ac.IterationNightDuration() // validated at load time
+	nightSec := int(nightDur.Seconds())
 
 	// Render {{agent.name}}, {{channels.*}}, etc. in the operator-authored
 	// prompt the same way CLAUDE.local.md is rendered. Without this, agents
@@ -447,8 +505,17 @@ func Generate(cfg *config.Config, agentKey string) string {
 	}
 	skillsSyncCmd := ""
 	if cfg.SkillsRepo != "" {
+		// PIPESTATUS, not ||: without pipefail, `sync | tee || log` reacts to
+		// tee's exit status, so sync failures were silently swallowed (bit a
+		// production host for 3 weeks: a dirty clone blocked every pull and
+		// the "skills sync failed" branch never fired). The warning is also
+		// prepended to the agent's prompt so the agent itself escalates.
 		skillsSyncCmd = fmt.Sprintf(
-			`clem sync-skills --home "$HOME" --agent-key %q --repo %q 2>&1 | tee -a "$LOGFILE" || log "skills sync failed"`,
+			`clem sync-skills --home "$HOME" --agent-key %q --repo %q 2>&1 | tee -a "$LOGFILE"
+    if [ "${PIPESTATUS[0]}" != "0" ]; then
+        log "skills sync failed"
+        RUNNER_WARNINGS="${RUNNER_WARNINGS}[runner] Skills sync FAILED this iteration; your skills may be stale. Check ~/.cache for a dirty clone or auth failure, fix or escalate to the alerts channel. "
+    fi`,
 			agentKey, cfg.SkillsRepo,
 		)
 	}
@@ -462,12 +529,12 @@ func Generate(cfg *config.Config, agentKey string) string {
 		OSUser:         cfg.OSUsername(agentKey),
 		HomeDir:        fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
 		SleepActive:    iterSec,
-		// Night sleep matches active. The previous 2x doubler hurt spend:
-		// Anthropic's prompt cache TTL is 5 min, so any iter > 5m at night
-		// guaranteed a cache miss every session — same session count cut
-		// you'd get from cold-cache cost increase. Match active to keep cache
-		// hot, or override per-iteration in clem.yaml directly.
-		SleepNight:      iterSec,
+		// Night sleep defaults to the active value; iteration_night overrides.
+		// History: a hardcoded 2x night doubler was removed on the belief the
+		// prompt-cache TTL was 5 min. Subscription Claude Code actually gets
+		// the 1h TTL, refreshed on access (verified against session-log usage
+		// fields, 2026-06-13), so night intervals up to ~45m still start warm.
+		SleepNight:      nightSec,
 		AlertChannel:    alertChannel,
 		AlertCurl:       alertCurl,
 		WatchChannelIDs: discordWatchChannels(cfg),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -768,3 +768,59 @@ func TestGenerate_SkillsSyncAbsentWhenRepoUnset(t *testing.T) {
 		t.Errorf("runner should not invoke sync-skills when SkillsRepo unset; got:\n%s", out)
 	}
 }
+
+func TestGenerate_NightSleepDefaultsToIteration(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{Name: "L", Iteration: "10m", Prompt: "p"})
+	out := Generate(cfg, "lead")
+	if !strings.Contains(out, "SLEEP_ACTIVE=600") || !strings.Contains(out, "SLEEP_NIGHT=600") {
+		t.Errorf("expected both sleeps 600, got:\n%s", out)
+	}
+}
+
+func TestGenerate_NightSleepFromIterationNight(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{Name: "L", Iteration: "10m", IterationNight: "30m", Prompt: "p"})
+	out := Generate(cfg, "lead")
+	if !strings.Contains(out, "SLEEP_ACTIVE=600") || !strings.Contains(out, "SLEEP_NIGHT=1800") {
+		t.Errorf("expected active 600 night 1800, got:\n%s", out)
+	}
+}
+
+func TestGenerate_NextEffortAndQuotaBlocks(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{Name: "L", Iteration: "1m", Prompt: "p"})
+	out := Generate(cfg, "lead")
+	for _, want := range []string{
+		`if [ -f "$HOME/.claude/next-effort" ]`,
+		`export CLAUDE_CODE_EFFORT_LEVEL="$NEXT_EFFORT"`,
+		"unset CLAUDE_CODE_EFFORT_LEVEL",
+		`QUOTA_FILE="$HOME/.claude/quota.json"`,
+		"api.anthropic.com/api/oauth/usage",
+		`PROMPT="${RUNNER_WARNINGS}${PROMPT}"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in claude runner", want)
+		}
+	}
+	// opencode runtime gets warnings prepend but no effort/quota machinery
+	cfg = baseCfg("lead", config.AgentConfig{Name: "L", Iteration: "1m", Prompt: "p", Runtime: "opencode"})
+	out = Generate(cfg, "lead")
+	if strings.Contains(out, "next-effort") || strings.Contains(out, "QUOTA_FILE") {
+		t.Errorf("opencode runner should not contain effort/quota blocks")
+	}
+	if !strings.Contains(out, `PROMPT="${RUNNER_WARNINGS}${PROMPT}"`) {
+		t.Errorf("opencode runner missing warnings prepend")
+	}
+}
+
+func TestGenerate_SkillsSyncFailureUsesPipestatusAndWarns(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{Name: "L", Iteration: "1m", Prompt: "p"})
+	cfg.SkillsRepo = "https://example.com/skills"
+	out := Generate(cfg, "lead")
+	for _, want := range []string{
+		`if [ "${PIPESTATUS[0]}" != "0" ]`,
+		"Skills sync FAILED this iteration",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in runner with skills repo", want)
+		}
+	}
+}


### PR DESCRIPTION
Four runner/config features driven by a production cache+quota audit
(2026-06-13, consultant.dev team host):

- iteration_night: separate night-hours (22-07) sleep. The hardcoded
  night doubler was removed when the prompt-cache TTL was believed to be
  5 min; subscription Claude Code actually gets the 1h TTL refreshed on
  access (verified from session-log usage fields), so night intervals up
  to ~45m still start warm. Default: match iteration.
- next-effort handshake: agent writes low|medium|high|xhigh to
  ~/.claude/next-effort; runner validates, exports session-scoped
  CLAUDE_CODE_EFFORT_LEVEL for the next launch, deletes the file. No
  reset bookkeeping, no drift.
- runner warnings: sync-skills failures and <1h-to-expiry OAuth tokens
  are prepended to the injected prompt so the agent itself escalates.
  Also fixes sync-skills failure detection: 'sync | tee || log' tested
  tee's exit status (no pipefail), so failures never logged -- a dirty
  clone silently blocked one production agent's skill sync for 3 weeks.
  Now uses PIPESTATUS[0].
- quota snapshot: runner refreshes ~/.claude/quota.json from the OAuth
  usage endpoint at most every 25m; agents read the file instead of
  polling per-iteration (which 429s with multiple agents per host).

claude-code runtime gets all four; opencode gets the warnings prepend
plus the sync-skills fix (effort/quota are Claude-specific).
