### PR TITLE
feat(vault): fail-safe secret exposure gate (warn/strict/off policy)

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/jahwag/clem/internal/agent"
@@ -294,6 +296,18 @@ func writeAgentEnv(agentKey string, ac config.AgentConfig, osUser, homeDir strin
 	}
 
 	flatSecrets := vault.FlatSecrets(secrets)
+
+	if policy := cfg.Vault.ExposurePolicy; policy != "off" {
+		if violations := exposureViolations(flatSecrets, ac.BrokeredSecrets, ac.RevealSecrets); len(violations) > 0 {
+			msg := fmt.Sprintf("agent %s: %d granted key(s) neither brokered nor revealed: %s\n  (add to brokered_secrets, reveal_secrets, or set vault.exposure_policy: off)",
+				agentKey, len(violations), strings.Join(violations, ", "))
+			if policy == "strict" {
+				return nil, "", fmt.Errorf("%s", msg)
+			}
+			fmt.Fprintf(os.Stderr, "  warning: %s\n", msg)
+		}
+	}
+
 	merged := make(map[string]string, len(flatSecrets)+len(providerEnv)+12)
 	if ac.VaultBroker {
 		// agent-vault brokered: consolidate this agent's brokered secrets +
@@ -348,6 +362,27 @@ func writeAgentEnv(agentKey string, ac config.AgentConfig, osUser, homeDir strin
 		fmt.Printf("  warning: agent %s has GH_TOKEN but no git_email in clem.yaml — commits may leak operator identity\n", agentKey)
 	}
 	return secrets, ghToken, nil
+}
+
+// exposureViolations returns the sorted set of keys present in flat that are
+// neither brokered nor explicitly revealed. These are candidates that the
+// exposure policy check will warn or error on.
+func exposureViolations(flat map[string]string, brokered, revealed []string) []string {
+	skip := make(map[string]bool, len(brokered)+len(revealed))
+	for _, k := range brokered {
+		skip[k] = true
+	}
+	for _, k := range revealed {
+		skip[k] = true
+	}
+	var violations []string
+	for k := range flat {
+		if !skip[k] {
+			violations = append(violations, k)
+		}
+	}
+	sort.Strings(violations)
+	return violations
 }
 
 // brokeredSeedInputs resolves everything the brokering flow needs for one

--- a/cmd/provision_test.go
+++ b/cmd/provision_test.go
@@ -209,3 +209,52 @@ func TestSidecarSecretEnv_PerAgentDecryptFailureErrors(t *testing.T) {
 		t.Fatal("decrypt failure must abort the listener, not install it secretless")
 	}
 }
+
+// --- exposureViolations: pure policy check for the fail-safe exposure gate.
+
+func TestExposureViolations_GrantedOnlyIsViolation(t *testing.T) {
+	flat := map[string]string{"API_KEY": "v", "GH_TOKEN": "t"}
+	got := exposureViolations(flat, nil, nil)
+	if len(got) != 2 {
+		t.Fatalf("want 2 violations, got %v", got)
+	}
+}
+
+func TestExposureViolations_BrokeredSuppresses(t *testing.T) {
+	flat := map[string]string{"API_KEY": "v", "GH_TOKEN": "t"}
+	got := exposureViolations(flat, []string{"API_KEY", "GH_TOKEN"}, nil)
+	if len(got) != 0 {
+		t.Errorf("brokered keys must not be violations, got %v", got)
+	}
+}
+
+func TestExposureViolations_RevealedSuppresses(t *testing.T) {
+	flat := map[string]string{"DISCORD_TOKEN": "d"}
+	got := exposureViolations(flat, nil, []string{"DISCORD_TOKEN"})
+	if len(got) != 0 {
+		t.Errorf("revealed keys must not be violations, got %v", got)
+	}
+}
+
+func TestExposureViolations_PartialCoverage(t *testing.T) {
+	flat := map[string]string{"API_KEY": "v", "DISCORD_TOKEN": "d", "DEPLOY_KEY": "k"}
+	got := exposureViolations(flat, []string{"API_KEY"}, []string{"DISCORD_TOKEN"})
+	if len(got) != 1 || got[0] != "DEPLOY_KEY" {
+		t.Errorf("want only DEPLOY_KEY as violation, got %v", got)
+	}
+}
+
+func TestExposureViolations_EmptyFlatIsClean(t *testing.T) {
+	got := exposureViolations(nil, nil, nil)
+	if len(got) != 0 {
+		t.Errorf("empty flat must yield no violations, got %v", got)
+	}
+}
+
+func TestExposureViolations_OutputIsSorted(t *testing.T) {
+	flat := map[string]string{"ZZZ": "z", "AAA": "a", "MMM": "m"}
+	got := exposureViolations(flat, nil, nil)
+	if len(got) != 3 || got[0] != "AAA" || got[1] != "MMM" || got[2] != "ZZZ" {
+		t.Errorf("violations must be sorted, got %v", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,6 +279,11 @@ type AgentConfig struct {
 	// .env materialization — this is how DISCORD_TOKEN (gateway, unbrokerable)
 	// stays real while ANTHROPIC_API_KEY/Slack/Typefully/GH_TOKEN are brokered.
 	BrokeredSecrets []string `yaml:"brokered_secrets"`
+	// RevealSecrets lists granted vault keys that are intentionally seeded as
+	// real values in the agent's .env (explicit opt-out from fail-safe exposure
+	// check). Use for keys that cannot be HTTP-brokered: deploy keys, SSH keys,
+	// gRPC credentials, WebSocket auth, non-secret usernames.
+	RevealSecrets []string `yaml:"reveal_secrets"`
 	// EgressRestrictionExperimental is DEPRECATED — superseded by the top-level
 	// egress block (pipelock + nftables). When set true it still opts the agent
 	// into egress containment (treated like egress: true) but Load logs a
@@ -566,6 +571,12 @@ func Load(path string) (*Config, error) {
 		// valid
 	default:
 		return nil, fmt.Errorf("vault.backend must be env or agent-vault, got %q", cfg.Vault.Backend)
+	}
+	switch cfg.Vault.ExposurePolicy {
+	case "", "warn", "strict", "off":
+		// valid
+	default:
+		return nil, fmt.Errorf("vault.exposure_policy must be warn, strict, or off (got %q)", cfg.Vault.ExposurePolicy)
 	}
 	sourceNames := make(map[string]bool, len(cfg.Vault.Backends))
 	sawSops := false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2306,3 +2306,38 @@ func TestLoad_AcceptsValidVaultNames(t *testing.T) {
 		t.Fatalf("vaults = %v", cfg.Agents["lead"].Vaults)
 	}
 }
+
+func TestLoad_ExposurePolicyValid(t *testing.T) {
+	for _, policy := range []string{"", "warn", "strict", "off"} {
+		line := ""
+		if policy != "" {
+			line = "\nvault:\n  exposure_policy: " + policy
+		}
+		yaml := minYAML("") + line
+		if _, err := Load(writeYAML(t, yaml)); err != nil {
+			t.Errorf("exposure_policy %q should load, got: %v", policy, err)
+		}
+	}
+}
+
+func TestLoad_ExposurePolicyRejectsInvalid(t *testing.T) {
+	yaml := minYAML("") + "\nvault:\n  exposure_policy: paranoid"
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil {
+		t.Fatal("invalid exposure_policy must be rejected")
+	}
+	if !strings.Contains(err.Error(), "exposure_policy") {
+		t.Errorf("error must name exposure_policy, got: %v", err)
+	}
+}
+
+func TestLoad_RevealSecretsAccepted(t *testing.T) {
+	yaml := minYAML("") + "\n    reveal_secrets: [DISCORD_TOKEN, DEPLOY_KEY]"
+	cfg, err := Load(writeYAML(t, yaml))
+	if err != nil {
+		t.Fatalf("reveal_secrets should load: %v", err)
+	}
+	if len(cfg.Agents["lead"].RevealSecrets) != 2 {
+		t.Errorf("reveal_secrets = %v, want 2 entries", cfg.Agents["lead"].RevealSecrets)
+	}
+}

--- a/internal/config/vaultbroker.go
+++ b/internal/config/vaultbroker.go
@@ -63,6 +63,11 @@ type VaultBackend struct {
 	// materialized for agents (env vs agent-vault broker); Backends selects
 	// where secrets come from.
 	Backends []VaultSource `yaml:"backends"`
+	// ExposurePolicy controls what happens when a granted vault key is neither
+	// listed in an agent's brokered_secrets nor its reveal_secrets: "warn"
+	// (default) prints a warning at provision and continues; "strict" blocks
+	// provisioning; "off" silences the check (legacy behaviour).
+	ExposurePolicy string `yaml:"exposure_policy"`
 }
 
 // ValidVaultSourceTypes is the authoritative set of vault.backends source


### PR DESCRIPTION
## Problem

Secret brokering is opt-in per key, making provisioning fail-open. Any key granted to an agent via `vaults:` but not listed in `brokered_secrets` is written as its real value to the agent's `.env`. Adding a new key to a granted vault silently exposes it to every agent that vault is listed for.

**Verified code paths:**

Non-brokered path (`cmd/provision.go:327–334`):
```go
for k, v := range flatSecrets {
    merged[k] = v  // all granted keys → real in .env
}
```

Brokered path (`internal/agent/manager.go:325–331`):
```go
for k, v := range flat {
    if ac.IsBrokered(k) {
        env[k] = "__" + strings.ToLower(k) + "__"
    } else {
        env[k] = v  // non-brokered granted keys also go real
    }
}
```

Both paths confirm fail-open. Neither changed by this PR.

## What this PR adds

**`vault.exposure_policy: warn | strict | off`** (default: `warn`, backward-compatible)

- `warn`: prints a warning per agent for each granted key that is neither brokered nor explicitly revealed. Provisioning continues.
- `strict`: returns an error and blocks provisioning. Operators must resolve all violations before secrets are written.
- `off`: silences the check (legacy behavior).

**Per-agent `reveal_secrets: []`**

Explicit opt-out list for keys that cannot be HTTP-brokered (deploy keys, SSH keys, gRPC credentials, WebSocket auth, non-secret usernames). These are excluded from violation detection.

**Violation detection logic** (`exposureViolations`):
```
violations = granted_keys − brokered_secrets − reveal_secrets
```

Pure function, no decryption — uses the `flatSecrets` map (already decrypted for provisioning) to check key names only.

## Scope

This PR covers the config schema + provision-time enforcement only. `clem vault lint` (run outside of provision, without a decryption key) and `clem vault audit --fix` (migration helper) are Phase 2, tracked in #225.

## Adversarial review

Ran a refute-style review before opening this PR. Findings:
- Confirmed `exposureViolations()` correctly classifies keys
- Confirmed default `warn` (empty string) is handled at provision time via `policy != "off"` guard
- Confirmed strict mode error propagates from `writeAgentEnv` → `runProvision` → exit; no bypass path
- Confirmed no injection risks in `ExposurePolicy` or `RevealSecrets` fields (string comparison + error message only)
- Integration tests for `writeAgentEnv` in strict mode require OS-level mocks (out of scope); pure-logic tests cover all branch paths in `exposureViolations`

Closes #225