### PR TITLE
fix(provision): use TOML literal strings in WriteWranglerConfig

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -768,9 +768,9 @@ func WriteWranglerConfig(username, homeDir string, secrets map[string]string) er
 		return fmt.Errorf("creating wrangler config dir: %w", err)
 	}
 
-	configContent := fmt.Sprintf(`oauth_token = "%s"
-expiration_time = "%s"
-refresh_token = "%s"
+	configContent := fmt.Sprintf(`oauth_token = '%s'
+expiration_time = '%s'
+refresh_token = '%s'
 scopes = [ "account:read", "user:read", "workers:write", "workers_kv:write", "workers_routes:write", "workers_scripts:write", "workers_tail:read", "d1:write", "pages:write", "zone:read", "ssl_certs:write", "ai:write", "queues:write", "pipelines:write", "secrets_store:write", "containers:write", "cloudchamber:write", "connectivity:admin", "offline_access" ]
 `, oauth, expiration, refresh)
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1777,3 +1777,45 @@ func TestWriteSystemdEnvFile_RejectsNewline(t *testing.T) {
 		t.Fatal("expected error for newline in secret value")
 	}
 }
+
+func TestWriteWranglerConfig_LiteralStringsPreserveSpecialChars(t *testing.T) {
+	homeDir := t.TempDir()
+	// These chars corrupted the file when it used TOML basic strings:
+	// " broke the string delimiter and \ was treated as an escape prefix.
+	secrets := map[string]string{
+		"WRANGLER_OAUTH_TOKEN":   `tok"en\value`,
+		"WRANGLER_REFRESH_TOKEN": `ref\res"h`,
+		"WRANGLER_EXPIRATION":    "2099-01-01T00:00:00Z",
+	}
+	if err := WriteWranglerConfig("testuser", homeDir, secrets); err != nil {
+		t.Fatalf("WriteWranglerConfig: %v", err)
+	}
+	configPath := filepath.Join(homeDir, ".config", ".wrangler", "config", "default.toml")
+	b, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	got := string(b)
+	// Values must appear verbatim inside TOML literal strings (single-quoted).
+	if !strings.Contains(got, `oauth_token = 'tok"en\value'`) {
+		t.Errorf("oauth_token not written as literal string, got:\n%s", got)
+	}
+	if !strings.Contains(got, `refresh_token = 'ref\res"h'`) {
+		t.Errorf("refresh_token not written as literal string, got:\n%s", got)
+	}
+	info, _ := os.Stat(configPath)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("config file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteWranglerConfig_SkipsWhenSecretsAbsent(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := WriteWranglerConfig("testuser", homeDir, map[string]string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	configPath := filepath.Join(homeDir, ".config", ".wrangler", "config", "default.toml")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config file should not be written when secrets absent")
+	}
+}


### PR DESCRIPTION
## Problem

`WriteWranglerConfig` wrote OAuth tokens into `default.toml` using TOML basic strings (double-quoted). TOML basic strings interpret `\` as an escape prefix and use `"` as the closing delimiter. A token value containing either character produces an invalid TOML file:

```toml
oauth_token = "tok"en-value"    # TOML parse error: unexpected char after string close
refresh_token = "C:\path\data"  # \p and \d are invalid TOML escapes
```

Wrangler parses the file at deploy time and exits with a config error; the agent's Cloudflare Workers deploys stop working. `clem provision` does not detect the bad file — it writes and exits cleanly.

The root cause is the same pattern that `WriteEnvFile` already handles with single-quote escaping, but `WriteWranglerConfig` was not updated with equivalent escaping when it was added.

## Fix

Switch to TOML literal strings (single-quoted). Literal strings pass the value through verbatim — no escape processing. The only prohibited character is a literal single quote `'`, which does not appear in any known Cloudflare token format.

```toml
oauth_token = 'tok"en\value'    # valid — value is: tok"en\value
```

The `scopes` array uses hardcoded string literals (not user-supplied values) and is left unchanged.

## Tests

- `TestWriteWranglerConfig_LiteralStringsPreserveSpecialChars` — writes secrets containing `"` and `\`, reads back the TOML, asserts the values appear verbatim inside literal strings. Also checks 0600 file permissions.
- `TestWriteWranglerConfig_SkipsWhenSecretsAbsent` — no config file written when WRANGLER_* secrets are absent (existing no-op behaviour preserved).

## Adversarial review

Quick self-check:

- **Single-quote bypass**: a token containing `'` would produce `oauth_token = 'tok'en'` — invalid TOML. This is acknowledged in the original issue; Cloudflare tokens don't use single quotes. If that assumption changes, a TOML multi-line literal string (`'''…'''`) is the safe fallback and can be added then.
- **Newline in value**: TOML literal strings are single-line; a newline in the value would create a multi-line entry that TOML rejects. This is a pre-existing behaviour (newlines would also break `WriteEnvFile`). Out of scope for this fix.
- **Scope creep**: no changes to secrets handling or file-creation logic, only the string delimiter change.

Closes #121