### PR TITLE
fix(runner): keep _backend assignment inside the python MCP-config block

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -57,9 +57,9 @@ export CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1
 # built against. Pre-0.9.5 hardcoded /usr/local/bin and broke every time
 # system Python state drifted, requiring jahwag to re-edit .mcp.json every
 # iteration because the runner overwrites it.
-_backend = '{{.CoordinationBackend}}'
 python3 -c "
 import json, os
+_backend = '{{.CoordinationBackend}}'
 def _mcp_bin(name):
     pipx = '/opt/pipx/bin/' + name
     sysbin = '/usr/local/bin/' + name
@@ -254,9 +254,9 @@ tail -500 "$LOGFILE" > "$LOGFILE.tmp" 2>/dev/null && mv "$LOGFILE.tmp" "$LOGFILE
 # Write opencode.json with Ollama provider + discord-bot MCP (if token is set).
 # MCP binary paths come from _mcp_bin (pipx-isolated venv preferred over system
 # pip install — see the claude-code runner template above for the rationale).
-_backend = '{{.CoordinationBackend}}'
 python3 -c "
 import json, os
+_backend = '{{.CoordinationBackend}}'
 def _mcp_bin(name):
     pipx = '/opt/pipx/bin/' + name
     sysbin = '/usr/local/bin/' + name

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -911,3 +911,46 @@ func TestGenerate_SkillsSyncFailureUsesPipestatusAndWarns(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerate_BackendAssignedInsidePython is a regression test: the
+// `_backend = '<backend>'` assignment must live INSIDE the python3 -c MCP-config
+// script, not on the bash line above it. The earlier layout leaked it to the
+// shell ("clem-runner.sh: line NN: _backend: command not found") and left the
+// Python block raising NameError: name '_backend' is not defined.
+func TestGenerate_BackendAssignedInsidePython(t *testing.T) {
+	cases := []struct {
+		name    string
+		runtime string
+		model   string
+	}{
+		{"claude-code", "", "claude-opus-4-7"},
+		{"opencode", "opencode", "nemotron-3-nano:4b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseCfg("lead", config.AgentConfig{
+				Name:      "Lead",
+				Runtime:   tc.runtime,
+				Model:     tc.model,
+				Iteration: "1m",
+				Prompt:    "do the thing",
+			})
+			cfg.Coordination.Backend = "github"
+
+			out := Generate(cfg, "lead")
+
+			// Buggy layout: assignment on its own bash line right before python.
+			if strings.Contains(out, "_backend = 'github'\npython3 -c \"") {
+				t.Fatal("_backend assigned in bash immediately before python3 -c — leaks to the shell")
+			}
+			py := strings.Index(out, `python3 -c "`)
+			assign := strings.Index(out, "_backend = 'github'")
+			if py == -1 || assign == -1 {
+				t.Fatalf("missing python block or _backend assignment, got:\n%s", out)
+			}
+			if assign < py {
+				t.Errorf("_backend assigned before python3 -c (runs in bash), not inside python")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

The generated `clem-runner.sh` placed the backend assignment on a **bash** line directly above the Python MCP-config heredoc:

```sh
_backend = '{{.CoordinationBackend}}'
python3 -c "
import json, os
...
if _backend != 'github' and os.environ.get('DISCORD_TOKEN'):
```

So the shell executed `_backend = 'github'` →

```
/home/<user>/.local/bin/clem-runner.sh: line 36: _backend: command not found
Traceback (most recent call last):
  File "<string>", line 12, in <module>
NameError: name '_backend' is not defined
```

The Python block (which gates Discord/Slack MCP registration) never had `_backend` defined. On the **github** backend it's non-fatal — no coordination MCP is needed — but it errors on every iteration and aborts the `.mcp.json` write.

## Fix

Move `_backend = '{{.CoordinationBackend}}'` **inside** the `python3 -c "` script, right after `import json, os`. Applied to both runner templates (claude-code and opencode), which had the identical layout.

## Test

`TestGenerate_BackendAssignedInsidePython` (table-driven over both runtimes) asserts the assignment renders after `python3 -c "` and not on a standalone bash line. Verified it **fails on the pre-fix code** and passes after. `go fmt` / `go vet` / `go test ./...` all clean.
