### PR TITLE
fix(remote): validate repoName before SSH shell commands

### DIFF
--- a/internal/remote/names.go
+++ b/internal/remote/names.go
@@ -1,0 +1,27 @@
+package remote
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var validRepoName = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,100}$`)
+
+func validateRepoName(name string) error {
+	if !validRepoName.MatchString(name) {
+		return fmt.Errorf("repo name %q contains unsafe characters — check git remote origin", name)
+	}
+	return nil
+}
+
+// ValidatedRepoName returns RepoName after rejecting shell-metacharacter payloads.
+func ValidatedRepoName() (string, error) {
+	name, err := RepoName()
+	if err != nil {
+		return "", err
+	}
+	if err := validateRepoName(name); err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -102,7 +102,7 @@ func AgeKeyPath() string {
 // 2. clone repo
 // 3. clem provision
 func Provision(host, ghToken string) error {
-	repoName, err := RepoName()
+	repoName, err := ValidatedRepoName()
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func Provision(host, ghToken string) error {
 
 // Login runs clem login on the remote host with a TTY for interactive OAuth.
 func Login(host string) error {
-	repoName, err := RepoName()
+	repoName, err := ValidatedRepoName()
 	if err != nil {
 		return err
 	}

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -113,5 +114,53 @@ func TestAgeKeyPath_UnderHomeConfig(t *testing.T) {
 	p := AgeKeyPath()
 	if !strings.HasSuffix(p, ".config/sops/age/keys.txt") {
 		t.Errorf("AgeKeyPath = %q, want ~/.config/sops/age/keys.txt", p)
+	}
+}
+
+func TestBug118_MaliciousRepoNameInjectsShellCommand(t *testing.T) {
+	malicious := `legit; touch /tmp/pwned #`
+	// Same pattern as Provision/Login — repoName is unquoted in SSH shell.
+	cmd := fmt.Sprintf("cd ~/%s && clem provision", malicious)
+	if !strings.Contains(cmd, "; touch") {
+		t.Fatalf("expected injectable command, got %q", cmd)
+	}
+	if err := validateRepoName(malicious); err == nil {
+		t.Fatal("validateRepoName should reject shell metacharacters")
+	}
+}
+
+func TestRepoName_MaliciousRemoteRejectedByValidation(t *testing.T) {
+	chdirTempGitRepo(t, "git@github.com:org/legit;touch.git")
+	name, err := RepoName()
+	if err != nil {
+		t.Fatalf("RepoName: %v", err)
+	}
+	if name != "legit;touch" {
+		t.Fatalf("RepoName = %q, want %q", name, "legit;touch")
+	}
+	if _, err := ValidatedRepoName(); err == nil {
+		t.Fatal("ValidatedRepoName should reject malicious repo name from origin URL")
+	}
+}
+
+func TestValidateRepoName_AcceptsNormalNames(t *testing.T) {
+	for _, name := range []string{"clem", "my-team", "my_team", "repo.v2"} {
+		if err := validateRepoName(name); err != nil {
+			t.Errorf("validateRepoName(%q): %v", name, err)
+		}
+	}
+}
+
+func TestValidateRepoName_RejectsUnsafe(t *testing.T) {
+	for _, name := range []string{
+		`legit; touch /tmp/pwned #`,
+		"$(id)",
+		"repo name",
+		"../etc",
+		"",
+	} {
+		if err := validateRepoName(name); err == nil {
+			t.Errorf("validateRepoName(%q) expected error", name)
+		}
 	}
 }


### PR DESCRIPTION
## Why

Fixes #118.

`clem provision --remote` and `clem login --remote` build SSH commands with `repoName` from the local `git remote origin` embedded **unquoted**:

```go
fmt.Sprintf("cd ~/%s && clem provision", repoName)
```

A crafted remote like `git@github.com:org/legit;touch.git` yields `repoName = "legit;touch"`, splitting the remote shell command at `;`.

## Reproduction

Added `TestBug118_MaliciousRepoNameInjectsShellCommand` and `TestRepoName_MaliciousRemoteRejectedByValidation`:

1. Real git repo with malicious `origin` URL → `RepoName()` returns `legit;touch`
2. Unquoted SSH command contains `;touch` injection payload
3. `ValidatedRepoName()` rejects before any SSH call

## What changed

- `validateRepoName()` — allowlist `^[a-zA-Z0-9._-]{1,100}$`
- `ValidatedRepoName()` — wraps `RepoName()` + validation
- `Provision()` and `Login()` use validated name

## Test plan

- [x] `go test ./internal/remote/... -count=1`
- [x] `go test ./... -count=1`

## Notes

Separate from vault fixes (#215, #216) and quality gates (#214). Related #127 (token cleanup) is a follow-up PR.