### PR TITLE
fix(vault): validate vault names to prevent yq expression injection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -646,6 +646,11 @@ func Load(path string) (*Config, error) {
 		if ac.EgressRestrictionExperimental {
 			fmt.Fprintf(os.Stderr, "warning: agent %s: egress_restriction_experimental is deprecated — use the top-level egress: block (pipelock + nftables containment)\n", key)
 		}
+		for _, vaultName := range ac.Vaults {
+			if !validName.MatchString(vaultName) {
+				return nil, fmt.Errorf("agent %s: vault name %q must match ^[a-z][a-z0-9-]{0,30}$", key, vaultName)
+			}
+		}
 		if ac.VaultBroker {
 			if !cfg.Vault.IsAgentVault() {
 				return nil, fmt.Errorf("agent %s: vault_broker requires vault.backend: agent-vault", key)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -452,6 +452,60 @@ func TestLoad_VaultBackends_BadNameRejected(t *testing.T) {
 	}
 }
 
+func TestLoad_AgentVaultNamesValidated(t *testing.T) {
+	bad := []string{
+		"shared // .vaults",
+		"UPPER",
+		"has space",
+		"has|pipe",
+	}
+	for _, name := range bad {
+		t.Run(name, func(t *testing.T) {
+			path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    vaults: ["`+name+`"]
+`)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load with vault name %q expected error", name)
+			}
+			if !strings.Contains(err.Error(), "vault name") {
+				t.Errorf("Load(%q) error = %v, want vault name validation message", name, err)
+			}
+		})
+	}
+}
+
+func TestLoad_AgentVaultNamesValid(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    vaults: ["shared", "github-tokens"]
+`)
+	if _, err := Load(path); err != nil {
+		t.Fatalf("Load with valid vault names: %v", err)
+	}
+}
+
 func TestLoad_PrimaryMilestoneParsed(t *testing.T) {
 	path := writeYAML(t, `
 project: myteam

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -23,6 +23,19 @@ func validateSecretKey(key string) error {
 	return nil
 }
 
+// validVaultName mirrors the allowlist used for project and agent keys.
+// Vault names land in yq path expressions in Get and DecryptForAgent; a name
+// with yq operator characters (// | . []) alters expression semantics and can
+// leak secrets from vaults the agent was never granted.
+var validVaultName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}$`)
+
+func validateVaultName(name string) error {
+	if !validVaultName.MatchString(name) {
+		return fmt.Errorf("vault name %q must match ^[a-z][a-z0-9-]{0,30}$ (same allowlist as project and agent keys)", name)
+	}
+	return nil
+}
+
 // Init generates an age keypair and saves it to ~/.config/sops/age/keys.txt.
 // Prints the public key and instructions for .sops.yaml.
 func Init() error {
@@ -87,6 +100,9 @@ func Init() error {
 // Set sets a secret key for a vault in secrets.sops.yaml using sops --set.
 // keyval should be "KEY=value".
 func Set(vaultName, keyval string) error {
+	if err := validateVaultName(vaultName); err != nil {
+		return err
+	}
 	parts := strings.SplitN(keyval, "=", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid format, expected KEY=value, got: %s", keyval)
@@ -131,6 +147,9 @@ func Set(vaultName, keyval string) error {
 
 // Delete removes a secret key (or whole vault if key is empty) from secrets.sops.yaml.
 func Delete(vaultName, key string) error {
+	if err := validateVaultName(vaultName); err != nil {
+		return err
+	}
 	if key != "" {
 		if err := validateSecretKey(key); err != nil {
 			return err
@@ -142,12 +161,9 @@ func Delete(vaultName, key string) error {
 
 	var unsetExpr string
 	if key == "" {
-		unsetExpr = fmt.Sprintf(`["vaults"]["%s"]`, strings.ReplaceAll(vaultName, `"`, `\"`))
+		unsetExpr = fmt.Sprintf(`["vaults"]["%s"]`, jqEscape(vaultName))
 	} else {
-		unsetExpr = fmt.Sprintf(`["vaults"]["%s"]["%s"]`,
-			strings.ReplaceAll(vaultName, `"`, `\"`),
-			strings.ReplaceAll(key, `"`, `\"`),
-		)
+		unsetExpr = fmt.Sprintf(`["vaults"]["%s"]["%s"]`, jqEscape(vaultName), jqEscape(key))
 	}
 
 	// sops unset takes "file index" — file before index
@@ -165,6 +181,9 @@ func Delete(vaultName, key string) error {
 
 // Get retrieves a secret key for a vault from secrets.sops.yaml.
 func Get(vaultName, key string) error {
+	if err := validateVaultName(vaultName); err != nil {
+		return err
+	}
 	if err := validateSecretKey(key); err != nil {
 		return err
 	}
@@ -177,7 +196,7 @@ func Get(vaultName, key string) error {
 		return err
 	}
 
-	yqExpr := fmt.Sprintf(".vaults.%s.%s", vaultName, key)
+	yqExpr := fmt.Sprintf(`.vaults["%s"]["%s"]`, jqEscape(vaultName), jqEscape(key))
 	out, err := runYQ(yqExpr, decrypted)
 	if err != nil {
 		return fmt.Errorf("yq: %w", err)
@@ -240,6 +259,11 @@ func List() error {
 // Later vaults in the list win on key conflicts.
 // Falls back to legacy agents: structure with a warning if vaults: key is absent.
 func DecryptForAgent(agentKey string, vaultNames []string) (map[string]string, error) {
+	for _, vaultName := range vaultNames {
+		if err := validateVaultName(vaultName); err != nil {
+			return nil, err
+		}
+	}
 	if err := ensureSops(); err != nil {
 		return nil, err
 	}
@@ -270,7 +294,7 @@ func DecryptForAgent(agentKey string, vaultNames []string) (map[string]string, e
 
 	result := make(map[string]string)
 	for _, vaultName := range vaultNames {
-		yqExpr := fmt.Sprintf(".vaults.%s | to_entries | .[] | .key + \"=\" + .value", vaultName)
+		yqExpr := fmt.Sprintf(`.vaults["%s"] | to_entries | .[] | .key + "=" + .value`, jqEscape(vaultName))
 		out, err := runYQ(yqExpr, decrypted)
 		if err != nil {
 			return nil, fmt.Errorf("yq for vault %s: %w", vaultName, err)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -220,6 +220,62 @@ func TestDelete_RejectsInvalidKeyName(t *testing.T) {
 	}
 }
 
+func TestSet_RejectsInvalidVaultName(t *testing.T) {
+	for _, name := range []string{
+		"shared // .vaults",
+		"../escape",
+		"UPPER",
+		"has space",
+		"",
+		"a|b",
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := Set(name, "KEY=value")
+			if err == nil {
+				t.Fatalf("Set(%q) expected error for invalid vault name", name)
+			}
+			if !strings.Contains(err.Error(), "vault name") {
+				t.Errorf("Set(%q) error = %v, want vault name validation message", name, err)
+			}
+		})
+	}
+}
+
+func TestGet_RejectsInvalidVaultName(t *testing.T) {
+	err := Get("shared // .vaults", "KEY")
+	if err == nil {
+		t.Fatal("expected error for injection vault name")
+	}
+	if !strings.Contains(err.Error(), "vault name") {
+		t.Errorf("got: %v", err)
+	}
+}
+
+func TestDelete_RejectsInvalidVaultName(t *testing.T) {
+	err := Delete("has|pipe", "")
+	if err == nil {
+		t.Fatal("expected error for invalid vault name")
+	}
+	if !strings.Contains(err.Error(), "vault name") {
+		t.Errorf("got: %v", err)
+	}
+}
+
+func TestDecryptForAgent_RejectsInvalidVaultName(t *testing.T) {
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	// The attack from issue #122: a vault name with yq alternative operator
+	// falls back to the entire .vaults subtree, leaking all secrets.
+	_, err := DecryptForAgent("lead", []string{"shared // .vaults"})
+	if err == nil {
+		t.Fatal("expected error for yq-injection vault name")
+	}
+	if !strings.Contains(err.Error(), "vault name") {
+		t.Errorf("got: %v", err)
+	}
+}
+
 func TestJqEscape(t *testing.T) {
 	cases := []struct {
 		input string


### PR DESCRIPTION
## Problem

Vault names in `agents[].vaults` were not validated at `config.Load()` time. `DecryptForAgent` and `Get` interpolated them raw into yq path expressions. A crafted vault name like `"shared // .vaults"` uses yq's alternative operator to fall back to the entire `.vaults` subtree, leaking every secret from every vault into the agent's merged secrets map — including vaults the agent was never granted.

```yaml
agents:
  lead:
    vaults:
      - "shared // .vaults"  # yq falls back to .vaults when shared is null
```

Produces: `.vaults.shared // .vaults | to_entries | ...` → leaks all vaults.

## Fix

- Add `validateVaultName()` in `vault.go` using `^[a-z][a-z0-9-]{0,30}$` — the same allowlist as project and agent keys
- Call it at the top of `Set`, `Get`, `Delete`, and `DecryptForAgent` (before `ensureSops`, so invalid names fail fast)
- Add vault name loop in `config.Load()` agent validation block — catches crafted clem.yaml at load time
- Switch `Get()` and `DecryptForAgent()` yq expressions from dot notation to bracket notation + `jqEscape()` for defence-in-depth (adversarial review finding: dot notation would re-open the attack if the regex were ever relaxed)
- Switch `Delete()` jq unset expression from manual quote-only replacement to `jqEscape()`, matching `Set()`'s pattern and covering backslash

## Tests

- `TestDecryptForAgent_RejectsInvalidVaultName` — the exact attack from the issue
- `TestSet/Get/Delete_RejectsInvalidVaultName` — CLI-level rejection
- `TestLoad_AgentVaultNamesValidated` — config-layer rejection for `"shared // .vaults"`, `"UPPER"`, `"has space"`, `"has|pipe"`
- `TestLoad_AgentVaultNamesValid` — valid names `"shared"`, `"github-tokens"` still pass

## Adversarial review

Ran adversarial review before this PR. Two findings addressed:
1. Dot notation in `Get()`/`DecryptForAgent()` → replaced with bracket notation + `jqEscape()` for defence-in-depth
2. `Delete()` using manual `strings.ReplaceAll` for `"` only → replaced with `jqEscape()` (covers backslash too, matches `Set()` pattern)

No critical issues remain.

Closes #122