### PR TITLE
feat(quality): closed-loop quality gates for agent fleets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ What sets it apart: **secrets and egress are contained at the OS layer, not by t
 | **Self-healing** | systemd + tmux per agent. Watchdog timer restarts dead or stalled sessions. Alerts fire only after repeated failures. |
 | **Bring your own model** | Default Claude; one flag away from Ollama Cloud / Bedrock / Vertex / local models. Tested end-to-end on local Gemma 4 (E4B QAT via Ollama). |
 | **Live ops** | `clem status` shows health per agent. Optional ttyd web terminal per agent - attach in your browser. |
+| **Quality gates** | Optional closed feedback loop: deterministic build/test/lint/BDD checks after each session, with per-agent suites and fleet metrics. See [docs/quality-gates.md](docs/quality-gates.md). |
 | **Works locally** | Laptop, home server, Raspberry Pi, small VPS. No Kubernetes. No cloud services required. |
 
 ---
@@ -432,6 +433,16 @@ Derived names:
 - Systemd service: `clem-<project>-<agentkey>.service`
 - GitHub issue watcher: `clem-github-watch-<project>-<agentkey>.service` (github backend only)
 - Web terminal: `clem-ttyd-<project>-<agentkey>.service`
+
+**Quality gates** (optional, `quality.enabled: true`):
+
+Deterministic checks run automatically after each agent session. Failures feed back
+into the next iteration via `CLAUDE.local.md`; successes clear the feedback
+block. Supports fleet-wide baseline gates, agent-restricted gates, inline
+per-agent gates, and Gherkin/BDD acceptance specs.
+
+→ Full workflow, configuration, and fleet suite model: **[docs/quality-gates.md](docs/quality-gates.md)**.
+Samples: [`samples/quality-go/`](samples/quality-go/) · [`samples/quality-bdd/`](samples/quality-bdd/)
 
 ---
 

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jahwag/clem/internal/config"
 	"github.com/jahwag/clem/internal/githubwatch"
 	"github.com/jahwag/clem/internal/proxy"
+	"github.com/jahwag/clem/internal/quality"
 	"github.com/jahwag/clem/internal/remote"
 	"github.com/jahwag/clem/internal/runner"
 	"github.com/jahwag/clem/internal/vault"
@@ -201,6 +202,21 @@ func provisionAgent(agentKey string, ac config.AgentConfig) error {
 		if err := agent.EnsureOwnedDir(d, osUser); err != nil {
 			return fmt.Errorf("ensuring %s: %w", d, err)
 		}
+	}
+	if cfg.Quality != nil && cfg.Quality.Enabled {
+		clemDir := filepath.Join(homeDir, ".clem")
+		if err := agent.EnsureOwnedDir(clemDir, osUser); err != nil {
+			return fmt.Errorf("ensuring %s: %w", clemDir, err)
+		}
+		rc, err := cfg.RuntimeQualityForAgent(agentKey)
+		if err != nil {
+			return fmt.Errorf("quality config for %s: %w", agentKey, err)
+		}
+		if err := quality.WriteRuntimeConfig(homeDir, rc); err != nil {
+			return fmt.Errorf("writing quality config for %s: %w", agentKey, err)
+		}
+		chownDir(filepath.Join(homeDir, ".clem", "quality.json"), osUser)
+		fmt.Printf("  wrote %s/.clem/quality.json\n", homeDir)
 	}
 	content, mode, err := agentdoc.Render(cfg, agentKey, ".")
 	if err != nil {

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -62,6 +62,14 @@ func runProvision(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Provisioning project: %s\n", cfg.Project)
 
+	// Install the clem binary onto the host PATH (/usr/local/bin) before the
+	// agent loop: the runner template and the git pre-push hook invoke clem by
+	// absolute path, and the agent OS user's PATH is not guaranteed to contain
+	// the operator's clem location. Mirrors the trusted-tool install pattern.
+	if err := agent.InstallClem(); err != nil {
+		return err
+	}
+
 	// Phase 2: stand up the agent-vault credential proxy before the agent loop
 	// so per-agent tokens can be minted inside it. No-op unless backend active.
 	if cfg.Vault.IsAgentVault() {

--- a/cmd/quality.go
+++ b/cmd/quality.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jahwag/clem/internal/quality"
+	"github.com/spf13/cobra"
+)
+
+var qualityCmd = &cobra.Command{
+	Use:   "quality",
+	Short: "Quality gate metrics and runner-side execution",
+	RunE:  runQualitySummary,
+}
+
+var qualityRunCmd = &cobra.Command{
+	Use:    "run",
+	Short:  "Run quality suite after an agent session (runner-side)",
+	Hidden: true,
+	RunE:   runQualityRun,
+}
+
+var qualityPrePushCmd = &cobra.Command{
+	Use:    "pre-push",
+	Short:  "Run block-push quality gates (pre-push hook)",
+	Hidden: true,
+	RunE:   runQualityPrePush,
+}
+
+func init() {
+	qualityRunCmd.Flags().String("home", "", "agent home directory")
+	qualityRunCmd.Flags().String("workdir", "", "agent work directory (project checkout)")
+	qualityPrePushCmd.Flags().String("home", "", "agent home directory")
+	qualityPrePushCmd.Flags().String("workdir", "", "agent work directory")
+
+	qualityCmd.AddCommand(qualityRunCmd)
+	qualityCmd.AddCommand(qualityPrePushCmd)
+	rootCmd.AddCommand(qualityCmd)
+}
+
+func runQualityRun(cmd *cobra.Command, args []string) error {
+	code, err := executeQualityRun(cmd)
+	if err != nil {
+		return err
+	}
+	os.Exit(code)
+	return nil
+}
+
+func executeQualityRun(cmd *cobra.Command) (int, error) {
+	home, _ := cmd.Flags().GetString("home")
+	workdir, _ := cmd.Flags().GetString("workdir")
+	if home == "" || workdir == "" {
+		return 1, fmt.Errorf("quality run requires --home and --workdir")
+	}
+	rc, err := quality.LoadRuntimeConfig(home)
+	if err != nil {
+		return 1, err
+	}
+	code, err := quality.RunIteration(home, workdir, rc)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	return code, nil
+}
+
+func runQualityPrePush(cmd *cobra.Command, args []string) error {
+	home, _ := cmd.Flags().GetString("home")
+	workdir, _ := cmd.Flags().GetString("workdir")
+	if home == "" {
+		return fmt.Errorf("quality pre-push requires --home")
+	}
+	rc, err := quality.LoadRuntimeConfig(home)
+	if err != nil {
+		return err
+	}
+	if workdir == "" {
+		workdir = filepath.Join(home, rc.Project)
+	}
+	if err := quality.RunPrePush(home, workdir, rc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runQualitySummary(cmd *cobra.Command, args []string) error {
+	if cfg.Quality == nil || !cfg.Quality.Enabled {
+		fmt.Println("quality gates disabled in config")
+		return nil
+	}
+	keys := make([]string, 0, len(cfg.Agents))
+	for k := range cfg.Agents {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	fmt.Printf("%-10s %-8s %-12s %-10s %s\n", "AGENT", "LAST", "GATES", "ATTEMPT", "PASS RATE")
+	fmt.Println(strings.Repeat("-", 60))
+	for _, key := range keys {
+		home := fmt.Sprintf("/home/%s", cfg.OSUsername(key))
+		sum, err := quality.ReadAgentSummary(home, key)
+		if err != nil {
+			return err
+		}
+		if sum.GatesTotal == 0 {
+			fmt.Printf("%-10s %-8s %-12s %-10d %s\n", key, "-", "-", 0, "-")
+			continue
+		}
+		last := "FAIL"
+		if sum.LastPass {
+			last = "PASS"
+		}
+		gates := fmt.Sprintf("%d/%d", sum.GatesPass, sum.GatesTotal)
+		rate := fmt.Sprintf("%.0f%%", sum.PassRate*100)
+		fmt.Printf("%-10s %-8s %-12s %-10d %s\n", key, last, gates, sum.LastAttempt, rate)
+	}
+
+	fmt.Println()
+	for _, key := range keys {
+		home := fmt.Sprintf("/home/%s", cfg.OSUsername(key))
+		stats, err := quality.AggregateGateStats(home, key)
+		if err != nil {
+			return err
+		}
+		if len(stats) == 0 {
+			continue
+		}
+		sort.Slice(stats, func(i, j int) bool { return stats[i].Name < stats[j].Name })
+		fmt.Printf("Agent %s gate stats:\n", key)
+		for _, st := range stats {
+			fmt.Printf("  %-12s runs=%-4d pass=%.0f%% avg=%dms\n", st.Name, st.Runs, st.PassRate*100, st.AvgMS)
+		}
+		fmt.Println()
+	}
+	return nil
+}

--- a/cmd/quality_test.go
+++ b/cmd/quality_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jahwag/clem/internal/quality"
+	"github.com/spf13/cobra"
+)
+
+func TestExecuteQualityRun_ClosedLoop(t *testing.T) {
+	home := t.TempDir()
+	work := filepath.Join(home, "demo")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "CLAUDE.local.md"), []byte("# ctx\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rc := quality.RuntimeConfig{
+		Enabled:     true,
+		OnFailure:   "feedback",
+		MaxAttempts: 3,
+		AgentKey:    "lead",
+		Project:     "demo",
+		Gates: []quality.Gate{
+			{Name: "unit", Level: "unit", Cmd: "test -f .quality_ok", Blocking: true},
+		},
+	}
+	if err := quality.WriteRuntimeConfig(home, rc); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("home", home, "")
+	cmd.Flags().String("workdir", work, "")
+	if err := cmd.Flags().Set("home", home); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("workdir", work); err != nil {
+		t.Fatal(err)
+	}
+
+	code, err := executeQualityRun(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 1 {
+		t.Fatalf("fail without marker: code=%d", code)
+	}
+
+	if err := os.WriteFile(filepath.Join(work, ".quality_ok"), []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	code, err = executeQualityRun(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("pass with marker: code=%d", code)
+	}
+}
+
+func TestLoadConfigSkipsQualitySubcommands(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(prev) }()
+
+	qualityParent := &cobra.Command{Use: "quality"}
+	if err := loadConfig(qualityParent, nil); err != nil {
+		t.Errorf("loadConfig(quality): %v", err)
+	}
+	for _, name := range []string{"run", "pre-push"} {
+		sub := &cobra.Command{Use: name}
+		qualityParent.AddCommand(sub)
+		if err := loadConfig(sub, nil); err != nil {
+			t.Errorf("loadConfig(quality %s): %v", name, err)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,13 @@ func loadConfig(cmd *cobra.Command, args []string) error {
 	if cmd.Name() == "sync-skills" {
 		return nil
 	}
+	// quality run/pre-push runs as the agent user with runtime config in ~/.clem/
+	if cmd.Name() == "quality" {
+		return nil
+	}
+	if cmd.Parent() != nil && cmd.Parent().Name() == "quality" {
+		return nil
+	}
 
 	var err error
 	cfg, err = config.Load(configPath)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jahwag/clem/internal/agent"
+	"github.com/jahwag/clem/internal/quality"
 	"github.com/spf13/cobra"
 )
 
@@ -29,9 +30,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	sort.Strings(keys)
 
 	// Header
-	fmt.Printf("%-10s %-20s %-20s %-8s %-8s %-8s %-20s %s\n",
-		"AGENT", "NAME", "USER", "SYSTEMD", "TMUX", "TTYD", "TOKEN EXPIRES", "LAST LOG")
-	fmt.Println(strings.Repeat("-", 120))
+	fmt.Printf("%-10s %-20s %-20s %-8s %-8s %-8s %-10s %-20s %s\n",
+		"AGENT", "NAME", "USER", "SYSTEMD", "TMUX", "TTYD", "QUALITY", "TOKEN EXPIRES", "LAST LOG")
+	fmt.Println(strings.Repeat("-", 130))
 
 	for _, agentKey := range keys {
 		ac := cfg.Agents[agentKey]
@@ -62,8 +63,20 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		logPath := fmt.Sprintf("/home/%s/.claude/%s-runner.log", osUser, agentKey)
 		lastLog := agent.LastLogLine(logPath)
 
-		fmt.Printf("%-10s %-20s %-20s %-8s %-8s %-8s %-20s %s\n",
-			agentKey, ac.Name, osUser, systemdState, tmuxAlive, ttydStr, expiryStr, lastLog)
+		qualityStr := "-"
+		if cfg.Quality != nil && cfg.Quality.Enabled {
+			sum, err := quality.ReadAgentSummary(homeDir, agentKey)
+			if err == nil && sum.GatesTotal > 0 {
+				if sum.LastPass {
+					qualityStr = fmt.Sprintf("✅ %d/%d", sum.GatesPass, sum.GatesTotal)
+				} else {
+					qualityStr = fmt.Sprintf("❌ %d/%d", sum.GatesPass, sum.GatesTotal)
+				}
+			}
+		}
+
+		fmt.Printf("%-10s %-20s %-20s %-8s %-8s %-8s %-10s %-20s %s\n",
+			agentKey, ac.Name, osUser, systemdState, tmuxAlive, ttydStr, qualityStr, expiryStr, lastLog)
 	}
 	return nil
 }

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,0 +1,283 @@
+# Quality gates — closed feedback loop
+
+clem quality gates turn **deterministic checks** into a **closed feedback loop**
+for agent fleets. You declare what “correct” means for your project; after each
+agent session the runner executes those checks and feeds structured failures back
+into the next iteration — before broken work reaches CI or a PR.
+
+`quality.enabled: false` (default) preserves today’s behaviour exactly.
+
+---
+
+## Why quality gates?
+
+Agent fleets are good at producing code quickly, but non-deterministic LLM output
+needs an objective arbiter. Quality gates provide that arbiter **locally and
+iteratively**:
+
+| Benefit | What it means in practice |
+|---------|---------------------------|
+| **Faster convergence** | Agents fix failing tests/lint/BDD scenarios in the next iteration instead of waiting for CI |
+| **Lower CI noise** | Fewer red builds and review cycles on obvious failures |
+| **Token discipline** | Feedback replaces a delimited block in `CLAUDE.local.md` each iteration — it does not accumulate |
+| **Fleet observability** | Per-agent JSONL metrics, `clem quality`, and the QUALITY column in `clem status` |
+| **Extensible checks** | Shell commands today; Gherkin/BDD (`kind: bdd`) for living acceptance specs |
+| **Zero regression default** | Disabled unless explicitly enabled in `clem.yaml` |
+
+Gates are a **local pre-filter**. GitHub/GitLab CI remains the merge authority.
+
+---
+
+## End-to-end workflow
+
+Each agent in the fleet runs inside `clem-runner.sh`. When quality gates are
+enabled and provisioned, every session follows this loop:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  1. START ITERATION                                             │
+│     Runner loads prior feedback from ~/.clem/quality-feedback.txt│
+│     → prepended to the agent prompt as RUNNER_WARNINGS          │
+│     → injected block in CLAUDE.local.md (delimited markers)     │
+└────────────────────────────┬────────────────────────────────────┘
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  2. AGENT SESSION                                               │
+│     Claude Code / opencode works on the task in $WORKDIR        │
+└────────────────────────────┬────────────────────────────────────┘
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  3. POST-SESSION GATES  (clem quality run)                      │
+│     Read ~/.clem/quality.json (provisioned per agent)           │
+│     Run agent's gate suite in order (fail-fast on blocking gates)│
+│     Append results to ~/.clem/<agent>-quality.jsonl             │
+└────────────────────────────┬────────────────────────────────────┘
+                             ▼
+                    ┌────────┴────────┐
+                    │  All gates pass? │
+                    └────────┬────────┘
+                  yes │               │ no
+                      ▼               ▼
+              Clear feedback    Format verdict
+              Reset attempts    Write quality-feedback.txt
+              exit 0            Inject CLAUDE.local.md block
+                                Increment attempt counter
+                                exit 1 (retry next iteration)
+                                      │
+                                      ▼
+                                max_attempts reached?
+                                      │
+                              yes ──► mark task BLOCKED
+                                      alert coordination channel
+                                      exit 2
+```
+
+### What the agent sees on failure
+
+Feedback is structured and gate-specific. For command gates, stdout/stderr
+(truncated) is included. For BDD gates, Feature/Scenario lines are extracted so
+Gherkin remains the source of truth:
+
+```
+[quality] Quality gates failed (attempt 2/3)
+
+Gate: unit (level: unit)
+Exit: 1
+Output:
+--- FAIL: TestHandler (0.01s)
+    handler_test.go:42: expected 200 got 500
+```
+
+On pass, the feedback file is removed and the delimited block is stripped from
+`CLAUDE.local.md` entirely.
+
+---
+
+## Fleet integration
+
+Quality gates are **per-agent**, provisioned at `clem provision` time:
+
+| Artifact | Path | Purpose |
+|----------|------|---------|
+| Runtime config | `~/.clem/quality.json` | Gate suite, on_failure mode, max_attempts |
+| Feedback | `~/.clem/quality-feedback.txt` | Runner reads before next session |
+| State | `~/.clem/quality-state.json` | Attempt counter, blocked flag, task ID |
+| Metrics | `~/.clem/<agent>-quality.jsonl` | One JSON line per gate result |
+| Task binding | `~/.clem/current-task-id` | Resets attempts when task changes |
+
+The runner hook (in `~/bin/clem-runner.sh`) runs automatically — no agent
+cooperation required:
+
+```bash
+# After each session:
+clem quality run --home "$HOME" --workdir "$WORKDIR"
+
+# Before each session:
+# feedback loaded from ~/.clem/quality-feedback.txt into prompt
+```
+
+Pre-push (`clem quality pre-push`) runs only when `on_failure: block-push` is
+configured, as Pass 5 of the git pre-push hook installed by `clem provision`.
+
+---
+
+## Gate layers: general + agent-specific
+
+Gates can be shared across the fleet or scoped to individual agents.
+
+| Layer | Where defined | Who runs it (default suite) |
+|-------|---------------|----------------------------|
+| **Baseline** | `quality.baseline_suite` or gates without `agents:` | Every agent |
+| **Agent-restricted** | `quality.gates[].agents: [lead]` | Only listed agents |
+| **Inline** | `agents.<key>.quality_gates` | Only that agent |
+
+### Default suite (no `quality_suite`)
+
+When an agent has no `quality_suite`, clem resolves:
+
+1. **Baseline** — gates in `baseline_suite`, or (if unset) all global gates with no `agents:` restriction, sorted by level
+2. **Agent-restricted global gates** — gates whose `agents:` includes this agent
+3. **Inline gates** — `quality_gates` on the agent
+
+Agent-restricted gates in the global catalog are **not** run by other agents.
+
+### Explicit suite
+
+```yaml
+quality_suite: [build, unit]
+```
+
+Runs **only** those gates, in that order. Each gate must exist and be allowed
+for the agent.
+
+### Inherit + extras
+
+Extend the default suite:
+
+```yaml
+quality_suite: [+lint]              # baseline + lint
+quality_suite: [inherit, +acceptance]
+```
+
+---
+
+## Configuration reference
+
+### Top-level `quality` block
+
+```yaml
+quality:
+  enabled: true                      # default: false
+  on_failure: feedback               # feedback | block-push | advisory
+  max_attempts: 3                    # closed-loop retries before BLOCKED
+  baseline_suite: [build, unit, lint]
+  gates:
+    - name: build
+      kind: command                  # default; explicit shell command
+      level: build
+      cmd: "go build ./..."
+      blocking: true                 # fail-fast; stops suite on failure
+      timeout: 120s                  # default 5m
+      retries: 0                     # re-run gate N times before failing
+    - name: acceptance
+      kind: bdd                      # living Gherkin specs
+      level: acceptance
+      specs: [features/]
+      runner: godog                  # godog | behave | cucumber
+      agents: [lead]                 # only lead runs by default
+      blocking: true
+      timeout: 600s
+```
+
+### `on_failure` modes
+
+| Mode | Iteration behaviour | Pre-push |
+|------|---------------------|----------|
+| `feedback` | Fail → write feedback → retry until pass or max_attempts → BLOCKED | No gate check |
+| `block-push` | Gates run but iteration is not blocked; metrics recorded | Blocking gates must pass to push |
+| `advisory` | Gates run; failures logged to JSONL only; no feedback loop | No gate check |
+
+### Per-agent overrides
+
+```yaml
+agents:
+  lead:
+    quality_suite: [+acceptance]     # default + extra gate
+    quality_gates:                   # agent-local gate definitions
+      - name: lead-smoke
+        level: custom
+        cmd: "./scripts/lead-smoke.sh"
+        blocking: true
+
+  reviewer:
+    quality_suite: [build, unit]     # explicit subset; no lint, no acceptance
+```
+
+### Gate kinds
+
+| `kind` | Use case |
+|--------|----------|
+| `command` | Any deterministic check: `go test`, `eslint`, `terraform validate`, custom scripts |
+| `bdd` | **Living Gherkin specs** — `features/*.feature` as executable acceptance tests |
+
+For BDD/SDD, stack cheap checks first:
+
+1. `build` / `typecheck` — compile sanity
+2. `unit` — fast regression
+3. `bdd` (`level: acceptance`) — behaviour from Gherkin via godog/behave/cucumber
+
+Override with an explicit `cmd` anytime you need a custom runner invocation.
+
+### Gate levels (canonical order)
+
+`build` → `typecheck` → `unit` → `integration` → `lint` → `acceptance` → `custom`
+
+When no explicit order is given, gates are sorted by level.
+
+---
+
+## Observability
+
+```bash
+# Per-agent summary from JSONL metrics
+clem quality
+
+# Fleet status including QUALITY column
+clem status
+```
+
+Example `clem quality` output:
+
+```
+AGENT      LAST     GATES        ATTEMPT    PASS RATE
+------------------------------------------------------------
+lead       PASS     3/3          0          85%
+reviewer   FAIL     1/2          2          60%
+```
+
+---
+
+## Getting started
+
+1. Add a `quality:` block to `clem.yaml` (see `samples/quality-go/` or
+   `samples/quality-bdd/`)
+2. Run `clem provision` — writes `~/.clem/quality.json` and updates runner hooks
+   for each agent
+3. Agents converge locally; CI validates before merge
+
+### Samples
+
+| Sample | Demonstrates |
+|--------|--------------|
+| [`samples/quality-go/`](../samples/quality-go/) | Command gates, baseline suite, agent-restricted integration gate |
+| [`samples/quality-bdd/`](../samples/quality-bdd/) | Gherkin acceptance gates with `kind: bdd` |
+
+---
+
+## Design notes
+
+- **Deterministic only** — gates are shell commands with exit-code semantics (0 = pass). No LLM-as-judge.
+- **Fail-fast** — blocking gate failure stops the suite; non-blocking failures are recorded but do not fail the run.
+- **Task-scoped attempts** — changing `~/.clem/current-task-id` resets the attempt counter.
+- **Timeout exit 124** — gates exceeding their timeout are reported as timeout failures.
+- **Provision required** — editing `clem.yaml` alone does not update running agents; re-provision to refresh runtime config.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -132,6 +132,40 @@ func EnsureSystemUser(username string) error {
 	return nil
 }
 
+// ClemBin is the absolute path the clem binary is installed to during
+// provision. The agent OS user's PATH is not guaranteed to contain the
+// operator's clem location, so the runner template and the pre-push hook
+// reference clem by this absolute path (mirroring how pipelock/agent-vault are
+// referenced). Installing here also lands clem on the agent user's PATH.
+const ClemBin = "/usr/local/bin/clem"
+
+// InstallClem copies the currently-running clem binary to ClemBin (mode 0755)
+// so the agent runner and the git pre-push hook — which invoke clem by absolute
+// path — find it regardless of the agent user's PATH. Mirrors the
+// install-to-/usr/local/bin pattern used for the other trusted tools, but the
+// source is our own executable (resolved through any symlink) rather than a
+// pinned download. Must run as root (provision already requires it) so the
+// destination is writable and world-executable for every agent user.
+func InstallClem() error {
+	src, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving running clem binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(src); err == nil {
+		src = resolved
+	}
+	// Already in place (e.g. clem was launched from ClemBin): nothing to do.
+	if resolved, err := filepath.EvalSymlinks(ClemBin); err == nil && resolved == src {
+		fmt.Printf("  clem already installed at %s\n", ClemBin)
+		return nil
+	}
+	fmt.Printf("  installing clem to %s\n", ClemBin)
+	if out, err := sys.Run("install", "-m", "0755", src, ClemBin); err != nil {
+		return fmt.Errorf("installing clem to %s: %w\n%s", ClemBin, err, out)
+	}
+	return nil
+}
+
 // PipelockVersion is the pinned pipelock release clem installs. Bump
 // deliberately; the binary is a security boundary (the egress firewall/DLP).
 const PipelockVersion = "v2.5.0"
@@ -624,15 +658,24 @@ while read local_ref local_sha remote_ref remote_sha; do
   fi
 done
 
-# Pass 5: quality gates (when provisioned with quality.enabled).
+# Pass 5: quality gates (when provisioned with quality.enabled). clem is
+# referenced by absolute path because the agent user's PATH is not guaranteed
+# to contain it. A 127 (binary missing) must NOT masquerade as a gate failure:
+# fail closed with a distinct message so the operator can fix the install,
+# mirroring how the other trusted tools are required by absolute path.
 if [ -f "$HOME/.clem/quality.json" ]; then
-  if ! clem quality pre-push --home "$HOME" 2>&1; then
+  CLEM_RC=0
+  %s quality pre-push --home "$HOME" 2>&1 || CLEM_RC=$?
+  if [ "$CLEM_RC" -eq 127 ]; then
+    echo "clem pre-push hook: push blocked - clem not found at %s (quality gates could not run)" >&2
+    exit 1
+  elif [ "$CLEM_RC" -ne 0 ]; then
     echo "clem pre-push hook: push blocked - quality gates failed" >&2
     exit 1
   fi
 fi
 exit 0
-`, PrePushAllowSecretMarker, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapBytesPattern, PrePushAllowSecretMarker)
+`, PrePushAllowSecretMarker, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapBytesPattern, PrePushAllowSecretMarker, ClemBin, ClemBin)
 
 // stripGitConfigKey removes every line of `content` whose leading text is
 // "\t<key> = ". Used to clear stale name/email entries before re-writing them

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -623,6 +623,14 @@ while read local_ref local_sha remote_ref remote_sha; do
     fi
   fi
 done
+
+# Pass 5: quality gates (when provisioned with quality.enabled).
+if [ -f "$HOME/.clem/quality.json" ]; then
+  if ! clem quality pre-push --home "$HOME" 2>&1; then
+    echo "clem pre-push hook: push blocked - quality gates failed" >&2
+    exit 1
+  fi
+fi
 exit 0
 `, PrePushAllowSecretMarker, SecretPatternRegex, SecretCodePatternRegex, UnicodeTrapBytesPattern, PrePushAllowSecretMarker)
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -140,6 +140,9 @@ func TestPrePushHookContent_IsExecutableBash(t *testing.T) {
 	if !strings.Contains(prePushHookContent, PrePushAllowSecretMarker) {
 		t.Errorf("pre-push hook should embed allow-marker %q so bash and Go agree on the bypass token", PrePushAllowSecretMarker)
 	}
+	if !strings.Contains(prePushHookContent, "clem quality pre-push") {
+		t.Error("pre-push hook should invoke quality pre-push when quality.json exists")
+	}
 	if !strings.Contains(prePushHookContent, `grep -E '^\+([^+]|$)'`) {
 		t.Error("pre-push hook should restrict secret-pattern scanning to ADDED diff lines (^+ excluding ^+++)")
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -143,8 +143,48 @@ func TestPrePushHookContent_IsExecutableBash(t *testing.T) {
 	if !strings.Contains(prePushHookContent, "clem quality pre-push") {
 		t.Error("pre-push hook should invoke quality pre-push when quality.json exists")
 	}
+	// clem must be invoked by absolute path: the agent OS user's PATH is not
+	// guaranteed to contain it (FIX 1). A bare `clem quality pre-push` would
+	// exit 127 and masquerade as a gate failure.
+	if !strings.Contains(prePushHookContent, ClemBin+" quality pre-push") {
+		t.Errorf("pre-push hook must invoke clem by absolute path %q", ClemBin)
+	}
+	if strings.Contains(prePushHookContent, "\n  clem quality pre-push") {
+		t.Error("pre-push hook must not invoke clem via bare PATH")
+	}
+	// A 127 (clem missing) must be distinguished from a genuine gate failure.
+	if !strings.Contains(prePushHookContent, `CLEM_RC" -eq 127`) {
+		t.Error("pre-push hook must distinguish rc 127 (clem missing) from a real gate failure")
+	}
+	if !strings.Contains(prePushHookContent, "clem not found at "+ClemBin) {
+		t.Error("pre-push hook should emit a distinct 'clem not found' message on rc 127, not the misleading 'quality gates failed'")
+	}
 	if !strings.Contains(prePushHookContent, `grep -E '^\+([^+]|$)'`) {
 		t.Error("pre-push hook should restrict secret-pattern scanning to ADDED diff lines (^+ excluding ^+++)")
+	}
+}
+
+// TestInstallClem_CopiesRunningBinaryToUsrLocalBin guards FIX 1: provision must
+// install the running clem binary onto the host PATH (/usr/local/bin/clem, mode
+// 0755) so the runner and pre-push hook find it by absolute path. Mirrors the
+// pipelock/agent-vault install assertions.
+func TestInstallClem_CopiesRunningBinaryToUsrLocalBin(t *testing.T) {
+	stub := withStub(t)
+	if err := InstallClem(); err != nil {
+		t.Fatalf("InstallClem: %v", err)
+	}
+	var found bool
+	for _, c := range stub.calls {
+		if c[0] == "install" {
+			found = true
+			// Expect: install -m 0755 <src> /usr/local/bin/clem
+			if len(c) < 5 || c[1] != "-m" || c[2] != "0755" || c[len(c)-1] != ClemBin {
+				t.Errorf("unexpected install invocation: %v", c)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected an `install` call placing clem at %s, got calls=%v", ClemBin, stub.calls)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,9 @@ type Config struct {
 	// The cache directory name is derived from the URL's last path segment
 	// (with .git stripped).
 	SkillsRepo string `yaml:"skills_repo"`
+	// Quality configures deterministic quality gates (test, lint, build, etc.).
+	// Disabled by default for zero regression.
+	Quality *QualityConfig `yaml:"quality"`
 	// Extra collects top-level keys not matched by any field above (the
 	// decoder is otherwise strict — see Load). Only "x-"-prefixed extension
 	// keys are accepted, as holders for shared YAML anchors (the
@@ -313,6 +316,12 @@ type AgentConfig struct {
 	// (e.g. CI runners on the same VPS) so one cannot starve the other.
 	// Empty fields are omitted from the generated unit — systemd defaults apply.
 	ResourceLimits ResourceLimits `yaml:"resource_limits"`
+	// QualitySuite selects gates for this agent. Empty = baseline + agent-specific
+	// gates. Use "inherit" or "+gate" entries to extend the default suite.
+	// An explicit list (no inherit/+) replaces the default entirely.
+	QualitySuite []string `yaml:"quality_suite"`
+	// QualityGates defines agent-local gates not shared with the fleet.
+	QualityGates []QualityGate `yaml:"quality_gates"`
 }
 
 // ResourceLimits maps directly to systemd cgroup directives. All fields
@@ -544,6 +553,11 @@ func Load(path string) (*Config, error) {
 	if cfg.SkillsRepo != "" && !isPlausibleGitURL(cfg.SkillsRepo) {
 		return nil, fmt.Errorf("skills_repo %q is not a recognized git URL (expected https://, git://, ssh://, or git@host:path)", cfg.SkillsRepo)
 	}
+	if cfg.Quality != nil {
+		if err := cfg.Quality.validate(); err != nil {
+			return nil, err
+		}
+	}
 	switch cfg.Egress.Posture {
 	case "", "strict", "balanced", "audit":
 		// valid
@@ -674,7 +688,22 @@ func Load(path string) (*Config, error) {
 		if err := ac.validateExtensions(key); err != nil {
 			return nil, err
 		}
+		if err := validateAgentQualitySuite(&cfg, key, ac.QualitySuite); err != nil {
+			return nil, err
+		}
+		if err := validateAgentQualityGates(&cfg, key, ac.QualityGates); err != nil {
+			return nil, err
+		}
 		cfg.Agents[key] = ac
+	}
+	if cfg.Quality != nil {
+		agentKeys := make(map[string]bool, len(cfg.Agents))
+		for key := range cfg.Agents {
+			agentKeys[key] = true
+		}
+		if err := cfg.Quality.validateAgents(agentKeys); err != nil {
+			return nil, err
+		}
 	}
 	if err := cfg.validateVaultServices(); err != nil {
 		return nil, err

--- a/internal/config/quality.go
+++ b/internal/config/quality.go
@@ -1,0 +1,449 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jahwag/clem/internal/quality"
+)
+
+// QualityConfig defines deterministic quality gates for agent output.
+type QualityConfig struct {
+	Enabled       bool          `yaml:"enabled"`
+	OnFailure     string        `yaml:"on_failure"`
+	MaxAttempts   int           `yaml:"max_attempts"`
+	BaselineSuite []string      `yaml:"baseline_suite"`
+	Gates         []QualityGate `yaml:"gates"`
+}
+
+// QualityGate is one deterministic check in the quality suite.
+//
+// kind:
+//   - command (default): run cmd verbatim — any deterministic check
+//   - bdd: living Gherkin specs (features/) executed as acceptance gates
+//
+// For kind=bdd, set specs to feature paths and optionally runner (godog,
+// behave, cucumber). cmd overrides the auto-resolved runner command.
+type QualityGate struct {
+	Name     string   `yaml:"name"`
+	Kind     string   `yaml:"kind"`
+	Level    string   `yaml:"level"`
+	Cmd      string   `yaml:"cmd"`
+	Specs    []string `yaml:"specs"`
+	Runner   string   `yaml:"runner"`
+	Blocking bool     `yaml:"blocking"`
+	Timeout  string   `yaml:"timeout"`
+	Retries  int      `yaml:"retries"`
+	// Agents restricts this gate to specific agent keys. Empty = any agent.
+	Agents []string `yaml:"agents"`
+}
+
+func (q *QualityConfig) validate() error {
+	if q == nil || !q.Enabled {
+		return nil
+	}
+	switch q.OnFailure {
+	case "", "feedback", "block-push", "advisory":
+	default:
+		return fmt.Errorf("quality.on_failure must be feedback, block-push, or advisory, got %q", q.OnFailure)
+	}
+	if q.MaxAttempts < 0 {
+		return fmt.Errorf("quality.max_attempts must be >= 0, got %d", q.MaxAttempts)
+	}
+	if len(q.Gates) == 0 {
+		return fmt.Errorf("quality.enabled is true but no gates are defined")
+	}
+	names := make(map[string]bool, len(q.Gates))
+	for i, g := range q.Gates {
+		if g.Name == "" {
+			return fmt.Errorf("quality.gates[%d]: name is required", i)
+		}
+		if names[g.Name] {
+			return fmt.Errorf("quality.gates: duplicate name %q", g.Name)
+		}
+		names[g.Name] = true
+		if !quality.ValidLevel(g.Level) {
+			return fmt.Errorf("quality.gates[%d] (%s): unknown level %q (valid: %s)", i, g.Name, g.Level, strings.Join(quality.LevelOrder, ", "))
+		}
+		if !quality.ValidKind(g.Kind) {
+			return fmt.Errorf("quality.gates[%d] (%s): unknown kind %q (valid: %s)", i, g.Name, g.Kind, strings.Join(quality.ValidKinds, ", "))
+		}
+		if _, err := g.ResolvedCmd(); err != nil {
+			return fmt.Errorf("quality.gates[%d] (%s): %w", i, g.Name, err)
+		}
+		if g.Runner != "" && g.KindOrDefault() == quality.KindBDD {
+			switch g.Runner {
+			case "godog", "behave", "cucumber":
+			default:
+				return fmt.Errorf("quality.gates[%d] (%s): bdd runner must be godog, behave, or cucumber, got %q", i, g.Name, g.Runner)
+			}
+		}
+		if g.Timeout != "" {
+			if _, err := time.ParseDuration(g.Timeout); err != nil {
+				return fmt.Errorf("quality.gates[%d] (%s): invalid timeout %q: %w", i, g.Name, g.Timeout, err)
+			}
+		}
+		if g.Retries < 0 {
+			return fmt.Errorf("quality.gates[%d] (%s): retries must be >= 0", i, g.Name)
+		}
+	}
+	for _, name := range q.BaselineSuite {
+		if !names[name] {
+			return fmt.Errorf("quality.baseline_suite references unknown gate %q", name)
+		}
+	}
+	return nil
+}
+
+func (q *QualityConfig) validateAgents(agentKeys map[string]bool) error {
+	if q == nil || !q.Enabled {
+		return nil
+	}
+	for i, g := range q.Gates {
+		for _, key := range g.Agents {
+			if !agentKeys[key] {
+				return fmt.Errorf("quality.gates[%d] (%s): agents references unknown agent %q", i, g.Name, key)
+			}
+		}
+	}
+	return nil
+}
+
+// OnFailureOrDefault returns the configured on_failure mode.
+func (q *QualityConfig) OnFailureOrDefault() string {
+	if q == nil || q.OnFailure == "" {
+		return "feedback"
+	}
+	return q.OnFailure
+}
+
+// MaxAttemptsOrDefault returns max closed-loop attempts.
+func (q *QualityConfig) MaxAttemptsOrDefault() int {
+	if q == nil || q.MaxAttempts == 0 {
+		return 3
+	}
+	return q.MaxAttempts
+}
+
+// GateByName returns a gate definition by name.
+func (q *QualityConfig) GateByName(name string) (QualityGate, bool) {
+	if q == nil {
+		return QualityGate{}, false
+	}
+	for _, g := range q.Gates {
+		if g.Name == name {
+			return g, true
+		}
+	}
+	return QualityGate{}, false
+}
+
+// SuiteForAgent resolves the ordered gate list for an agent key.
+//
+// Default (empty quality_suite): baseline gates + agent-restricted global gates
+// + inline quality_gates for that agent.
+//
+// Explicit quality_suite: exact gate list in order.
+//
+// Inherit mode (quality_suite contains "inherit" or "+name"): starts from the
+// default suite, then appends extra gate names.
+func (c *Config) SuiteForAgent(agentKey string) ([]quality.Gate, error) {
+	if c.Quality == nil || !c.Quality.Enabled {
+		return nil, nil
+	}
+	ac, ok := c.Agents[agentKey]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent %q", agentKey)
+	}
+	if len(ac.QualitySuite) == 0 {
+		return c.defaultSuiteForAgent(agentKey)
+	}
+	if suiteUsesInherit(ac.QualitySuite) {
+		return c.inheritSuiteForAgent(agentKey, ac.QualitySuite)
+	}
+	var selected []QualityGate
+	for _, name := range ac.QualitySuite {
+		g, ok := c.gateForAgent(agentKey, name)
+		if !ok {
+			return nil, fmt.Errorf("agent %s: quality_suite references unknown or disallowed gate %q", agentKey, name)
+		}
+		selected = append(selected, g)
+	}
+	return toRuntimeGates(selected), nil
+}
+
+func gateAllowedForAgent(g QualityGate, agentKey string) bool {
+	if len(g.Agents) == 0 {
+		return true
+	}
+	return slices.Contains(g.Agents, agentKey)
+}
+
+func (c *Config) gateForAgent(agentKey, name string) (QualityGate, bool) {
+	if c.Quality == nil {
+		return QualityGate{}, false
+	}
+	if g, ok := c.Quality.GateByName(name); ok && gateAllowedForAgent(g, agentKey) {
+		return g, true
+	}
+	ac, ok := c.Agents[agentKey]
+	if !ok {
+		return QualityGate{}, false
+	}
+	for _, g := range ac.QualityGates {
+		if g.Name == name {
+			return g, true
+		}
+	}
+	return QualityGate{}, false
+}
+
+func suiteUsesInherit(suite []string) bool {
+	for _, entry := range suite {
+		if entry == "inherit" || strings.HasPrefix(entry, "+") {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Config) defaultSuiteForAgent(agentKey string) ([]quality.Gate, error) {
+	selected, err := c.defaultSuiteGates(agentKey)
+	if err != nil {
+		return nil, err
+	}
+	return toRuntimeGates(selected), nil
+}
+
+func (c *Config) defaultSuiteGates(agentKey string) ([]QualityGate, error) {
+	ac := c.Agents[agentKey]
+	var ordered []QualityGate
+	seen := make(map[string]bool)
+	appendGate := func(g QualityGate) {
+		if seen[g.Name] {
+			return
+		}
+		seen[g.Name] = true
+		ordered = append(ordered, g)
+	}
+
+	if len(c.Quality.BaselineSuite) > 0 {
+		for _, name := range c.Quality.BaselineSuite {
+			g, ok := c.Quality.GateByName(name)
+			if !ok {
+				return nil, fmt.Errorf("quality.baseline_suite references unknown gate %q", name)
+			}
+			if !gateAllowedForAgent(g, agentKey) {
+				return nil, fmt.Errorf("agent %s: baseline gate %q is restricted to other agents", agentKey, name)
+			}
+			appendGate(g)
+		}
+	} else {
+		var unrestricted []QualityGate
+		for _, g := range c.Quality.Gates {
+			if len(g.Agents) == 0 {
+				unrestricted = append(unrestricted, g)
+			}
+		}
+		slices.SortFunc(unrestricted, func(a, b QualityGate) int {
+			if r := quality.LevelRank(a.Level) - quality.LevelRank(b.Level); r != 0 {
+				return r
+			}
+			return strings.Compare(a.Name, b.Name)
+		})
+		for _, g := range unrestricted {
+			appendGate(g)
+		}
+	}
+
+	var extras []QualityGate
+	for _, g := range c.Quality.Gates {
+		if len(g.Agents) > 0 && slices.Contains(g.Agents, agentKey) {
+			extras = append(extras, g)
+		}
+	}
+	extras = append(extras, ac.QualityGates...)
+	slices.SortFunc(extras, func(a, b QualityGate) int {
+		if r := quality.LevelRank(a.Level) - quality.LevelRank(b.Level); r != 0 {
+			return r
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	for _, g := range extras {
+		appendGate(g)
+	}
+	return ordered, nil
+}
+
+func (c *Config) inheritSuiteForAgent(agentKey string, suite []string) ([]quality.Gate, error) {
+	selected, err := c.defaultSuiteGates(agentKey)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(selected))
+	for _, g := range selected {
+		seen[g.Name] = true
+	}
+	for _, entry := range suite {
+		if entry == "inherit" {
+			continue
+		}
+		name := entry
+		if strings.HasPrefix(entry, "+") {
+			name = entry[1:]
+		}
+		if name == "" {
+			return nil, fmt.Errorf("agent %s: invalid quality_suite entry %q", agentKey, entry)
+		}
+		if seen[name] {
+			continue
+		}
+		g, ok := c.gateForAgent(agentKey, name)
+		if !ok {
+			return nil, fmt.Errorf("agent %s: quality_suite references unknown or disallowed gate %q", agentKey, name)
+		}
+		seen[name] = true
+		selected = append(selected, g)
+	}
+	return toRuntimeGates(selected), nil
+}
+
+func toRuntimeGates(gates []QualityGate) []quality.Gate {
+	out := make([]quality.Gate, 0, len(gates))
+	for _, g := range gates {
+		timeout := 5 * time.Minute
+		if g.Timeout != "" {
+			timeout, _ = time.ParseDuration(g.Timeout)
+		}
+		cmd, _ := g.ResolvedCmd()
+		out = append(out, quality.Gate{
+			Name:     g.Name,
+			Kind:     g.KindOrDefault(),
+			Level:    g.Level,
+			Cmd:      cmd,
+			Specs:    slices.Clone(g.Specs),
+			Runner:   g.Runner,
+			Blocking: g.Blocking,
+			Timeout:  timeout,
+			Retries:  g.Retries,
+		})
+	}
+	return out
+}
+
+// KindOrDefault returns command when kind is unset.
+func (g QualityGate) KindOrDefault() string {
+	return quality.KindOrDefault(g.Kind)
+}
+
+// ResolvedCmd returns the shell command for this gate.
+func (g QualityGate) ResolvedCmd() (string, error) {
+	switch g.KindOrDefault() {
+	case quality.KindCommand:
+		cmd := strings.TrimSpace(g.Cmd)
+		if cmd == "" {
+			return "", fmt.Errorf("cmd is required for kind=command")
+		}
+		return cmd, nil
+	case quality.KindBDD:
+		if strings.TrimSpace(g.Cmd) != "" {
+			return strings.TrimSpace(g.Cmd), nil
+		}
+		if len(g.Specs) == 0 {
+			return "", fmt.Errorf("bdd gate requires specs (Gherkin feature paths) or an explicit cmd")
+		}
+		specs := strings.Join(g.Specs, " ")
+		runner := g.Runner
+		if runner == "" {
+			runner = "godog"
+		}
+		switch runner {
+		case "godog":
+			return "godog " + specs, nil
+		case "behave":
+			return "behave " + specs, nil
+		case "cucumber":
+			return "npx cucumber-js " + specs, nil
+		default:
+			return "", fmt.Errorf("unknown bdd runner %q", runner)
+		}
+	default:
+		return "", fmt.Errorf("unknown kind %q", g.Kind)
+	}
+}
+
+// RuntimeQualityForAgent builds the provision-time runtime config blob.
+func (c *Config) RuntimeQualityForAgent(agentKey string) (quality.RuntimeConfig, error) {
+	gates, err := c.SuiteForAgent(agentKey)
+	if err != nil {
+		return quality.RuntimeConfig{}, err
+	}
+	rc := quality.RuntimeConfig{
+		Enabled:     c.Quality != nil && c.Quality.Enabled,
+		OnFailure:   c.Quality.OnFailureOrDefault(),
+		MaxAttempts: c.Quality.MaxAttemptsOrDefault(),
+		AgentKey:    agentKey,
+		Project:     c.Project,
+		Gates:       gates,
+	}
+	return rc, nil
+}
+
+func validateAgentQualitySuite(c *Config, agentKey string, suite []string) error {
+	if len(suite) == 0 {
+		return nil
+	}
+	if c.Quality == nil || !c.Quality.Enabled {
+		return fmt.Errorf("agent %s: quality_suite set but quality.enabled is false", agentKey)
+	}
+	for _, entry := range suite {
+		if entry == "inherit" {
+			continue
+		}
+		name := entry
+		if strings.HasPrefix(entry, "+") {
+			name = entry[1:]
+		}
+		if name == "" {
+			return fmt.Errorf("agent %s: invalid quality_suite entry %q", agentKey, entry)
+		}
+		if _, ok := c.gateForAgent(agentKey, name); !ok {
+			return fmt.Errorf("agent %s: quality_suite references unknown or disallowed gate %q", agentKey, name)
+		}
+	}
+	return nil
+}
+
+func validateAgentQualityGates(c *Config, agentKey string, gates []QualityGate) error {
+	if len(gates) == 0 {
+		return nil
+	}
+	if c.Quality == nil || !c.Quality.Enabled {
+		return fmt.Errorf("agent %s: quality_gates set but quality.enabled is false", agentKey)
+	}
+	names := make(map[string]bool, len(gates))
+	for i, g := range gates {
+		if g.Name == "" {
+			return fmt.Errorf("agent %s: quality_gates[%d]: name is required", agentKey, i)
+		}
+		if names[g.Name] {
+			return fmt.Errorf("agent %s: duplicate quality_gates name %q", agentKey, g.Name)
+		}
+		names[g.Name] = true
+		if _, ok := c.Quality.GateByName(g.Name); ok {
+			return fmt.Errorf("agent %s: quality_gates name %q conflicts with global gate", agentKey, g.Name)
+		}
+		if !quality.ValidLevel(g.Level) {
+			return fmt.Errorf("agent %s: quality_gates[%d] (%s): unknown level %q", agentKey, i, g.Name, g.Level)
+		}
+		if !quality.ValidKind(g.Kind) {
+			return fmt.Errorf("agent %s: quality_gates[%d] (%s): unknown kind %q", agentKey, i, g.Name, g.Kind)
+		}
+		if _, err := g.ResolvedCmd(); err != nil {
+			return fmt.Errorf("agent %s: quality_gates[%d] (%s): %w", agentKey, i, g.Name, err)
+		}
+	}
+	return nil
+}

--- a/internal/config/quality_test.go
+++ b/internal/config/quality_test.go
@@ -1,0 +1,335 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jahwag/clem/internal/quality"
+)
+
+func TestLoad_QualityConfigValid(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g", alerts: "a"}
+quality:
+  enabled: true
+  on_failure: feedback
+  max_attempts: 2
+  gates:
+    - name: build
+      level: build
+      cmd: "go build ./..."
+      blocking: true
+      timeout: 60s
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    quality_suite: [build]
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gates, err := cfg.SuiteForAgent("lead")
+	if err != nil || len(gates) != 1 || gates[0].Name != "build" {
+		t.Fatalf("suite = %+v err=%v", gates, err)
+	}
+}
+
+func TestLoad_QualityUnknownGateRejected(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  gates:
+    - name: unit
+      level: unit
+      cmd: "true"
+agents:
+  lead:
+    name: "Lead"
+    quality_suite: [missing]
+`)
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected unknown gate error, got %v", err)
+	}
+}
+
+func TestLoad_QualityDisabledByDefault(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+agents:
+  lead:
+    name: "Lead"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Quality != nil && cfg.Quality.Enabled {
+		t.Fatal("quality should be disabled by default")
+	}
+}
+
+func TestQualityGate_ResolvedCmdBehaveCucumber(t *testing.T) {
+	for _, tc := range []struct {
+		runner, want string
+	}{
+		{"behave", "behave features/"},
+		{"cucumber", "npx cucumber-js features/"},
+	} {
+		g := QualityGate{Kind: "bdd", Specs: []string{"features/"}, Runner: tc.runner}
+		cmd, err := g.ResolvedCmd()
+		if err != nil || cmd != tc.want {
+			t.Fatalf("%s: cmd=%q err=%v", tc.runner, cmd, err)
+		}
+	}
+}
+
+func TestLoad_QualityBDDGateResolvesGodog(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  gates:
+    - name: acceptance
+      kind: bdd
+      level: acceptance
+      specs: [features/]
+      runner: godog
+      blocking: true
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gates, err := cfg.SuiteForAgent("lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gates) != 1 || gates[0].Cmd != "godog features/" {
+		t.Fatalf("got %+v", gates[0])
+	}
+	if gates[0].Kind != "bdd" {
+		t.Fatalf("kind = %q", gates[0].Kind)
+	}
+}
+
+func TestSuiteForAgent_BaselineAndAgentRestricted(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  baseline_suite: [build, unit]
+  gates:
+    - name: build
+      level: build
+      cmd: "go build ./..."
+      blocking: true
+    - name: unit
+      level: unit
+      cmd: "go test ./..."
+      blocking: true
+    - name: lint
+      level: lint
+      cmd: "golangci-lint run"
+      blocking: false
+    - name: acceptance
+      level: acceptance
+      kind: bdd
+      specs: [features/]
+      runner: godog
+      agents: [lead]
+      blocking: true
+agents:
+  lead:
+    name: "Lead"
+  reviewer:
+    name: "Reviewer"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lead, err := cfg.SuiteForAgent("lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lead) != 3 {
+		t.Fatalf("lead suite = %d gates, want 3: %+v", len(lead), gateNames(lead))
+	}
+	if lead[0].Name != "build" || lead[1].Name != "unit" || lead[2].Name != "acceptance" {
+		t.Fatalf("lead order = %v", gateNames(lead))
+	}
+	reviewer, err := cfg.SuiteForAgent("reviewer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reviewer) != 2 || gateNames(reviewer)[0] != "build" {
+		t.Fatalf("reviewer suite = %+v", gateNames(reviewer))
+	}
+}
+
+func TestSuiteForAgent_InheritAddsExtra(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  baseline_suite: [build, unit]
+  gates:
+    - name: build
+      level: build
+      cmd: "go build ./..."
+      blocking: true
+    - name: unit
+      level: unit
+      cmd: "go test ./..."
+      blocking: true
+    - name: lint
+      level: lint
+      cmd: "golangci-lint run"
+      blocking: false
+agents:
+  lead:
+    name: "Lead"
+    quality_suite: [+lint]
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gates, err := cfg.SuiteForAgent("lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gates) != 3 || gates[2].Name != "lint" {
+		t.Fatalf("got %+v", gateNames(gates))
+	}
+}
+
+func TestSuiteForAgent_InlineQualityGates(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  baseline_suite: [unit]
+  gates:
+    - name: unit
+      level: unit
+      cmd: "go test ./..."
+      blocking: true
+agents:
+  lead:
+    name: "Lead"
+    quality_gates:
+      - name: lead-smoke
+        level: custom
+        cmd: "./scripts/lead-smoke.sh"
+        blocking: true
+    quality_suite: [inherit, +lead-smoke]
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gates, err := cfg.SuiteForAgent("lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gates) != 2 || gates[1].Name != "lead-smoke" {
+		t.Fatalf("got %+v", gateNames(gates))
+	}
+}
+
+func TestLoad_AgentRestrictedGateNotInExplicitSuiteForOtherAgent(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  gates:
+    - name: unit
+      level: unit
+      cmd: "true"
+      blocking: true
+    - name: lead-only
+      level: custom
+      cmd: "true"
+      agents: [lead]
+      blocking: true
+agents:
+  reviewer:
+    name: "Reviewer"
+    quality_suite: [unit, lead-only]
+`)
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "lead-only") {
+		t.Fatalf("expected disallowed gate error, got %v", err)
+	}
+}
+
+func TestLoad_UnknownAgentInGateAgentsRejected(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+quality:
+  enabled: true
+  gates:
+    - name: unit
+      level: unit
+      cmd: "true"
+      agents: [missing]
+      blocking: true
+agents:
+  lead:
+    name: "Lead"
+`)
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected unknown agent error, got %v", err)
+	}
+}
+
+func gateNames(gates []quality.Gate) []string {
+	names := make([]string, len(gates))
+	for i, g := range gates {
+		names[i] = g.Name
+	}
+	return names
+}

--- a/internal/quality/feedback.go
+++ b/internal/quality/feedback.go
@@ -1,0 +1,127 @@
+package quality
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	FeedbackStartMarker = "<!-- clem:quality-feedback:start -->"
+	FeedbackEndMarker   = "<!-- clem:quality-feedback:end -->"
+	FeedbackMaxBytes    = 4096
+)
+
+// FormatFeedback renders a human-readable failure summary for agent consumption.
+// BDD gates emphasize living Gherkin spec context so agents converge on the
+// behaviors encoded in features/, not just generic test output.
+func FormatFeedback(v Verdict, attempt, maxAttempts int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[quality] Deterministic checks failed (attempt %d/%d). Use this feedback to fix the code — specs are the source of truth:\n\n", attempt, maxAttempts)
+	for _, r := range v.Results {
+		if r.Pass {
+			continue
+		}
+		kind := KindOrDefault(r.Kind)
+		fmt.Fprintf(&b, "### Gate: %s (%s, kind=%s)\n", r.Name, r.Level, kind)
+		if len(r.Specs) > 0 {
+			fmt.Fprintf(&b, "Living specs: %s\n", strings.Join(r.Specs, ", "))
+		}
+		fmt.Fprintf(&b, "Command failed (exit %d", r.ExitCode)
+		if r.Error != "" {
+			fmt.Fprintf(&b, ", %s", r.Error)
+		}
+		b.WriteString(")\n")
+		if kind == KindBDD || r.Level == "acceptance" {
+			if hints := ExtractBDDHints(r.Output); hints != "" {
+				b.WriteString("Failing scenarios / steps:\n```\n")
+				b.WriteString(truncateOutput(hints, 1500))
+				b.WriteString("\n```\n")
+			}
+		}
+		if r.Output != "" {
+			b.WriteString("Output:\n```\n")
+			b.WriteString(truncateOutput(r.Output, 1500))
+			b.WriteString("\n```\n")
+		}
+		b.WriteString("\n")
+	}
+	return truncateOutput(b.String(), FeedbackMaxBytes)
+}
+
+// WriteFeedbackFile writes runner-visible feedback for the next prompt prepend.
+func WriteFeedbackFile(homeDir, text string) error {
+	if err := os.MkdirAll(filepath.Join(homeDir, ".clem"), 0700); err != nil {
+		return err
+	}
+	if text == "" {
+		return os.Remove(FeedbackPath(homeDir))
+	}
+	return os.WriteFile(FeedbackPath(homeDir), []byte(text), 0600)
+}
+
+// InjectFeedbackBlock replaces or inserts the delimited block in CLAUDE.local.md.
+func InjectFeedbackBlock(claudeLocalPath, feedback string) error {
+	var existing []byte
+	if data, err := os.ReadFile(claudeLocalPath); err == nil {
+		existing = data
+	}
+	content := replaceFeedbackBlock(string(existing), feedback)
+	return os.WriteFile(claudeLocalPath, []byte(content), 0644)
+}
+
+func replaceFeedbackBlock(content, feedback string) string {
+	start := strings.Index(content, FeedbackStartMarker)
+	end := strings.Index(content, FeedbackEndMarker)
+	if start >= 0 && end > start {
+		end += len(FeedbackEndMarker)
+		before := strings.TrimSpace(content[:start])
+		after := strings.TrimSpace(content[end:])
+		if feedback == "" {
+			switch {
+			case before == "" && after == "":
+				return ""
+			case before == "":
+				return after
+			case after == "":
+				return before
+			default:
+				return before + "\n\n" + after
+			}
+		}
+		block := buildFeedbackBlock(feedback)
+		switch {
+		case before == "" && after == "":
+			return block
+		case before == "":
+			return block + "\n\n" + after
+		case after == "":
+			return before + "\n\n" + block
+		default:
+			return before + "\n\n" + block + "\n\n" + after
+		}
+	}
+	content = strings.TrimSpace(content)
+	if feedback == "" {
+		return content
+	}
+	block := buildFeedbackBlock(feedback)
+	if content == "" {
+		return block
+	}
+	return content + "\n\n" + block
+}
+
+func buildFeedbackBlock(feedback string) string {
+	return FeedbackStartMarker + "\n" + feedback + "\n" + FeedbackEndMarker
+}
+
+// ClearFeedback removes feedback from both file and CLAUDE.local.md.
+func ClearFeedback(homeDir, claudeLocalPath string) error {
+	_ = os.Remove(FeedbackPath(homeDir))
+	if claudeLocalPath == "" {
+		return nil
+	}
+	return InjectFeedbackBlock(claudeLocalPath, "")
+}

--- a/internal/quality/integration_test.go
+++ b/internal/quality/integration_test.go
@@ -111,22 +111,45 @@ func TestIntegration_ClosedLoopConvergence(t *testing.T) {
 
 func TestIntegration_MaxAttemptsBlocks(t *testing.T) {
 	h := newHarness(t, "exit 1", 2)
+	claudeLocal := filepath.Join(h.Work, "CLAUDE.local.md")
 
 	code, _ := h.runIteration(t)
 	if code != 1 {
 		t.Fatalf("first fail: code=%d", code)
 	}
+	// After a non-final failure, feedback is injected for the agent to retry.
+	if _, err := os.Stat(quality.FeedbackPath(h.Home)); err != nil {
+		t.Fatalf("feedback file should exist after non-final fail: %v", err)
+	}
+
+	// Second fail = the transition into blocked: returns 2 (the runner alerts
+	// once on this), AND clears the loop feedback (the agent can't self-recover).
 	code, err := h.runIteration(t)
 	if code != 2 {
-		t.Fatalf("second fail: want code 2 (blocked), got %d err=%v", code, err)
+		t.Fatalf("transition fail: want code 2 (blocked), got %d err=%v", code, err)
 	}
 	state, _ := quality.LoadState(h.Home)
 	if !state.Blocked {
 		t.Fatal("state should be blocked")
 	}
+	if _, err := os.Stat(quality.FeedbackPath(h.Home)); !os.IsNotExist(err) {
+		t.Fatal("feedback file should be cleared on transition into blocked")
+	}
+	if content, _ := os.ReadFile(claudeLocal); strings.Contains(string(content), quality.FeedbackStartMarker) {
+		t.Fatalf("CLAUDE.local.md feedback block should be cleared on transition: %q", content)
+	}
+
+	// Third run = already-blocked no-op: returns 3 (NOT 2, so the runner does
+	// not re-alert) and does not re-create feedback.
 	code, _ = h.runIteration(t)
-	if code != 2 {
-		t.Fatalf("third run on blocked task: want code 2, got %d", code)
+	if code != 3 {
+		t.Fatalf("already-blocked run: want code 3 (quiet no-op), got %d", code)
+	}
+	if _, err := os.Stat(quality.FeedbackPath(h.Home)); !os.IsNotExist(err) {
+		t.Fatal("already-blocked run must not re-create feedback file")
+	}
+	if content, _ := os.ReadFile(claudeLocal); strings.Contains(string(content), quality.FeedbackStartMarker) {
+		t.Fatalf("already-blocked run must not re-inject feedback block: %q", content)
 	}
 }
 

--- a/internal/quality/integration_test.go
+++ b/internal/quality/integration_test.go
@@ -339,7 +339,11 @@ func (h *harness) readJSONL(t *testing.T) []quality.JSONLEntry {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close jsonl: %v", err)
+		}
+	})
 	var out []quality.JSONLEntry
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {

--- a/internal/quality/integration_test.go
+++ b/internal/quality/integration_test.go
@@ -1,0 +1,363 @@
+package quality_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jahwag/clem/internal/config"
+	"github.com/jahwag/clem/internal/quality"
+)
+
+// harness simulates an agent home + project workdir for integration tests.
+type harness struct {
+	Home     string
+	Work     string
+	AgentKey string
+	RC       quality.RuntimeConfig
+}
+
+func newHarness(t *testing.T, gateCmd string, maxAttempts int) *harness {
+	t.Helper()
+	home := t.TempDir()
+	work := filepath.Join(home, "demo")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "CLAUDE.local.md"), []byte("# agent context\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rc := quality.RuntimeConfig{
+		Enabled:     true,
+		OnFailure:   "feedback",
+		MaxAttempts: maxAttempts,
+		AgentKey:    "lead",
+		Project:     "demo",
+		Gates: []quality.Gate{
+			{Name: "check", Level: "unit", Cmd: gateCmd, Blocking: true},
+		},
+	}
+	if err := quality.WriteRuntimeConfig(home, rc); err != nil {
+		t.Fatal(err)
+	}
+	return &harness{Home: home, Work: work, AgentKey: "lead", RC: rc}
+}
+
+func (h *harness) runIteration(t *testing.T) (int, error) {
+	t.Helper()
+	return quality.RunIteration(h.Home, h.Work, h.RC)
+}
+
+func (h *harness) markerPath() string {
+	return filepath.Join(h.Work, ".quality_ok")
+}
+
+func (h *harness) setOK(t *testing.T) {
+	t.Helper()
+	if err := os.WriteFile(h.markerPath(), []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegration_ClosedLoopConvergence(t *testing.T) {
+	h := newHarness(t, "test -f .quality_ok", 5)
+
+	code, err := h.runIteration(t)
+	if code != 1 || err == nil {
+		t.Fatalf("iter1: want code 1 + err, got %d %v", code, err)
+	}
+	fb, _ := os.ReadFile(quality.FeedbackPath(h.Home))
+	if len(fb) == 0 {
+		t.Fatal("iter1: expected feedback file")
+	}
+	claude, _ := os.ReadFile(filepath.Join(h.Work, "CLAUDE.local.md"))
+	if !strings.Contains(string(claude), quality.FeedbackStartMarker) {
+		t.Fatal("iter1: CLAUDE.local.md should contain feedback block")
+	}
+	state, _ := quality.LoadState(h.Home)
+	if state.Attempts != 1 {
+		t.Fatalf("iter1: attempts = %d, want 1", state.Attempts)
+	}
+
+	h.setOK(t)
+	code, err = h.runIteration(t)
+	if code != 0 || err != nil {
+		t.Fatalf("iter2: want pass, got %d %v", code, err)
+	}
+	if _, err := os.Stat(quality.FeedbackPath(h.Home)); !os.IsNotExist(err) {
+		t.Fatal("iter2: feedback file should be cleared on pass")
+	}
+	claude, _ = os.ReadFile(filepath.Join(h.Work, "CLAUDE.local.md"))
+	if strings.Contains(string(claude), quality.FeedbackStartMarker) {
+		t.Fatal("iter2: feedback block should be cleared from CLAUDE.local.md")
+	}
+	state, _ = quality.LoadState(h.Home)
+	if state.Attempts != 0 {
+		t.Fatalf("iter2: attempts reset, got %d", state.Attempts)
+	}
+
+	entries := h.readJSONL(t)
+	if len(entries) < 2 {
+		t.Fatalf("expected >=2 jsonl entries, got %d", len(entries))
+	}
+	if !entries[len(entries)-1].Pass {
+		t.Fatal("last jsonl entry should be pass=true")
+	}
+}
+
+func TestIntegration_MaxAttemptsBlocks(t *testing.T) {
+	h := newHarness(t, "exit 1", 2)
+
+	code, _ := h.runIteration(t)
+	if code != 1 {
+		t.Fatalf("first fail: code=%d", code)
+	}
+	code, err := h.runIteration(t)
+	if code != 2 {
+		t.Fatalf("second fail: want code 2 (blocked), got %d err=%v", code, err)
+	}
+	state, _ := quality.LoadState(h.Home)
+	if !state.Blocked {
+		t.Fatal("state should be blocked")
+	}
+	code, _ = h.runIteration(t)
+	if code != 2 {
+		t.Fatalf("third run on blocked task: want code 2, got %d", code)
+	}
+}
+
+func TestIntegration_TaskChangeResetsAttempts(t *testing.T) {
+	h := newHarness(t, "exit 1", 5)
+	if _, err := h.runIteration(t); err == nil {
+		t.Fatal("expected fail")
+	}
+	state, _ := quality.LoadState(h.Home)
+	if state.Attempts != 1 {
+		t.Fatalf("attempts=%d", state.Attempts)
+	}
+
+	if err := os.WriteFile(quality.TaskIDPath(h.Home), []byte("task-b\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := quality.ResetAttemptsIfTaskChanged(h.Home, "task-b")
+	if err != nil || state.Attempts != 0 {
+		t.Fatalf("reset: state=%+v err=%v", state, err)
+	}
+	code, _ := h.runIteration(t)
+	if code != 1 {
+		t.Fatalf("new task first fail: code=%d", code)
+	}
+	state, _ = quality.LoadState(h.Home)
+	if state.TaskID != "task-b" || state.Attempts != 1 {
+		t.Fatalf("state after new task: %+v", state)
+	}
+}
+
+func TestIntegration_BDDGateFeedback(t *testing.T) {
+	home := t.TempDir()
+	work := filepath.Join(home, "demo")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "CLAUDE.local.md"), []byte("# ctx\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rc := quality.RuntimeConfig{
+		Enabled:     true,
+		OnFailure:   "feedback",
+		MaxAttempts: 3,
+		AgentKey:    "lead",
+		Gates: []quality.Gate{
+			{
+				Name:     "acceptance",
+				Kind:     quality.KindBDD,
+				Level:    "acceptance",
+				Specs:    []string{"features/"},
+				Cmd:      `echo "Feature: Greeting\nScenario: hello\nexpected hello got bye"; exit 1`,
+				Blocking: true,
+			},
+		},
+	}
+	code, err := quality.RunIteration(home, work, rc)
+	if code != 1 || err == nil {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	fb, _ := os.ReadFile(quality.FeedbackPath(home))
+	body := string(fb)
+	for _, want := range []string{"Living specs: features/", "Feature: Greeting", "Scenario:"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("feedback missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestIntegration_AdvisoryNeverBlocksIteration(t *testing.T) {
+	h := newHarness(t, "exit 1", 3)
+	h.RC.OnFailure = "advisory"
+	code, err := h.runIteration(t)
+	if code != 0 || err != nil {
+		t.Fatalf("advisory should return 0, got %d %v", code, err)
+	}
+	if _, err := os.Stat(quality.FeedbackPath(h.Home)); err == nil {
+		t.Fatal("advisory should not write feedback file")
+	}
+}
+
+func TestIntegration_ConfigRoundTrip(t *testing.T) {
+	path := writeConfigYAML(t, `
+project: demo
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "1", alerts: "2"}
+quality:
+  enabled: true
+  max_attempts: 4
+  gates:
+    - name: unit
+      level: unit
+      cmd: "test -f .quality_ok"
+      blocking: true
+    - name: bdd
+      kind: bdd
+      level: acceptance
+      specs: [features/]
+      runner: godog
+      blocking: true
+agents:
+  lead:
+    name: Lead
+    model: claude-sonnet-4-6
+    quality_suite: [unit, bdd]
+`)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, err := cfg.RuntimeQualityForAgent("lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	if err := quality.WriteRuntimeConfig(home, rc); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := quality.LoadRuntimeConfig(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Gates) != 2 || loaded.Gates[1].Cmd != "godog features/" {
+		t.Fatalf("loaded gates: %+v", loaded.Gates)
+	}
+}
+
+func TestIntegration_BaselineAndAgentRestricted(t *testing.T) {
+	path := writeConfigYAML(t, `
+project: demo
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "1", alerts: "2"}
+quality:
+  enabled: true
+  baseline_suite: [unit]
+  gates:
+    - name: unit
+      level: unit
+      cmd: "true"
+      blocking: true
+    - name: acceptance
+      kind: bdd
+      level: acceptance
+      specs: [features/]
+      runner: godog
+      agents: [lead]
+      blocking: true
+agents:
+  lead:
+    name: Lead
+    model: claude-sonnet-4-6
+    quality_suite: [+acceptance]
+  reviewer:
+    name: Reviewer
+    model: claude-sonnet-4-6
+`)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leadRC, err := cfg.RuntimeQualityForAgent("lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leadRC.Gates) != 2 || leadRC.Gates[1].Name != "acceptance" {
+		t.Fatalf("lead gates: %+v", leadRC.Gates)
+	}
+	reviewerRC, err := cfg.RuntimeQualityForAgent("reviewer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reviewerRC.Gates) != 1 || reviewerRC.Gates[0].Name != "unit" {
+		t.Fatalf("reviewer gates: %+v", reviewerRC.Gates)
+	}
+}
+
+func TestRunSuite_GateTimeout(t *testing.T) {
+	dir := t.TempDir()
+	gates := []quality.Gate{
+		{Name: "slow", Level: "custom", Cmd: "sleep 2", Blocking: true, Timeout: 100 * time.Millisecond},
+	}
+	v := quality.RunSuite(dir, gates, "t", 1)
+	if v.Pass {
+		t.Fatal("expected timeout failure")
+	}
+	if len(v.Results) != 1 || v.Results[0].ExitCode != 124 {
+		t.Fatalf("results=%+v", v.Results)
+	}
+}
+
+func TestRunSuite_GateRetries(t *testing.T) {
+	dir := t.TempDir()
+	// Fails first time, succeeds second — simulate with a counter file
+	script := `n=$(cat .retry_count 2>/dev/null || echo 0); n=$((n+1)); echo $n > .retry_count; [ "$n" -ge 2 ]`
+	gates := []quality.Gate{
+		{Name: "flaky", Level: "unit", Cmd: script, Blocking: true, Retries: 2},
+	}
+	v := quality.RunSuite(dir, gates, "t", 1)
+	if !v.Pass {
+		t.Fatalf("expected pass after retry, results=%+v", v.Results)
+	}
+}
+
+func (h *harness) readJSONL(t *testing.T) []quality.JSONLEntry {
+	t.Helper()
+	f, err := os.Open(quality.JSONLPath(h.Home, h.AgentKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var out []quality.JSONLEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e quality.JSONLEntry
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func writeConfigYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clem.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/quality/kinds.go
+++ b/internal/quality/kinds.go
@@ -1,0 +1,68 @@
+package quality
+
+import "strings"
+
+// Gate kinds — extensible check types. "command" is the default escape hatch;
+// "bdd" binds living Gherkin specs to executable acceptance gates (SDD/BDD).
+const (
+	KindCommand = "command"
+	KindBDD     = "bdd"
+)
+
+var ValidKinds = []string{KindCommand, KindBDD}
+
+// ValidKind reports whether kind is known (empty counts as command).
+func ValidKind(kind string) bool {
+	if kind == "" {
+		return true
+	}
+	for _, k := range ValidKinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// KindOrDefault normalizes an empty kind to command.
+func KindOrDefault(kind string) string {
+	if kind == "" {
+		return KindCommand
+	}
+	return kind
+}
+
+// ExtractBDDHints pulls Feature/Scenario/step failure lines from BDD runner
+// output so agents get deterministic, spec-grounded feedback — not just a
+// generic exit code.
+func ExtractBDDHints(output string) string {
+	var hints []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		switch {
+		case strings.HasPrefix(lower, "feature:"),
+			strings.HasPrefix(lower, "scenario:"),
+			strings.HasPrefix(lower, "scenario outline:"),
+			strings.Contains(lower, "failed steps:"),
+			strings.Contains(lower, "undefined scenarios:"),
+			strings.Contains(lower, "ambiguous steps:"),
+			strings.HasPrefix(lower, "  ✖"),
+			strings.HasPrefix(lower, "  ×"),
+			strings.Contains(lower, "assertionerror"),
+			strings.Contains(lower, "expected"),
+			strings.Contains(lower, "gherkin"):
+			hints = append(hints, line)
+		}
+		if len(hints) >= 24 {
+			break
+		}
+	}
+	if len(hints) == 0 {
+		return ""
+	}
+	return strings.Join(hints, "\n")
+}

--- a/internal/quality/kinds_test.go
+++ b/internal/quality/kinds_test.go
@@ -1,0 +1,37 @@
+package quality_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jahwag/clem/internal/quality"
+)
+
+func TestExtractBDDHints(t *testing.T) {
+	out := quality.ExtractBDDHints(`Feature: Login
+  Scenario: valid credentials
+    ✖ expected 200 got 401
+Failed steps:
+  Then the response status should be 200`)
+	if !strings.Contains(out, "Feature: Login") || !strings.Contains(out, "Scenario:") {
+		t.Fatalf("hints = %q", out)
+	}
+}
+
+func TestFormatFeedback_BBDSection(t *testing.T) {
+	v := quality.Verdict{
+		Pass: false,
+		Results: []quality.GateResult{{
+			Name:   "acceptance",
+			Kind:   quality.KindBDD,
+			Level:  "acceptance",
+			Specs:  []string{"features/"},
+			Pass:   false,
+			Output: "Feature: Checkout\nScenario: pay with card\nexpected true got false",
+		}},
+	}
+	text := quality.FormatFeedback(v, 1, 3)
+	if !strings.Contains(text, "Living specs: features/") || !strings.Contains(text, "Feature: Checkout") {
+		t.Fatalf("feedback = %s", text)
+	}
+}

--- a/internal/quality/levels.go
+++ b/internal/quality/levels.go
@@ -1,0 +1,57 @@
+package quality
+
+import (
+	"fmt"
+	"slices"
+)
+
+// ValidLevel reports whether level is a known gate level.
+func ValidLevel(level string) bool {
+	return slices.Contains(LevelOrder, level)
+}
+
+// LevelRank returns the sort order for a level (higher = run later).
+func LevelRank(level string) int {
+	for i, l := range LevelOrder {
+		if l == level {
+			return i
+		}
+	}
+	return len(LevelOrder)
+}
+
+// SortGatesByLevel sorts gates by canonical level order, preserving name order
+// within the same level.
+func SortGatesByLevel(gates []Gate) {
+	slices.SortFunc(gates, func(a, b Gate) int {
+		if r := LevelRank(a.Level) - LevelRank(b.Level); r != 0 {
+			return r
+		}
+		return stringsCompare(a.Name, b.Name)
+	})
+}
+
+func stringsCompare(a, b string) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+// ValidateGateNames ensures gate names are unique.
+func ValidateGateNames(gates []Gate) error {
+	seen := make(map[string]bool, len(gates))
+	for _, g := range gates {
+		if g.Name == "" {
+			return fmt.Errorf("quality gate missing name")
+		}
+		if seen[g.Name] {
+			return fmt.Errorf("duplicate quality gate name %q", g.Name)
+		}
+		seen[g.Name] = true
+	}
+	return nil
+}

--- a/internal/quality/metrics.go
+++ b/internal/quality/metrics.go
@@ -204,7 +204,15 @@ func WriteRuntimeConfig(homeDir string, rc RuntimeConfig) error {
 }
 
 // RunIteration executes the full post-session quality loop side effects.
-// Returns exit code 0 on pass, 1 on blocking failure, 2 on max attempts blocked.
+// Returns exit code:
+//
+//	0 on pass (or advisory/disabled no-op),
+//	1 on a non-final blocking failure (feedback injected, agent may retry),
+//	2 on the transition into blocked — max attempts just exhausted; the runner
+//	  fires the [BLOCKED] alert once and feedback is cleared (the alert is the
+//	  human signal, the agent cannot self-recover),
+//	3 on an already-blocked iteration — a quiet no-op that does NOT re-run gates,
+//	  re-alert, or re-inject feedback (the human was alerted on the transition).
 func RunIteration(homeDir, workdir string, rc RuntimeConfig) (int, error) {
 	if !rc.Enabled || len(rc.Gates) == 0 {
 		return 0, nil
@@ -215,7 +223,10 @@ func RunIteration(homeDir, workdir string, rc RuntimeConfig) (int, error) {
 		return 1, err
 	}
 	if state.Blocked && rc.OnFailure != "block-push" {
-		return 2, fmt.Errorf("task %q is blocked after exhausting quality attempts", taskID)
+		// Already blocked: quiet no-op. Return 3 (not 2) so the runner does not
+		// re-fire the [BLOCKED] alert every loop. Feedback was already cleared
+		// at the transition, so nothing to re-inject here.
+		return 3, fmt.Errorf("task %q is blocked after exhausting quality attempts", taskID)
 	}
 
 	if rc.OnFailure == "block-push" {
@@ -260,6 +271,12 @@ func RunIteration(homeDir, workdir string, rc RuntimeConfig) (int, error) {
 
 	if rc.MaxAttempts > 0 && attempt >= rc.MaxAttempts {
 		state.Blocked = true
+		// Clear the loop feedback at the transition: the agent has exhausted its
+		// attempts and cannot self-recover, so re-prepending the feedback every
+		// subsequent iteration is noise. The [BLOCKED] alert is the human signal.
+		if err := ClearFeedback(homeDir, claudeLocal); err != nil {
+			return 2, err
+		}
 		if err := SaveState(homeDir, state); err != nil {
 			return 2, err
 		}

--- a/internal/quality/metrics.go
+++ b/internal/quality/metrics.go
@@ -9,8 +9,14 @@ import (
 	"time"
 )
 
+func deferClose(f *os.File, err *error) {
+	if cerr := f.Close(); cerr != nil && *err == nil {
+		*err = cerr
+	}
+}
+
 // AppendJSONL records each gate result from a verdict run.
-func AppendJSONL(homeDir, agentKey string, v Verdict) error {
+func AppendJSONL(homeDir, agentKey string, v Verdict) (err error) {
 	path := JSONLPath(homeDir, agentKey)
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
@@ -19,7 +25,9 @@ func AppendJSONL(homeDir, agentKey string, v Verdict) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		deferClose(f, &err)
+	}()
 	for _, r := range v.Results {
 		entry := JSONLEntry{
 			TS:         v.Timestamp,
@@ -64,7 +72,7 @@ type GateStats struct {
 }
 
 // ReadAgentSummary parses the last verdict line-group from JSONL.
-func ReadAgentSummary(homeDir, agentKey string) (AgentSummary, error) {
+func ReadAgentSummary(homeDir, agentKey string) (sum AgentSummary, err error) {
 	path := JSONLPath(homeDir, agentKey)
 	f, err := os.Open(path)
 	if err != nil {
@@ -73,7 +81,7 @@ func ReadAgentSummary(homeDir, agentKey string) (AgentSummary, error) {
 		}
 		return AgentSummary{}, err
 	}
-	defer f.Close()
+	defer deferClose(f, &err)
 
 	var entries []JSONLEntry
 	sc := bufio.NewScanner(f)
@@ -98,7 +106,7 @@ func ReadAgentSummary(homeDir, agentKey string) (AgentSummary, error) {
 		lastRun = append([]JSONLEntry{entries[i]}, lastRun...)
 	}
 	lastTS := entries[len(entries)-1].TS
-	sum := AgentSummary{AgentKey: agentKey, LastTS: lastTS, LastAttempt: lastAttempt}
+	sum = AgentSummary{AgentKey: agentKey, LastTS: lastTS, LastAttempt: lastAttempt}
 	for _, e := range lastRun {
 		sum.GatesTotal++
 		if e.Pass {
@@ -126,11 +134,11 @@ func ReadAgentSummary(homeDir, agentKey string) (AgentSummary, error) {
 	if total > 0 {
 		sum.PassRate = float64(passes) / float64(total)
 	}
-	return sum, nil
+	return sum, err
 }
 
 // AggregateGateStats computes per-gate stats from JSONL.
-func AggregateGateStats(homeDir, agentKey string) ([]GateStats, error) {
+func AggregateGateStats(homeDir, agentKey string) (out []GateStats, err error) {
 	path := JSONLPath(homeDir, agentKey)
 	f, err := os.Open(path)
 	if err != nil {
@@ -139,7 +147,7 @@ func AggregateGateStats(homeDir, agentKey string) ([]GateStats, error) {
 		}
 		return nil, err
 	}
-	defer f.Close()
+	defer deferClose(f, &err)
 
 	byGate := map[string]*GateStats{}
 	sc := bufio.NewScanner(f)
@@ -159,7 +167,7 @@ func AggregateGateStats(homeDir, agentKey string) ([]GateStats, error) {
 		}
 		st.AvgMS += e.DurationMS
 	}
-	out := make([]GateStats, 0, len(byGate))
+	out = make([]GateStats, 0, len(byGate))
 	for _, st := range byGate {
 		if st.Runs > 0 {
 			st.PassRate = float64(st.Passes) / float64(st.Runs)
@@ -167,7 +175,7 @@ func AggregateGateStats(homeDir, agentKey string) ([]GateStats, error) {
 		}
 		out = append(out, *st)
 	}
-	return out, nil
+	return out, err
 }
 
 // LoadRuntimeConfig reads ~/.clem/quality.json.
@@ -202,7 +210,6 @@ func RunIteration(homeDir, workdir string, rc RuntimeConfig) (int, error) {
 		return 0, nil
 	}
 	taskID := CurrentTaskID(homeDir)
-	attempt := 1
 	state, err := ResetAttemptsIfTaskChanged(homeDir, taskID)
 	if err != nil {
 		return 1, err
@@ -219,7 +226,7 @@ func RunIteration(homeDir, workdir string, rc RuntimeConfig) (int, error) {
 		return 0, nil
 	}
 
-	attempt = state.Attempts + 1
+	attempt := state.Attempts + 1
 	verdict := RunSuite(workdir, rc.Gates, taskID, attempt)
 	if err := AppendJSONL(homeDir, rc.AgentKey, verdict); err != nil {
 		return 1, err

--- a/internal/quality/metrics.go
+++ b/internal/quality/metrics.go
@@ -1,0 +1,289 @@
+package quality
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// AppendJSONL records each gate result from a verdict run.
+func AppendJSONL(homeDir, agentKey string, v Verdict) error {
+	path := JSONLPath(homeDir, agentKey)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, r := range v.Results {
+		entry := JSONLEntry{
+			TS:         v.Timestamp,
+			TaskID:     v.TaskID,
+			Attempt:    v.Attempt,
+			Gate:       r.Name,
+			Pass:       r.Pass,
+			DurationMS: r.DurationMS,
+			ExitCode:   r.ExitCode,
+			Blocking:   r.Blocking,
+		}
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		if _, err := f.Write(append(data, '\n')); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AgentSummary is the latest quality snapshot for one agent.
+type AgentSummary struct {
+	AgentKey    string
+	LastPass    bool
+	GatesPass   int
+	GatesTotal  int
+	LastAttempt int
+	LastGate    string
+	LastTS      time.Time
+	PassRate    float64
+}
+
+// GateStats aggregates metrics for one gate name.
+type GateStats struct {
+	Name     string
+	Runs     int
+	Passes   int
+	PassRate float64
+	AvgMS    int64
+}
+
+// ReadAgentSummary parses the last verdict line-group from JSONL.
+func ReadAgentSummary(homeDir, agentKey string) (AgentSummary, error) {
+	path := JSONLPath(homeDir, agentKey)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return AgentSummary{AgentKey: agentKey}, nil
+		}
+		return AgentSummary{}, err
+	}
+	defer f.Close()
+
+	var entries []JSONLEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e JSONLEntry
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	if len(entries) == 0 {
+		return AgentSummary{AgentKey: agentKey}, nil
+	}
+
+	// Take the last run by attempt number (all gates in one suite share attempt).
+	lastAttempt := entries[len(entries)-1].Attempt
+	var lastRun []JSONLEntry
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].Attempt != lastAttempt {
+			break
+		}
+		lastRun = append([]JSONLEntry{entries[i]}, lastRun...)
+	}
+	lastTS := entries[len(entries)-1].TS
+	sum := AgentSummary{AgentKey: agentKey, LastTS: lastTS, LastAttempt: lastAttempt}
+	for _, e := range lastRun {
+		sum.GatesTotal++
+		if e.Pass {
+			sum.GatesPass++
+		} else {
+			sum.LastPass = false
+			sum.LastGate = e.Gate
+		}
+	}
+	if sum.GatesTotal > 0 && sum.GatesPass == sum.GatesTotal {
+		sum.LastPass = true
+	}
+	if len(lastRun) > 0 && sum.LastGate == "" {
+		sum.LastGate = lastRun[len(lastRun)-1].Gate
+	}
+
+	// Pass rate across all entries.
+	passes, total := 0, 0
+	for _, e := range entries {
+		total++
+		if e.Pass {
+			passes++
+		}
+	}
+	if total > 0 {
+		sum.PassRate = float64(passes) / float64(total)
+	}
+	return sum, nil
+}
+
+// AggregateGateStats computes per-gate stats from JSONL.
+func AggregateGateStats(homeDir, agentKey string) ([]GateStats, error) {
+	path := JSONLPath(homeDir, agentKey)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	byGate := map[string]*GateStats{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e JSONLEntry
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			continue
+		}
+		st, ok := byGate[e.Gate]
+		if !ok {
+			st = &GateStats{Name: e.Gate}
+			byGate[e.Gate] = st
+		}
+		st.Runs++
+		if e.Pass {
+			st.Passes++
+		}
+		st.AvgMS += e.DurationMS
+	}
+	out := make([]GateStats, 0, len(byGate))
+	for _, st := range byGate {
+		if st.Runs > 0 {
+			st.PassRate = float64(st.Passes) / float64(st.Runs)
+			st.AvgMS /= int64(st.Runs)
+		}
+		out = append(out, *st)
+	}
+	return out, nil
+}
+
+// LoadRuntimeConfig reads ~/.clem/quality.json.
+func LoadRuntimeConfig(homeDir string) (RuntimeConfig, error) {
+	data, err := os.ReadFile(RuntimeConfigPath(homeDir))
+	if err != nil {
+		return RuntimeConfig{}, fmt.Errorf("reading quality config: %w", err)
+	}
+	var rc RuntimeConfig
+	if err := json.Unmarshal(data, &rc); err != nil {
+		return RuntimeConfig{}, fmt.Errorf("parsing quality config: %w", err)
+	}
+	return rc, nil
+}
+
+// WriteRuntimeConfig writes ~/.clem/quality.json.
+func WriteRuntimeConfig(homeDir string, rc RuntimeConfig) error {
+	if err := os.MkdirAll(filepath.Join(homeDir, ".clem"), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(rc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(RuntimeConfigPath(homeDir), data, 0600)
+}
+
+// RunIteration executes the full post-session quality loop side effects.
+// Returns exit code 0 on pass, 1 on blocking failure, 2 on max attempts blocked.
+func RunIteration(homeDir, workdir string, rc RuntimeConfig) (int, error) {
+	if !rc.Enabled || len(rc.Gates) == 0 {
+		return 0, nil
+	}
+	taskID := CurrentTaskID(homeDir)
+	attempt := 1
+	state, err := ResetAttemptsIfTaskChanged(homeDir, taskID)
+	if err != nil {
+		return 1, err
+	}
+	if state.Blocked && rc.OnFailure != "block-push" {
+		return 2, fmt.Errorf("task %q is blocked after exhausting quality attempts", taskID)
+	}
+
+	if rc.OnFailure == "block-push" {
+		verdict := RunSuite(workdir, rc.Gates, taskID, 0)
+		if err := AppendJSONL(homeDir, rc.AgentKey, verdict); err != nil {
+			return 1, err
+		}
+		return 0, nil
+	}
+
+	attempt = state.Attempts + 1
+	verdict := RunSuite(workdir, rc.Gates, taskID, attempt)
+	if err := AppendJSONL(homeDir, rc.AgentKey, verdict); err != nil {
+		return 1, err
+	}
+
+	claudeLocal := filepath.Join(workdir, "CLAUDE.local.md")
+	if verdict.Pass {
+		state.Attempts = 0
+		state.Blocked = false
+		if err := ClearFeedback(homeDir, claudeLocal); err != nil {
+			return 1, err
+		}
+		if err := SaveState(homeDir, state); err != nil {
+			return 1, err
+		}
+		return 0, nil
+	}
+
+	if rc.OnFailure == "advisory" {
+		return 0, nil
+	}
+
+	state.Attempts = attempt
+	feedback := FormatFeedback(verdict, attempt, rc.MaxAttempts)
+	if err := WriteFeedbackFile(homeDir, feedback); err != nil {
+		return 1, err
+	}
+	if err := InjectFeedbackBlock(claudeLocal, feedback); err != nil && !os.IsNotExist(err) {
+		return 1, err
+	}
+
+	if rc.MaxAttempts > 0 && attempt >= rc.MaxAttempts {
+		state.Blocked = true
+		if err := SaveState(homeDir, state); err != nil {
+			return 2, err
+		}
+		return 2, fmt.Errorf("quality gates failed %d times for task %q — marked blocked", attempt, taskID)
+	}
+	if err := SaveState(homeDir, state); err != nil {
+		return 1, err
+	}
+	return 1, fmt.Errorf("quality gates failed (attempt %d/%d)", attempt, rc.MaxAttempts)
+}
+
+// RunPrePush runs blocking gates for block-push mode.
+func RunPrePush(homeDir, workdir string, rc RuntimeConfig) error {
+	if !rc.Enabled || rc.OnFailure != "block-push" {
+		return nil
+	}
+	var blocking []Gate
+	for _, g := range rc.Gates {
+		if g.Blocking {
+			blocking = append(blocking, g)
+		}
+	}
+	if len(blocking) == 0 {
+		return nil
+	}
+	v := RunSuite(workdir, blocking, "pre-push", 0)
+	if err := AppendJSONL(homeDir, rc.AgentKey, v); err != nil {
+		return err
+	}
+	if !v.Pass {
+		return fmt.Errorf("quality pre-push gate(s) failed")
+	}
+	return nil
+}

--- a/internal/quality/metrics_test.go
+++ b/internal/quality/metrics_test.go
@@ -1,0 +1,136 @@
+package quality_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jahwag/clem/internal/quality"
+)
+
+func TestReadAgentSummary_LastAttemptGroup(t *testing.T) {
+	home := t.TempDir()
+	agent := "lead"
+	ts1 := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	ts2 := ts1.Add(time.Minute)
+
+	v1 := quality.Verdict{
+		Timestamp: ts1,
+		TaskID:    "task-a",
+		Attempt:   1,
+		Results: []quality.GateResult{
+			{Name: "unit", Pass: false, Blocking: true},
+			{Name: "lint", Pass: true, Blocking: false},
+		},
+	}
+	v2 := quality.Verdict{
+		Timestamp: ts2,
+		TaskID:    "task-a",
+		Attempt:   2,
+		Results: []quality.GateResult{
+			{Name: "unit", Pass: true, Blocking: true},
+			{Name: "lint", Pass: true, Blocking: false},
+		},
+	}
+	if err := quality.AppendJSONL(home, agent, v1); err != nil {
+		t.Fatal(err)
+	}
+	if err := quality.AppendJSONL(home, agent, v2); err != nil {
+		t.Fatal(err)
+	}
+
+	sum, err := quality.ReadAgentSummary(home, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.LastAttempt != 2 {
+		t.Fatalf("LastAttempt=%d, want 2", sum.LastAttempt)
+	}
+	if !sum.LastPass {
+		t.Fatal("expected LastPass=true for attempt 2")
+	}
+	if sum.GatesTotal != 2 || sum.GatesPass != 2 {
+		t.Fatalf("gates pass/total = %d/%d, want 2/2", sum.GatesPass, sum.GatesTotal)
+	}
+	if sum.PassRate <= 0 {
+		t.Fatalf("PassRate=%v, want > 0", sum.PassRate)
+	}
+}
+
+func TestReadAgentSummary_MissingFile(t *testing.T) {
+	sum, err := quality.ReadAgentSummary(t.TempDir(), "lead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.AgentKey != "lead" || sum.GatesTotal != 0 {
+		t.Fatalf("unexpected summary: %+v", sum)
+	}
+}
+
+func TestAggregateGateStats(t *testing.T) {
+	home := t.TempDir()
+	agent := "lead"
+	v := quality.Verdict{
+		Timestamp: time.Now().UTC(),
+		TaskID:    "t",
+		Attempt:   1,
+		Results: []quality.GateResult{
+			{Name: "unit", Pass: true, DurationMS: 10},
+			{Name: "unit", Pass: false, DurationMS: 30},
+			{Name: "lint", Pass: true, DurationMS: 20},
+		},
+	}
+	if err := quality.AppendJSONL(home, agent, v); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := quality.AggregateGateStats(home, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 gate stats, got %d", len(stats))
+	}
+	byName := map[string]quality.GateStats{}
+	for _, s := range stats {
+		byName[s.Name] = s
+	}
+	unit := byName["unit"]
+	if unit.Runs != 2 || unit.Passes != 1 {
+		t.Fatalf("unit stats: %+v", unit)
+	}
+	if unit.PassRate != 0.5 {
+		t.Fatalf("unit pass rate = %v, want 0.5", unit.PassRate)
+	}
+	if unit.AvgMS != 20 {
+		t.Fatalf("unit avg ms = %d, want 20", unit.AvgMS)
+	}
+}
+
+func TestWriteLoadRuntimeConfig(t *testing.T) {
+	home := t.TempDir()
+	rc := quality.RuntimeConfig{
+		Enabled:     true,
+		OnFailure:   "feedback",
+		MaxAttempts: 5,
+		AgentKey:    "lead",
+		Project:     "demo",
+		Gates: []quality.Gate{
+			{Name: "unit", Level: "unit", Cmd: "true", Blocking: true},
+		},
+	}
+	if err := quality.WriteRuntimeConfig(home, rc); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".clem", "quality.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := quality.LoadRuntimeConfig(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.Enabled || loaded.MaxAttempts != 5 || len(loaded.Gates) != 1 {
+		t.Fatalf("loaded: %+v", loaded)
+	}
+}

--- a/internal/quality/quality_test.go
+++ b/internal/quality/quality_test.go
@@ -1,0 +1,124 @@
+package quality_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jahwag/clem/internal/quality"
+)
+
+func TestRunSuite_FailFastOnBlocking(t *testing.T) {
+	dir := t.TempDir()
+	gates := []quality.Gate{
+		{Name: "build", Level: "build", Cmd: "exit 1", Blocking: true},
+		{Name: "unit", Level: "unit", Cmd: "exit 0", Blocking: true},
+	}
+	v := quality.RunSuite(dir, gates, "task-1", 1)
+	if v.Pass {
+		t.Fatal("expected fail")
+	}
+	if len(v.Results) != 1 {
+		t.Fatalf("expected fail-fast after 1 gate, got %d results", len(v.Results))
+	}
+}
+
+func TestRunSuite_RunsAllWhenNonBlockingFails(t *testing.T) {
+	dir := t.TempDir()
+	gates := []quality.Gate{
+		{Name: "lint", Level: "lint", Cmd: "exit 1", Blocking: false},
+		{Name: "unit", Level: "unit", Cmd: "exit 0", Blocking: true},
+	}
+	v := quality.RunSuite(dir, gates, "task-1", 1)
+	if !v.Pass {
+		t.Fatal("expected pass when only advisory gate fails")
+	}
+	if len(v.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(v.Results))
+	}
+}
+
+func TestRunIteration_FeedbackAndAttempts(t *testing.T) {
+	home := t.TempDir()
+	work := filepath.Join(home, "proj")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatal(err)
+	}
+	claudeLocal := filepath.Join(work, "CLAUDE.local.md")
+	if err := os.WriteFile(claudeLocal, []byte("# local\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rc := quality.RuntimeConfig{
+		Enabled:     true,
+		OnFailure:   "feedback",
+		MaxAttempts: 3,
+		AgentKey:    "lead",
+		Project:     "proj",
+		Gates: []quality.Gate{
+			{Name: "unit", Level: "unit", Cmd: "exit 1", Blocking: true},
+		},
+	}
+	code, err := quality.RunIteration(home, work, rc)
+	if code != 1 || err == nil {
+		t.Fatalf("expected code 1 with error, got code=%d err=%v", code, err)
+	}
+	feedback, err := os.ReadFile(quality.FeedbackPath(home))
+	if err != nil {
+		t.Fatalf("feedback file: %v", err)
+	}
+	if !strings.Contains(string(feedback), "[quality]") {
+		t.Fatalf("unexpected feedback: %s", feedback)
+	}
+	content, _ := os.ReadFile(claudeLocal)
+	if !strings.Contains(string(content), quality.FeedbackStartMarker) {
+		t.Fatal("CLAUDE.local.md missing feedback block")
+	}
+}
+
+func TestRunIteration_PassClearsFeedback(t *testing.T) {
+	home := t.TempDir()
+	work := filepath.Join(home, "proj")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatal(err)
+	}
+	claudeLocal := filepath.Join(work, "CLAUDE.local.md")
+	if err := os.WriteFile(claudeLocal, []byte(quality.FeedbackStartMarker+"\nold\n"+quality.FeedbackEndMarker), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rc := quality.RuntimeConfig{
+		Enabled:   true,
+		OnFailure: "feedback",
+		AgentKey:  "lead",
+		Gates: []quality.Gate{
+			{Name: "unit", Level: "unit", Cmd: "true", Blocking: true},
+		},
+	}
+	code, err := quality.RunIteration(home, work, rc)
+	if code != 0 || err != nil {
+		t.Fatalf("expected pass, got code=%d err=%v", code, err)
+	}
+	if _, err := os.Stat(quality.FeedbackPath(home)); !os.IsNotExist(err) {
+		t.Fatal("feedback file should be removed on pass")
+	}
+	content, _ := os.ReadFile(claudeLocal)
+	if strings.Contains(string(content), quality.FeedbackStartMarker) {
+		t.Fatalf("CLAUDE.local.md should not contain feedback block after pass: %q", content)
+	}
+}
+
+func TestRunPrePush_BlockPushMode(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	rc := quality.RuntimeConfig{
+		Enabled:   true,
+		OnFailure: "block-push",
+		AgentKey:  "lead",
+		Gates: []quality.Gate{
+			{Name: "unit", Level: "unit", Cmd: "exit 1", Blocking: true},
+		},
+	}
+	if err := quality.RunPrePush(home, work, rc); err == nil {
+		t.Fatal("expected pre-push failure")
+	}
+}

--- a/internal/quality/run.go
+++ b/internal/quality/run.go
@@ -1,0 +1,103 @@
+package quality
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const defaultGateTimeout = 5 * time.Minute
+
+// RunSuite executes gates in order with fail-fast on blocking failures.
+func RunSuite(workdir string, gates []Gate, taskID string, attempt int) Verdict {
+	v := Verdict{
+		TaskID:    taskID,
+		Attempt:   attempt,
+		Timestamp: time.Now().UTC(),
+		Pass:      true,
+	}
+	for _, gate := range gates {
+		result := runGateWithRetries(workdir, gate)
+		v.Results = append(v.Results, result)
+		if !result.Pass && gate.Blocking {
+			v.Pass = false
+			v.BlockingFailed = true
+			break
+		}
+	}
+	if v.BlockingFailed {
+		v.Pass = false
+	}
+	return v
+}
+
+func runGateWithRetries(workdir string, gate Gate) GateResult {
+	retries := gate.Retries
+	if retries < 0 {
+		retries = 0
+	}
+	var last GateResult
+	for i := 0; i <= retries; i++ {
+		last = runGate(workdir, gate, i+1)
+		if last.Pass {
+			return last
+		}
+	}
+	return last
+}
+
+func runGate(workdir string, gate Gate, attemptNum int) GateResult {
+	timeout := gate.Timeout
+	if timeout <= 0 {
+		timeout = defaultGateTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, "bash", "-lc", gate.Cmd)
+	cmd.Dir = workdir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	result := GateResult{
+		Name:       gate.Name,
+		Kind:       KindOrDefault(gate.Kind),
+		Level:      gate.Level,
+		Specs:      gate.Specs,
+		Blocking:   gate.Blocking,
+		Attempt:    attemptNum,
+		DurationMS: duration.Milliseconds(),
+	}
+	if err == nil {
+		result.Pass = true
+		result.ExitCode = 0
+	} else if ctx.Err() == context.DeadlineExceeded {
+		result.Error = fmt.Sprintf("timeout after %s", timeout)
+		result.ExitCode = 124
+	} else if exitErr, ok := err.(*exec.ExitError); ok {
+		result.ExitCode = exitErr.ExitCode()
+	} else {
+		result.Error = err.Error()
+		result.ExitCode = 1
+	}
+	combined := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
+	result.Output = truncateOutput(combined, 8192)
+	return result
+}
+
+func truncateOutput(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/internal/quality/state.go
+++ b/internal/quality/state.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	stateFileName   = "quality-state.json"
-	taskIDFileName  = "current-task-id"
-	feedbackFile    = "quality-feedback.txt"
+	stateFileName  = "quality-state.json"
+	taskIDFileName = "current-task-id"
+	feedbackFile   = "quality-feedback.txt"
 )
 
 // StatePath returns ~/.clem/quality-state.json under homeDir.

--- a/internal/quality/state.go
+++ b/internal/quality/state.go
@@ -1,0 +1,94 @@
+package quality
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	stateFileName   = "quality-state.json"
+	taskIDFileName  = "current-task-id"
+	feedbackFile    = "quality-feedback.txt"
+)
+
+// StatePath returns ~/.clem/quality-state.json under homeDir.
+func StatePath(homeDir string) string {
+	return filepath.Join(homeDir, ".clem", stateFileName)
+}
+
+// TaskIDPath returns ~/.clem/current-task-id under homeDir.
+func TaskIDPath(homeDir string) string {
+	return filepath.Join(homeDir, ".clem", taskIDFileName)
+}
+
+// FeedbackPath returns ~/.clem/quality-feedback.txt under homeDir.
+func FeedbackPath(homeDir string) string {
+	return filepath.Join(homeDir, ".clem", feedbackFile)
+}
+
+// RuntimeConfigPath returns ~/.clem/quality.json under homeDir.
+func RuntimeConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, ".clem", "quality.json")
+}
+
+// JSONLPath returns ~/.clem/<agentKey>-quality.jsonl under homeDir.
+func JSONLPath(homeDir, agentKey string) string {
+	return filepath.Join(homeDir, ".clem", agentKey+"-quality.jsonl")
+}
+
+// LoadState reads persisted attempt state.
+func LoadState(homeDir string) (State, error) {
+	path := StatePath(homeDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{}, nil
+		}
+		return State{}, err
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// SaveState writes attempt state.
+func SaveState(homeDir string, s State) error {
+	if err := os.MkdirAll(filepath.Join(homeDir, ".clem"), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(StatePath(homeDir), data, 0600)
+}
+
+// CurrentTaskID reads the active task id or returns "default".
+func CurrentTaskID(homeDir string) string {
+	data, err := os.ReadFile(TaskIDPath(homeDir))
+	if err != nil {
+		return "default"
+	}
+	id := strings.TrimSpace(string(data))
+	if id == "" {
+		return "default"
+	}
+	return id
+}
+
+// ResetAttemptsIfTaskChanged clears attempts when task id changes.
+func ResetAttemptsIfTaskChanged(homeDir, taskID string) (State, error) {
+	s, err := LoadState(homeDir)
+	if err != nil {
+		return State{}, err
+	}
+	if s.TaskID != taskID {
+		s = State{TaskID: taskID, Attempts: 0, Blocked: false}
+	}
+	return s, nil
+}

--- a/internal/quality/types.go
+++ b/internal/quality/types.go
@@ -1,0 +1,77 @@
+package quality
+
+import "time"
+
+// Canonical gate levels, cheapest to most expensive.
+var LevelOrder = []string{
+	"build", "typecheck", "lint", "unit", "integration", "acceptance", "custom",
+}
+
+// RuntimeConfig is the per-agent quality configuration written at provision
+// time to ~/.clem/quality.json for runner and pre-push consumption.
+type RuntimeConfig struct {
+	Enabled     bool        `json:"enabled"`
+	OnFailure   string      `json:"on_failure"`
+	MaxAttempts int         `json:"max_attempts"`
+	AgentKey    string      `json:"agent_key"`
+	Project     string      `json:"project"`
+	Gates       []Gate        `json:"gates"`
+	AlertScript string      `json:"alert_script,omitempty"`
+}
+
+// Gate is a single deterministic quality check.
+type Gate struct {
+	Name     string        `json:"name"`
+	Kind     string        `json:"kind,omitempty"`   // command (default) | bdd
+	Level    string        `json:"level"`
+	Cmd      string        `json:"cmd"`
+	Specs    []string      `json:"specs,omitempty"` // Gherkin paths for kind=bdd
+	Runner   string        `json:"runner,omitempty"` // godog | behave | cucumber
+	Blocking bool          `json:"blocking"`
+	Timeout  time.Duration `json:"timeout"`
+	Retries  int           `json:"retries"`
+}
+
+// GateResult captures one gate execution outcome.
+type GateResult struct {
+	Name       string        `json:"name"`
+	Kind       string        `json:"kind,omitempty"`
+	Level      string        `json:"level"`
+	Specs      []string      `json:"specs,omitempty"`
+	Blocking   bool          `json:"blocking"`
+	Pass       bool          `json:"pass"`
+	ExitCode   int           `json:"exit_code"`
+	DurationMS int64         `json:"duration_ms"`
+	Output     string        `json:"output,omitempty"`
+	Error      string        `json:"error,omitempty"`
+	Attempt    int           `json:"attempt"`
+}
+
+// Verdict is the aggregated result of a suite run.
+type Verdict struct {
+	Pass           bool         `json:"pass"`
+	BlockingFailed bool         `json:"blocking_failed"`
+	Results        []GateResult `json:"results"`
+	TaskID         string       `json:"task_id"`
+	Attempt        int          `json:"attempt"`
+	Timestamp      time.Time    `json:"timestamp"`
+}
+
+// JSONLEntry is one append-only metrics record.
+type JSONLEntry struct {
+	TS         time.Time `json:"ts"`
+	TaskID     string    `json:"task_id"`
+	Attempt    int       `json:"attempt"`
+	Gate       string    `json:"gate"`
+	Pass       bool      `json:"pass"`
+	DurationMS int64     `json:"duration_ms"`
+	ExitCode   int       `json:"exit_code"`
+	Blocking   bool      `json:"blocking"`
+}
+
+// State tracks per-task closed-loop attempts.
+type State struct {
+	TaskID  string `json:"task_id"`
+	Attempts int   `json:"attempts"`
+	Blocked bool  `json:"blocked"`
+}

--- a/internal/quality/types.go
+++ b/internal/quality/types.go
@@ -10,22 +10,22 @@ var LevelOrder = []string{
 // RuntimeConfig is the per-agent quality configuration written at provision
 // time to ~/.clem/quality.json for runner and pre-push consumption.
 type RuntimeConfig struct {
-	Enabled     bool        `json:"enabled"`
-	OnFailure   string      `json:"on_failure"`
-	MaxAttempts int         `json:"max_attempts"`
-	AgentKey    string      `json:"agent_key"`
-	Project     string      `json:"project"`
-	Gates       []Gate        `json:"gates"`
-	AlertScript string      `json:"alert_script,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	OnFailure   string `json:"on_failure"`
+	MaxAttempts int    `json:"max_attempts"`
+	AgentKey    string `json:"agent_key"`
+	Project     string `json:"project"`
+	Gates       []Gate `json:"gates"`
+	AlertScript string `json:"alert_script,omitempty"`
 }
 
 // Gate is a single deterministic quality check.
 type Gate struct {
 	Name     string        `json:"name"`
-	Kind     string        `json:"kind,omitempty"`   // command (default) | bdd
+	Kind     string        `json:"kind,omitempty"` // command (default) | bdd
 	Level    string        `json:"level"`
 	Cmd      string        `json:"cmd"`
-	Specs    []string      `json:"specs,omitempty"` // Gherkin paths for kind=bdd
+	Specs    []string      `json:"specs,omitempty"`  // Gherkin paths for kind=bdd
 	Runner   string        `json:"runner,omitempty"` // godog | behave | cucumber
 	Blocking bool          `json:"blocking"`
 	Timeout  time.Duration `json:"timeout"`
@@ -34,17 +34,17 @@ type Gate struct {
 
 // GateResult captures one gate execution outcome.
 type GateResult struct {
-	Name       string        `json:"name"`
-	Kind       string        `json:"kind,omitempty"`
-	Level      string        `json:"level"`
-	Specs      []string      `json:"specs,omitempty"`
-	Blocking   bool          `json:"blocking"`
-	Pass       bool          `json:"pass"`
-	ExitCode   int           `json:"exit_code"`
-	DurationMS int64         `json:"duration_ms"`
-	Output     string        `json:"output,omitempty"`
-	Error      string        `json:"error,omitempty"`
-	Attempt    int           `json:"attempt"`
+	Name       string   `json:"name"`
+	Kind       string   `json:"kind,omitempty"`
+	Level      string   `json:"level"`
+	Specs      []string `json:"specs,omitempty"`
+	Blocking   bool     `json:"blocking"`
+	Pass       bool     `json:"pass"`
+	ExitCode   int      `json:"exit_code"`
+	DurationMS int64    `json:"duration_ms"`
+	Output     string   `json:"output,omitempty"`
+	Error      string   `json:"error,omitempty"`
+	Attempt    int      `json:"attempt"`
 }
 
 // Verdict is the aggregated result of a suite run.
@@ -71,7 +71,7 @@ type JSONLEntry struct {
 
 // State tracks per-task closed-loop attempts.
 type State struct {
-	TaskID  string `json:"task_id"`
-	Attempts int   `json:"attempts"`
-	Blocked bool  `json:"blocked"`
+	TaskID   string `json:"task_id"`
+	Attempts int    `json:"attempts"`
+	Blocked  bool   `json:"blocked"`
 }

--- a/internal/runner/quality_test.go
+++ b/internal/runner/quality_test.go
@@ -24,13 +24,53 @@ func TestGenerate_QualityGatesEnabled(t *testing.T) {
 	out := Generate(cfg, "lead")
 	for _, want := range []string{
 		"quality-feedback.txt",
-		"clem quality run --home",
+		// clem must be referenced by absolute path (agent PATH is not trusted).
+		"/usr/local/bin/clem quality run --home",
 		"Quality gates finished",
+		// rc 127 (binary missing) is logged distinctly, not treated as a pass.
+		`QUALITY_RC" -eq 127`,
+		"quality gates skipped",
+		// rc 2 = transition into blocked → alert once.
+		`QUALITY_RC" -eq 2`,
 		"Quality gates exhausted max attempts",
+		// rc 3 = already-blocked no-op → log only, no alert.
+		`QUALITY_RC" -eq 3`,
+		"no-op (alert already sent)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("runner missing %q", want)
 		}
+	}
+	// The bare (PATH-dependent) invocation must be gone.
+	if strings.Contains(out, "\n        clem quality run") {
+		t.Error("runner must not invoke clem via bare PATH")
+	}
+}
+
+// TestGenerate_QualityAlertsOnlyOnTransition guards FIX 2: the runner fires the
+// [BLOCKED] alert only on rc 2 (the transition), never on rc 3 (already
+// blocked). The alert branch must sit between the rc==2 and rc==3 branches.
+func TestGenerate_QualityAlertsOnlyOnTransition(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-sonnet-4-6", Iteration: "1m", Prompt: "work",
+	})
+	cfg.Quality = &config.QualityConfig{
+		Enabled:   true,
+		OnFailure: "feedback",
+		Gates:     []config.QualityGate{{Name: "unit", Level: "unit", Cmd: "go test ./...", Blocking: true}},
+	}
+	out := Generate(cfg, "lead")
+
+	idx2 := strings.Index(out, `QUALITY_RC" -eq 2`)
+	idx3 := strings.Index(out, `QUALITY_RC" -eq 3`)
+	idxAlert := strings.Index(out, "Quality gates exhausted max attempts")
+	if idx2 < 0 || idx3 < 0 || idxAlert < 0 {
+		t.Fatalf("expected rc 2, rc 3 and alert branches in:\n%s", out)
+	}
+	// The alert log line must fall inside the rc==2 branch: after rc==2 and
+	// before rc==3 (the no-op branch carries no alert).
+	if !(idx2 < idxAlert && idxAlert < idx3) {
+		t.Errorf("alert must live in the rc==2 branch only (idx2=%d alert=%d idx3=%d)", idx2, idxAlert, idx3)
 	}
 }
 

--- a/internal/runner/quality_test.go
+++ b/internal/runner/quality_test.go
@@ -1,0 +1,59 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jahwag/clem/internal/config"
+)
+
+func TestGenerate_QualityGatesEnabled(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-sonnet-4-6",
+		Iteration: "1m",
+		Prompt:    "work",
+	})
+	cfg.Quality = &config.QualityConfig{
+		Enabled:   true,
+		OnFailure: "feedback",
+		Gates: []config.QualityGate{
+			{Name: "unit", Level: "unit", Cmd: "go test ./...", Blocking: true},
+		},
+	}
+	out := Generate(cfg, "lead")
+	for _, want := range []string{
+		"quality-feedback.txt",
+		"clem quality run --home",
+		"Quality gates finished",
+		"Quality gates exhausted max attempts",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("runner missing %q", want)
+		}
+	}
+}
+
+func TestGenerate_QualityDisabledOmitsHooks(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-sonnet-4-6", Iteration: "1m", Prompt: "work",
+	})
+	out := Generate(cfg, "lead")
+	if strings.Contains(out, "clem quality run") {
+		t.Error("quality run should be absent when disabled")
+	}
+}
+
+func TestGenerate_QualityFeedbackPrependedBeforeSession(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Model: "claude-sonnet-4-6", Iteration: "1m", Prompt: "work",
+	})
+	cfg.Quality = &config.QualityConfig{
+		Enabled: true,
+		Gates:   []config.QualityGate{{Name: "unit", Level: "unit", Cmd: "true", Blocking: true}},
+	}
+	out := Generate(cfg, "lead")
+	if !strings.Contains(out, `quality-feedback.txt`) || !strings.Contains(out, "RUNNER_WARNINGS") {
+		t.Fatalf("runner should prepend quality feedback before session:\n%s", out)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -130,6 +130,8 @@ while true; do
     PROMPT='{{.Prompt}}'
     RUNNER_WARNINGS=""
 
+    {{.QualityFeedbackLoad}}
+
     # Guard: CLAUDE.local.md too large (token waste)
     if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
         SIZE=$(stat -c %s "$WORKDIR/CLAUDE.local.md" 2>/dev/null || echo 0)
@@ -209,6 +211,8 @@ while true; do
     EXIT_CODE=$?
     ELAPSED=$(( $(date +%s) - START ))
     log "Exited $EXIT_CODE after ${ELAPSED}s"
+
+    {{.QualityRunCmd}}
 
     HOUR=$(date +%H)
     if [ "$HOUR" -ge 7 ] && [ "$HOUR" -lt 22 ]; then
@@ -312,6 +316,8 @@ while true; do
     PROMPT='{{.Prompt}}'
     RUNNER_WARNINGS=""
 
+    {{.QualityFeedbackLoad}}
+
     # Guard: CLAUDE.local.md too large (token waste)
     if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
         SIZE=$(stat -c %s "$WORKDIR/CLAUDE.local.md" 2>/dev/null || echo 0)
@@ -337,6 +343,8 @@ while true; do
     EXIT_CODE=$?
     ELAPSED=$(( $(date +%s) - START ))
     log "Exited $EXIT_CODE after ${ELAPSED}s"
+
+    {{.QualityRunCmd}}
 
     HOUR=$(date +%H)
     if [ "$HOUR" -ge 7 ] && [ "$HOUR" -lt 22 ]; then
@@ -458,6 +466,12 @@ type RunnerParams struct {
 	// to refresh the agent's ~/.claude/skills/ symlinks from the team skills
 	// repo. Empty when cfg.SkillsRepo is unset, in which case no sync runs.
 	SkillsSyncCmd string
+	// QualityFeedbackLoad prepends prior gate failure context to the prompt.
+	QualityFeedbackLoad string
+	// QualityRunCmd runs the post-session quality suite via clem quality run.
+	QualityRunCmd string
+	// QualityBlockedAlert is the alert curl for max-attempts exhaustion.
+	QualityBlockedAlert string
 }
 
 // bashDoubleQuoteEscaper escapes the four characters that stay live inside a
@@ -558,6 +572,10 @@ func Generate(cfg *config.Config, agentKey string) string {
 		SidecarServers:      sidecarServersLiteral(cfg, agentKey),
 		SkillsSyncCmd:       skillsSyncCmd,
 	}
+	feedbackLoad, runCmd, blockedAlert := qualityRunnerSnippets(cfg, agentKey, ac, alertChannel, backend)
+	p.QualityFeedbackLoad = feedbackLoad
+	p.QualityRunCmd = renderTemplate(runCmd, RunnerParams{QualityBlockedAlert: blockedAlert})
+	p.QualityBlockedAlert = blockedAlert
 	switch ac.RuntimeKind() {
 	case "opencode":
 		return renderTemplate(opencodeRunnerTemplate, p)
@@ -717,6 +735,9 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.CoordinationBackend}}", p.CoordinationBackend,
 		"{{.GitHubWatchUnitDeps}}", p.GitHubWatchUnitDeps,
 		"{{.SkillsSyncCmd}}", p.SkillsSyncCmd,
+		"{{.QualityFeedbackLoad}}", p.QualityFeedbackLoad,
+		"{{.QualityRunCmd}}", p.QualityRunCmd,
+		"{{.QualityBlockedAlert}}", p.QualityBlockedAlert,
 	)
 	return r.Replace(tmpl)
 }
@@ -735,6 +756,33 @@ func sidecarServersLiteral(cfg *config.Config, agentKey string) string {
 		}
 	}
 	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func qualityRunnerSnippets(cfg *config.Config, agentKey string, ac config.AgentConfig, alertChannel string, backend coordination.Backend) (feedbackLoad, runCmd, blockedAlert string) {
+	if cfg.Quality == nil || !cfg.Quality.Enabled {
+		return "", "", ""
+	}
+	feedbackLoad = `if [ -f "$HOME/.clem/quality-feedback.txt" ]; then
+        RUNNER_WARNINGS="${RUNNER_WARNINGS}$(cat "$HOME/.clem/quality-feedback.txt") "
+    fi`
+	runCmd = `if [ -f "$HOME/.clem/quality.json" ]; then
+        QUALITY_RC=0
+        clem quality run --home "$HOME" --workdir "$WORKDIR" || QUALITY_RC=$?
+        log "Quality gates finished (rc=${QUALITY_RC})"
+        if [ "$QUALITY_RC" -eq 2 ]; then
+            log "Quality gates exhausted max attempts — alerting"
+            source "$HOME/.env" 2>/dev/null
+            {{.QualityBlockedAlert}}
+        fi
+    fi`
+	blockedMsg := fmt.Sprintf("⚠️ %s: quality gates failed repeatedly — task [BLOCKED]. Manual intervention required.", escapeForAlert(ac.Name))
+	blockedBody := coordination.RenderAlert(backend, coordination.AlertParams{
+		Repo:    cfg.Coordination.GithubRepo,
+		Channel: alertChannel,
+		Message: blockedMsg,
+	})
+	blockedAlert = coordination.AlertCurlGuard(backend, alertChannel, blockedBody)
+	return feedbackLoad, runCmd, blockedAlert
 }
 
 // watchChannelIDs returns coordination-backend-specific watcher configuration

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jahwag/clem/internal/agent"
 	"github.com/jahwag/clem/internal/agentdoc"
 	"github.com/jahwag/clem/internal/config"
 	"github.com/jahwag/clem/internal/coordination"
@@ -556,7 +557,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 		Prompt:         strings.ReplaceAll(promptText, "'", `'\''`),
 		OSUser:         cfg.OSUsername(agentKey),
 		HomeDir:        fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
-		SleepActive: iterSec,
+		SleepActive:    iterSec,
 		// Night sleep defaults to the active value; iteration_night overrides.
 		// History: a hardcoded 2x night doubler was removed on the belief the
 		// prompt-cache TTL was 5 min. Subscription Claude Code actually gets
@@ -765,16 +766,25 @@ func qualityRunnerSnippets(cfg *config.Config, agentKey string, ac config.AgentC
 	feedbackLoad = `if [ -f "$HOME/.clem/quality-feedback.txt" ]; then
         RUNNER_WARNINGS="${RUNNER_WARNINGS}$(cat "$HOME/.clem/quality-feedback.txt") "
     fi`
-	runCmd = `if [ -f "$HOME/.clem/quality.json" ]; then
+	// clem is referenced by absolute path: the agent OS user's PATH is not
+	// guaranteed to contain it. rc 127 (binary missing) must NOT be treated as
+	// a gate pass nor fire the blocked alert; rc 2 is the transition into
+	// blocked (alert once); rc 3 is an already-blocked no-op (log only, the
+	// human was already alerted on the transition).
+	runCmd = fmt.Sprintf(`if [ -f "$HOME/.clem/quality.json" ]; then
         QUALITY_RC=0
-        clem quality run --home "$HOME" --workdir "$WORKDIR" || QUALITY_RC=$?
+        %s quality run --home "$HOME" --workdir "$WORKDIR" || QUALITY_RC=$?
         log "Quality gates finished (rc=${QUALITY_RC})"
-        if [ "$QUALITY_RC" -eq 2 ]; then
+        if [ "$QUALITY_RC" -eq 127 ]; then
+            log "ERROR: clem not found at %s — quality gates skipped"
+        elif [ "$QUALITY_RC" -eq 2 ]; then
             log "Quality gates exhausted max attempts — alerting"
             source "$HOME/.env" 2>/dev/null
             {{.QualityBlockedAlert}}
+        elif [ "$QUALITY_RC" -eq 3 ]; then
+            log "Task already blocked — no-op (alert already sent)"
         fi
-    fi`
+    fi`, agent.ClemBin, agent.ClemBin)
 	blockedMsg := fmt.Sprintf("⚠️ %s: quality gates failed repeatedly — task [BLOCKED]. Manual intervention required.", escapeForAlert(ac.Name))
 	blockedBody := coordination.RenderAlert(backend, coordination.AlertParams{
 		Repo:    cfg.Coordination.GithubRepo,

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,6 +9,8 @@ Samples today:
 - [`ollama-mellum2/`](ollama-mellum2/) - **Discord** coordination + local [JetBrains Mellum 2](https://www.jetbrains.com/mellum/) (code specialist, Apache-2.0) via Ollama. MoE, native tool_use, ~16 GB RAM. Published as `ghcr.io/jahwag/clem-sample:latest-mellum2`.
 - [`github-tasks/`](github-tasks/) - **GitHub Issues** coordination via `gh` CLI (no chat MCP). Task board lives in a dedicated repo with `clem:*` labels.
 - [`secure-fleet/`](secure-fleet/) - security-hardened multi-agent fleet — egress controls, resource limits, vault isolation. A configuration reference, not a model demo.
+- [`quality-go/`](quality-go/) - **Quality gates** — deterministic build/test/lint with closed feedback loop.
+- [`quality-bdd/`](quality-bdd/) - **SDD/BDD** — living Gherkin specs (`features/`) as executable acceptance gates via `kind: bdd`.
 
 ## Quick start (prebuilt image)
 

--- a/samples/quality-bdd/README.md
+++ b/samples/quality-bdd/README.md
@@ -1,0 +1,16 @@
+# Quality gates + living Gherkin specs (SDD/BDD)
+
+This sample shows **Spec-Driven Development** with clem: Gherkin features in
+`features/` are executable acceptance gates, not dead documentation.
+
+After each agent session, clem runs `godog features/` and injects failing
+scenarios into the next iteration via the closed feedback loop.
+
+```yaml
+# See clem.yaml — kind: bdd binds features/ to the acceptance gate
+```
+
+Wire your step definitions in the project repo as usual; clem only orchestrates
+*when* specs run and *how* failures return to the agent.
+
+See [docs/quality-gates.md](../../docs/quality-gates.md) for the full model.

--- a/samples/quality-bdd/clem.yaml
+++ b/samples/quality-bdd/clem.yaml
@@ -1,0 +1,39 @@
+project: quality-bdd-demo
+coordination:
+  backend: discord
+  server_id: "${DISCORD_SERVER_ID}"
+  channels:
+    general: "${DISCORD_GENERAL_CHANNEL}"
+    tasks: "${DISCORD_TASKS_CHANNEL}"
+    alerts: "${DISCORD_ALERTS_CHANNEL}"
+
+quality:
+  enabled: true
+  on_failure: feedback
+  max_attempts: 5
+  gates:
+    - name: unit
+      level: unit
+      cmd: "go test ./..."
+      blocking: true
+      timeout: 300s
+    - name: acceptance
+      kind: bdd
+      level: acceptance
+      specs:
+        - features/
+      runner: godog
+      blocking: true
+      timeout: 600s
+
+agents:
+  lead:
+    name: "Spec Lead"
+    role: "Implement against living Gherkin specs; fix failing scenarios before [DONE]"
+    model: "claude-sonnet-4-6"
+    iteration: "5m"
+    prompt: |
+      Specs in features/ define expected behaviour. When quality gates fail,
+      read the injected feedback block in CLAUDE.local.md and align code to the
+      failing Feature/Scenario — do not guess requirements from memory.
+    quality_suite: [unit, acceptance]

--- a/samples/quality-bdd/features/greeting.feature
+++ b/samples/quality-bdd/features/greeting.feature
@@ -1,0 +1,9 @@
+Feature: Greeting service
+  As a user
+  I want a deterministic greeting
+  So that agents can verify behaviour via living specs
+
+  Scenario: default greeting
+    Given the greeting service is initialized
+    When I request a greeting for "world"
+    Then the response should be "hello, world"

--- a/samples/quality-go/README.md
+++ b/samples/quality-go/README.md
@@ -1,0 +1,17 @@
+# Quality gates sample
+
+Minimal clem.yaml showing deterministic quality gates on a Go project.
+
+```bash
+docker build -f samples/Dockerfile --build-arg SAMPLE=quality-go -t clem-quality .
+```
+
+With `quality.enabled: true`, the runner executes gates after each agent session
+and feeds failures back into the next iteration via `CLAUDE.local.md`.
+
+This sample demonstrates:
+
+- `baseline_suite` — shared gates for the fleet (`build`, `unit`, `lint`)
+- `agents: [lead]` — integration gate only for the lead agent
+- `quality_suite: [+integration]` — inherit baseline + extra gate
+- `quality_suite: [build, unit]` — explicit override for reviewer

--- a/samples/quality-go/clem.yaml
+++ b/samples/quality-go/clem.yaml
@@ -1,0 +1,57 @@
+project: quality-demo
+coordination:
+  backend: discord
+  server_id: "${DISCORD_SERVER_ID}"
+  channels:
+    general: "${DISCORD_GENERAL_CHANNEL}"
+    tasks: "${DISCORD_TASKS_CHANNEL}"
+    alerts: "${DISCORD_ALERTS_CHANNEL}"
+
+quality:
+  enabled: true
+  on_failure: feedback
+  max_attempts: 3
+  baseline_suite: [build, unit, lint]
+  gates:
+    - name: build
+      level: build
+      cmd: "go build ./..."
+      blocking: true
+      timeout: 120s
+    - name: unit
+      level: unit
+      cmd: "go test ./..."
+      blocking: true
+      timeout: 300s
+    - name: lint
+      level: lint
+      cmd: "golangci-lint run"
+      blocking: false
+      timeout: 120s
+    - name: integration
+      level: integration
+      cmd: "go test ./... -tags=integration"
+      agents: [lead]
+      blocking: true
+      timeout: 600s
+
+agents:
+  lead:
+    name: "Quality Lead"
+    role: "Implement features with passing gates before PR"
+    model: "claude-sonnet-4-6"
+    iteration: "5m"
+    prompt: |
+      You are the quality-demo lead. Fix failing quality gates before marking work done.
+    # default = baseline + integration (agents: [lead])
+    quality_suite: [+integration]
+
+  reviewer:
+    name: "Quality Reviewer"
+    role: "Review with baseline gates only"
+    model: "claude-sonnet-4-6"
+    iteration: "5m"
+    prompt: |
+      You are the reviewer. Baseline gates run automatically; no integration suite.
+    # explicit subset — no lint, no integration
+    quality_suite: [build, unit]


### PR DESCRIPTION
## Why

Agent fleets produce code quickly, but LLM output is non-deterministic. Without an objective arbiter, broken builds, failing tests, and lint errors often surface only after push — wasting CI cycles and reviewer time.

This PR adds **quality gates**: deterministic shell/BDD checks that run automatically after each agent session and feed structured failures back into the next iteration via a closed feedback loop. Agents converge locally before broken work reaches CI or a PR.

**Zero regression by default:** `quality.enabled: false` preserves today's behaviour exactly.

---

## What changed

### Core engine (`internal/quality/`)

- **Gate runner** — ordered suite execution with fail-fast on blocking gates, per-gate timeout (exit 124), and retries
- **Closed feedback loop** — verdict formatting, `~/.clem/quality-feedback.txt`, delimited block injection/removal in `CLAUDE.local.md`
- **State & metrics** — attempt counter per task, blocked flag after `max_attempts`, JSONL append to `~/.clem/<agent>-quality.jsonl`
- **Gate kinds** — `command` (default) and `bdd` (living Gherkin via godog/behave/cucumber with scenario extraction in feedback)

### Configuration (`internal/config/quality.go`)

- Top-level `quality:` block: `enabled`, `on_failure`, `max_attempts`, `gates[]`
- **Fleet suite model:**
  - `baseline_suite` — shared gates every agent runs by default
  - `gates[].agents` — restrict a global gate to specific agent keys
  - `agents.<key>.quality_gates` — inline agent-local gate definitions
  - `agents.<key>.quality_suite` — explicit override, or `inherit` / `+gate` to extend the default suite
- Validation at `clem.yaml` load time

### Fleet integration

| Component | Integration |
|-----------|-------------|
| **Runner** (`internal/runner/runner.go`) | Pre-session feedback load into prompt; post-session `clem quality run` |
| **Provision** (`cmd/provision.go`) | Writes `~/.clem/quality.json` per agent |
| **Pre-push hook** (`internal/agent/manager.go`) | Pass 5: `clem quality pre-push` when `on_failure: block-push` |
| **CLI** (`cmd/quality.go`) | `clem quality` summary; hidden `run` / `pre-push` for hooks |
| **Status** (`cmd/status.go`) | QUALITY column from JSONL metrics |

### `on_failure` modes

| Mode | Iteration | Pre-push |
|------|-----------|----------|
| `feedback` | Fail → feedback → retry until pass or BLOCKED | — |
| `block-push` | Metrics only on iteration | Blocking gates must pass to push |
| `advisory` | Metrics only; no feedback loop | — |

---

## Workflow (how it works)

```
agent session ends
       ↓
clem quality run (--home $HOME --workdir $WORKDIR)
       ↓
run agent's gate suite from ~/.clem/quality.json
       ↓
  pass? ──yes──► clear feedback, reset attempts, exit 0
       │
       no
       ↓
write quality-feedback.txt + inject CLAUDE.local.md block
increment attempt counter
       ↓
max_attempts reached? ──yes──► mark BLOCKED, alert channel, exit 2
       │
       no ──► exit 1 (runner sleeps, next iteration loads feedback into prompt)
```

Each agent in the fleet gets its own isolated state under its OS user home. Changing `~/.clem/current-task-id` resets the attempt counter for a new task.

---

## Benefits

- **Faster convergence** — agents fix failing tests/lint/BDD in the next iteration, not after CI
- **Lower CI noise** — fewer red builds on obvious failures
- **Token discipline** — feedback replaces a delimited block each iteration; no unbounded accumulation
- **Fleet observability** — `clem quality`, `clem status` QUALITY column, per-gate JSONL history
- **Flexible suites** — baseline for everyone, agent-restricted gates, inline per-agent gates, explicit overrides
- **SDD/BDD ready** — `kind: bdd` runs Gherkin features as acceptance gates with scenario-level feedback
- **Opt-in** — disabled by default; no change for existing deployments

---

## Documentation & samples

- **[docs/quality-gates.md](docs/quality-gates.md)** — full workflow guide, configuration reference, fleet integration, observability
- **[samples/quality-go/](samples/quality-go/)** — command gates with baseline suite and agent-restricted integration gate
- **[samples/quality-bdd/](samples/quality-bdd/)** — Gherkin acceptance gates with `kind: bdd`
- **README** — feature map entry and `clem.yaml` reference link

---

## Test plan

- [x] `go test ./... -count=1` — 386 tests pass
- [x] Integration tests: closed-loop convergence, max attempts / BLOCKED, task reset, BDD feedback, advisory mode, timeout (124), retries
- [x] Config tests: baseline suite, agent-restricted gates, `+inherit` syntax, inline `quality_gates`, validation
- [x] E2E smoke: build `clem`, run `quality run` through fail → pass → blocked scenarios with temp home/workdir
- [ ] Manual: enable in a sample fleet, `clem provision`, verify runner hook and `clem status` QUALITY column

---

## Migration / rollout

1. Add `quality:` block to `clem.yaml` (start with `enabled: false` to validate config)
2. Set `enabled: true`, define gates and per-agent suites
3. Run `clem provision` — required to write `~/.clem/quality.json` and update runner hooks
4. Monitor via `clem quality` and `clem status`

No changes to existing agents until explicitly enabled and re-provisioned.

---

## Notes

- Gates are **deterministic only** (exit code semantics). No LLM-as-judge.
- CI remains the merge authority; gates are a local pre-filter.
- Two signed commits: implementation + documentation/samples.