### PR TITLE
fix(config): validate git_name to block gitconfig injection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,14 @@ var snowflakeRe = regexp.MustCompile(`^[0-9]{17,19}$`)
 // parser treats them as line or field breaks.
 var gitEmailInvalid = regexp.MustCompile(`[\s\x00-\x1f\x7f]`)
 
+// gitNameInvalid matches ASCII control characters — the characters that corrupt
+// ~/.gitconfig, where git_name lands as the value of "name = <value>" under
+// the [user] section. A newline injects a new line, allowing a crafted name
+// to add git config sections (e.g. "[commit]\n\tgpgsign = false" disables
+// commit signing). Spaces are permitted because display names like
+// "Ada Lovelace" are the common case.
+var gitNameInvalid = regexp.MustCompile(`[\x00-\x1f\x7f]`)
+
 // agentNameInvalid matches ASCII control characters — the characters that
 // corrupt the line-delimited sinks name and role are written into. The worst
 // sink is systemd unit Description= lines (a newline terminates the directive
@@ -618,6 +626,9 @@ func Load(path string) (*Config, error) {
 		}
 		if ac.GitEmail != "" && gitEmailInvalid.MatchString(ac.GitEmail) {
 			return nil, fmt.Errorf("agent %s: git_email must not contain whitespace or control characters, got %q", key, ac.GitEmail)
+		}
+		if ac.GitName != "" && gitNameInvalid.MatchString(ac.GitName) {
+			return nil, fmt.Errorf("agent %s: git_name must not contain control characters, got %q", key, ac.GitName)
 		}
 		if agentNameInvalid.MatchString(ac.Name) {
 			return nil, fmt.Errorf("agent %s: name must not contain control characters, got %q", key, ac.Name)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -679,6 +679,65 @@ agents:
 	}
 }
 
+func TestLoad_GitNameRejectsControlCharacters(t *testing.T) {
+	cases := map[string]string{
+		"newline":         "Ada\n[commit]\n\tgpgsign = false",
+		"carriage return": "Ada\rEvil",
+		"tab":             "Ada\tEvil",
+		"control char":    "Ada\x01Evil",
+	}
+	for name, gitName := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Ada"
+    model: "claude-sonnet-4-6"
+    git_name: `+fmt.Sprintf("%q", gitName)+`
+`)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load accepted git_name %q, want error", gitName)
+			}
+			if !strings.Contains(err.Error(), "git_name") {
+				t.Errorf("error should name git_name, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_GitNameAllowsSpaces(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Ada"
+    model: "claude-sonnet-4-6"
+    git_name: "Ada Lovelace"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load rejected git_name with space: %v", err)
+	}
+	ac := cfg.Agents["lead"]
+	if ac.GitName != "Ada Lovelace" {
+		t.Errorf("GitName = %q, want %q", ac.GitName, "Ada Lovelace")
+	}
+}
+
 func TestLoad_AgentNameRoleRejectControlCharacters(t *testing.T) {
 	cases := map[string]struct {
 		field string


### PR DESCRIPTION
## Problem

`git_name` from `clem.yaml` was written into `~/.gitconfig` via string concatenation in `ConfigureGit` with no validation at `config.Load()` time. A value containing a newline injects new gitconfig sections:

```yaml
agents:
  lead:
    git_name: "Ada\n[commit]\n\tgpgsign = false"
```

After `clem provision`, the agent's `~/.gitconfig` contains a `[commit]` section with `gpgsign = false`, disabling SSH commit signing despite signing infrastructure being present. This requires write access to `clem.yaml` (operator-level), so severity is medium.

`git_email` already has the equivalent guard (`gitEmailInvalid`). `git_name` did not.

## Fix

- Add `gitNameInvalid = regexp.MustCompile(`[\x00-\x1f\x7f]`)` — rejects ASCII control chars (including newlines) but allows spaces, since display names like "Ada Lovelace" are the common case.
- Validate `ac.GitName` in `config.Load()` alongside the existing `ac.GitEmail` check.

Note: The regex differs from `gitEmailInvalid` (which also rejects whitespace) because `git_name` is never used as an `allowed_signers` principal — spaces are safe in the `.gitconfig` value sink.

## Tests

- `TestLoad_GitNameRejectsControlCharacters` — newline (the injection), carriage return, tab, and a generic control char all rejected.
- `TestLoad_GitNameAllowsSpaces` — "Ada Lovelace" accepted, guarding against over-restriction.

## Adversarial review

Ran adversarial review before this PR. Key findings checked:

- Injection confirmed: newline in `git_name` does create new gitconfig sections and can override `gpgsign`.
- Regex boundary verified: unicode line separators (U+2028, NEL) are correctly allowed — git config does not split on them.
- Legitimate names (accented, CJK, emoji, O'Brien) pass validation.
- No bypass via literal `\n` escape in YAML (YAML passes the two-char sequence, not a newline).
- `Load()` is the correct enforcement boundary; no additional hardening needed in `ConfigureGit`.

No critical issues found.

Closes #120