### PR TITLE
fix(vault): validate vault names to block yq path injection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -674,6 +674,9 @@ func Load(path string) (*Config, error) {
 		if err := ac.validateExtensions(key); err != nil {
 			return nil, err
 		}
+		if err := validateAgentVaults(key, ac.Vaults); err != nil {
+			return nil, err
+		}
 		cfg.Agents[key] = ac
 	}
 	if err := cfg.validateVaultServices(); err != nil {
@@ -683,6 +686,15 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func validateAgentVaults(agentKey string, vaults []string) error {
+	for _, name := range vaults {
+		if !validName.MatchString(name) {
+			return fmt.Errorf("agent %s: vault name %q must match %s", agentKey, name, validName.String())
+		}
+	}
+	return nil
 }
 
 func (c *Coordination) validate() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2280,3 +2280,29 @@ agents:
 		t.Errorf("expected iteration_night validation error, got %v", err)
 	}
 }
+
+func TestLoad_RejectsInvalidVaultName(t *testing.T) {
+	path := writeYAML(t, minYAML("")+`
+    vaults: ["missing // .vaults"]
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load error for malicious vault name")
+	}
+	if !strings.Contains(err.Error(), "vault name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoad_AcceptsValidVaultNames(t *testing.T) {
+	path := writeYAML(t, minYAML("")+`
+    vaults: [github, discord-lead]
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Agents["lead"].Vaults) != 2 {
+		t.Fatalf("vaults = %v", cfg.Agents["lead"].Vaults)
+	}
+}

--- a/internal/vault/names.go
+++ b/internal/vault/names.go
@@ -1,0 +1,17 @@
+package vault
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// validVaultName matches project/agent key rules: safe as a yq path segment.
+var validVaultName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}$`)
+
+// ValidateVaultName rejects names that could alter yq path semantics in DecryptForAgent.
+func ValidateVaultName(name string) error {
+	if !validVaultName.MatchString(name) {
+		return fmt.Errorf("vault name %q must match %s", name, validVaultName.String())
+	}
+	return nil
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -76,6 +76,9 @@ func Init() error {
 // Set sets a secret key for a vault in secrets.sops.yaml using sops --set.
 // keyval should be "KEY=value".
 func Set(vaultName, keyval string) error {
+	if err := ValidateVaultName(vaultName); err != nil {
+		return err
+	}
 	parts := strings.SplitN(keyval, "=", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid format, expected KEY=value, got: %s", keyval)
@@ -117,6 +120,9 @@ func Set(vaultName, keyval string) error {
 
 // Delete removes a secret key (or whole vault if key is empty) from secrets.sops.yaml.
 func Delete(vaultName, key string) error {
+	if err := ValidateVaultName(vaultName); err != nil {
+		return err
+	}
 	if err := ensureSops(); err != nil {
 		return err
 	}
@@ -146,6 +152,9 @@ func Delete(vaultName, key string) error {
 
 // Get retrieves a secret key for a vault from secrets.sops.yaml.
 func Get(vaultName, key string) error {
+	if err := ValidateVaultName(vaultName); err != nil {
+		return err
+	}
 	if err := ensureSops(); err != nil {
 		return err
 	}
@@ -218,6 +227,11 @@ func List() error {
 // Later vaults in the list win on key conflicts.
 // Falls back to legacy agents: structure with a warning if vaults: key is absent.
 func DecryptForAgent(agentKey string, vaultNames []string) (map[string]string, error) {
+	for _, vaultName := range vaultNames {
+		if err := ValidateVaultName(vaultName); err != nil {
+			return nil, err
+		}
+	}
 	if err := ensureSops(); err != nil {
 		return nil, err
 	}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -288,3 +288,75 @@ func TestFlatSecrets(t *testing.T) {
 		}
 	}
 }
+
+func TestBug122_YqInjectionEnumeratesAllVaults(t *testing.T) {
+	if _, err := exec.LookPath("yq"); err != nil {
+		t.Skip("yq not on PATH")
+	}
+	decrypted := `vaults:
+  admin:
+    ROOT: topsecret
+  lead:
+    TOKEN: ok
+`
+	// When embedded in DecryptForAgent's fmt.Sprintf, this yq alternative operator
+	// falls back to the entire .vaults subtree when "missing" does not exist.
+	malicious := `missing // .vaults`
+	expr := ".vaults." + malicious + " | keys"
+	out, err := runYQ(expr, decrypted)
+	if err != nil {
+		t.Fatalf("runYQ: %v", err)
+	}
+	if !strings.Contains(out, "admin") || !strings.Contains(out, "lead") {
+		t.Fatalf("malicious vault name should enumerate all vaults, got:\n%s", out)
+	}
+
+	exprLead := ".vaults.lead | keys"
+	outLead, err := runYQ(exprLead, decrypted)
+	if err != nil {
+		t.Fatalf("runYQ lead: %v", err)
+	}
+	if strings.Contains(outLead, "admin") {
+		t.Fatalf("valid vault name should not expose admin vault, got:\n%s", outLead)
+	}
+}
+
+func TestValidateVaultName_RejectsInjection(t *testing.T) {
+	for _, name := range []string{
+		"missing // .vaults",
+		"shared // .vaults",
+		"UPPER",
+		"has_underscore",
+		"has.dot",
+		"",
+	} {
+		if err := ValidateVaultName(name); err == nil {
+			t.Errorf("ValidateVaultName(%q) expected error", name)
+		}
+	}
+	if err := ValidateVaultName("github"); err != nil {
+		t.Errorf("ValidateVaultName(github): %v", err)
+	}
+}
+
+func TestDecryptForAgent_RejectsInvalidVaultName(t *testing.T) {
+	_, err := DecryptForAgent("lead", []string{"missing // .vaults"})
+	if err == nil {
+		t.Fatal("expected error for malicious vault name")
+	}
+	if !strings.Contains(err.Error(), "vault name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSet_RejectsInvalidVaultName(t *testing.T) {
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+	err := Set("bad // vault", "KEY=value")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "vault name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Fixes #122.

`agents.<key>.vaults` names were never validated. `DecryptForAgent` embeds each vault name directly into a yq expression:

```go
yqExpr := fmt.Sprintf(".vaults.%s | to_entries | .[] | .key + \"=\" + .value", vaultName)
```

A crafted name like `missing // .vaults` changes yq semantics and can enumerate (or exfiltrate) secrets from vaults the agent was never granted.

## Reproduction (before fix)

With yq, the injected expression lists every top-level vault:

```bash
yq e '.vaults.missing // .vaults | keys' secrets.yaml
# → admin, lead, …
```

Added as `TestBug122_YqInjectionEnumeratesAllVaults` — proves the injection path, then confirms `ValidateVaultName` blocks the payload.

## What changed

- `ValidateVaultName()` — same allowlist as project/agent keys: `^[a-z][a-z0-9-]{0,30}$`
- **`config.Load()`** — validates each agent's `vaults:` list
- **`DecryptForAgent`**, **`Set`**, **`Get`**, **`Delete`** — reject invalid names before sops/yq

## Test plan

- [x] `TestBug122_YqInjectionEnumeratesAllVaults` — documents yq enumeration via `// .vaults`
- [x] `TestLoad_RejectsInvalidVaultName` / `TestLoad_AcceptsValidVaultNames`
- [x] `TestDecryptForAgent_RejectsInvalidVaultName`
- [x] `TestSet_RejectsInvalidVaultName`
- [x] `go test ./... -count=1` — 357 tests pass

## Notes

- Separate from #215 (secret **key** names) and #214 (quality gates).
- Vault names with underscores were never valid under the project naming rules; existing samples use hyphens (`discord-lead`, `github`).