### PR TITLE
feat(runtime): add codex (OpenAI) as a third runtime

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -52,6 +52,26 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		fmt.Printf("[%s] %s (%s)\n", agentKey, ac.Name, osUser)
 
 		homeDir := fmt.Sprintf("/home/%s", osUser)
+
+		if ac.RuntimeKind() == "codex" {
+			if !agent.CodexNeedsLogin(homeDir) {
+				fmt.Printf("  codex already authenticated — skipping\n")
+				continue
+			}
+			// Device-auth prints a URL + code rather than opening a browser,
+			// which is what a headless agent host needs. The binary lives at
+			// the per-user npm prefix, off the default PATH, so call it directly.
+			fmt.Printf("  running codex login as %s\n", osUser)
+			loginCmd := exec.Command("su", "-", osUser, "-c", `"$HOME/.npm-global/bin/codex" login --device-auth`)
+			loginCmd.Stdin = os.Stdin
+			loginCmd.Stdout = os.Stdout
+			loginCmd.Stderr = os.Stderr
+			if err := loginCmd.Run(); err != nil {
+				return fmt.Errorf("codex login for %s: %w", osUser, err)
+			}
+			continue
+		}
+
 		if !agent.NeedsLogin(homeDir) {
 			expiry := agent.TokenExpiry(homeDir)
 			fmt.Printf("  token valid until %s — skipping\n", expiry.Format("2006-01-02"))

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -206,10 +206,12 @@ func provisionAgent(agentKey string, ac config.AgentConfig) error {
 	}
 	content, mode, err := agentdoc.Render(cfg, agentKey, ".")
 	if err != nil {
-		return fmt.Errorf("rendering CLAUDE.local.md for %s: %w", agentKey, err)
+		return fmt.Errorf("rendering instruction file for %s: %w", agentKey, err)
 	}
 	if content != nil {
-		dst := filepath.Join(workDir, "CLAUDE.local.md")
+		// Each runtime reads a different instruction file from the work dir:
+		// claude-code → CLAUDE.local.md, opencode/codex → AGENTS.md.
+		dst := filepath.Join(workDir, ac.InstructionFileName())
 		if err := os.WriteFile(dst, content, 0644); err != nil {
 			return fmt.Errorf("writing %s: %w", dst, err)
 		}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1056,6 +1056,28 @@ func NeedsLogin(homeDir string) bool {
 	return !HasRefreshToken(homeDir)
 }
 
+// CodexNeedsLogin returns true when manual `codex login` is required for the
+// user whose home is homeDir: the codex auth cache (~/.codex/auth.json) is
+// missing, unreadable, or carries neither an OAuth refresh token nor an API
+// key. Like Claude's NeedsLogin, the short-lived access token is not checked —
+// codex refreshes it transparently from the refresh token.
+func CodexNeedsLogin(homeDir string) bool {
+	data, err := os.ReadFile(filepath.Join(homeDir, ".codex", "auth.json"))
+	if err != nil {
+		return true
+	}
+	var auth struct {
+		OpenAIAPIKey string `json:"OPENAI_API_KEY"`
+		Tokens       struct {
+			RefreshToken string `json:"refresh_token"`
+		} `json:"tokens"`
+	}
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return true
+	}
+	return auth.Tokens.RefreshToken == "" && auth.OpenAIAPIKey == ""
+}
+
 // ChownPath changes ownership of a path to the given user (best effort).
 // Errors are intentionally swallowed — callers use this for tidy-up where
 // a failure doesn't block the operation. Prefer chownToUser for fatal paths.
@@ -1095,16 +1117,44 @@ func EnsureOwnedDir(path, username string) error {
 }
 
 // InstallRuntime installs the CLI for the given runtime kind as the agent's
-// OS user. Supported: "claude-code" (default), "opencode".
+// OS user. Supported: "claude-code" (default), "opencode", "codex".
 func InstallRuntime(username, kind string) error {
 	switch kind {
 	case "", "claude-code":
 		return InstallClaude(username)
 	case "opencode":
 		return InstallOpencode(username)
+	case "codex":
+		return InstallCodex(username)
 	default:
 		return fmt.Errorf("unknown runtime %q", kind)
 	}
+}
+
+// InstallCodex installs OpenAI's codex CLI for the given user via npm. Codex is
+// distributed on npm (no curl|bash installer like claude/opencode), so this
+// requires Node.js/npm to be present for the agent user. It uses a per-user
+// global prefix so the binary is owned by the agent (self-update works) and
+// lands at the stable path the runner invokes: ~/.npm-global/bin/codex.
+func InstallCodex(username string) error {
+	script := "set -e; " +
+		"command -v npm >/dev/null 2>&1 || { echo 'npm not found: install Node.js/npm for this user before provisioning a codex agent' >&2; exit 1; }; " +
+		"npm config set prefix \"$HOME/.npm-global\"; " +
+		"npm install -g @openai/codex@latest"
+	cmd := exec.Command("sudo", "-iu", username, "bash", "-c", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("installing codex for %s: %w\n%s", username, err, out)
+	}
+	binPath := fmt.Sprintf("/home/%s/.npm-global/bin/codex", username)
+	info, err := os.Stat(binPath)
+	if err != nil {
+		return fmt.Errorf("codex not found at %s after install: %w", binPath, err)
+	}
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("codex at %s is not executable", binPath)
+	}
+	return nil
 }
 
 // InstallOpencode runs the official opencode install script as the given user.

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -729,6 +729,61 @@ func TestHasRefreshToken(t *testing.T) {
 	}
 }
 
+func writeCodexAuth(t *testing.T, dir string, auth map[string]any) {
+	t.Helper()
+	codexDir := filepath.Join(dir, ".codex")
+	if err := os.MkdirAll(codexDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCodexNeedsLogin(t *testing.T) {
+	// No auth.json at all → needs login.
+	if !CodexNeedsLogin(t.TempDir()) {
+		t.Error("missing auth.json should require login")
+	}
+
+	// auth.json with neither refresh token nor API key → needs login.
+	dir := t.TempDir()
+	writeCodexAuth(t, dir, map[string]any{"tokens": map[string]any{"access_token": "short"}})
+	if !CodexNeedsLogin(dir) {
+		t.Error("auth without refresh token or API key should require login")
+	}
+
+	// OAuth refresh token present → authenticated.
+	dir = t.TempDir()
+	writeCodexAuth(t, dir, map[string]any{"tokens": map[string]any{"refresh_token": "rt_abc"}})
+	if CodexNeedsLogin(dir) {
+		t.Error("auth with refresh token should not require login")
+	}
+
+	// API-key login (no OAuth tokens) → authenticated.
+	dir = t.TempDir()
+	writeCodexAuth(t, dir, map[string]any{"OPENAI_API_KEY": "sk-test"})
+	if CodexNeedsLogin(dir) {
+		t.Error("auth with API key should not require login")
+	}
+
+	// Malformed JSON → needs login (fail safe).
+	dir = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".codex"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".codex", "auth.json"), []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if !CodexNeedsLogin(dir) {
+		t.Error("malformed auth.json should require login")
+	}
+}
+
 func TestWriteSettings_WritesExpectedFiles(t *testing.T) {
 	stub := withStub(t)
 	dir := t.TempDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -409,8 +409,23 @@ func (ac AgentConfig) RuntimeKind() string {
 		return "claude-code"
 	case "opencode":
 		return "opencode"
+	case "codex":
+		return "codex"
 	default:
 		return ac.Runtime
+	}
+}
+
+// InstructionFileName is the per-agent instruction file the agent's runtime
+// reads from its work directory. claude-code reads CLAUDE.local.md; opencode and
+// codex follow the AGENTS.md convention (neither reads CLAUDE.local.md). clem
+// renders the same content; only the filename differs by runtime.
+func (ac AgentConfig) InstructionFileName() string {
+	switch ac.RuntimeKind() {
+	case "opencode", "codex":
+		return "AGENTS.md"
+	default:
+		return "CLAUDE.local.md"
 	}
 }
 
@@ -618,10 +633,10 @@ func Load(path string) (*Config, error) {
 			return nil, fmt.Errorf("agent key must match ^[a-z][a-z0-9-]{0,30}$, got: %q", key)
 		}
 		switch ac.RuntimeKind() {
-		case "claude-code", "opencode":
+		case "claude-code", "opencode", "codex":
 			// supported
 		default:
-			return nil, fmt.Errorf("agent %s: unknown runtime %q (valid: claude-code, opencode)", key, ac.Runtime)
+			return nil, fmt.Errorf("agent %s: unknown runtime %q (valid: claude-code, opencode, codex)", key, ac.Runtime)
 		}
 		if ac.Model != "" && !modelRe.MatchString(ac.Model) {
 			return nil, fmt.Errorf("agent %s: model %q must match %s (rendered into a quoted shell argument in runner.sh)", key, ac.Model, modelRe.String())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1958,6 +1958,43 @@ func TestValidateMCPSidecars_OpencodeRejected(t *testing.T) {
 	}
 }
 
+func TestValidateMCPSidecars_CodexAllowed(t *testing.T) {
+	// codex speaks streamable-HTTP MCP, so sidecars are supported (unlike opencode).
+	cfg := &Config{
+		Project: "t",
+		MCPSidecars: MCPSidecarsConfig{Servers: []SidecarServer{
+			{Name: "es-ro", Identity: "shared", Command: "/bin/x", Secrets: []string{"K"}, SecretsVault: "infra"},
+		}},
+		Agents: map[string]AgentConfig{
+			"lead": {Name: "L", Runtime: "codex", Sidecars: []string{"es-ro"}},
+		},
+	}
+	if err := cfg.validateMCPSidecars(); err != nil {
+		t.Fatalf("codex sidecars should be allowed, got: %v", err)
+	}
+}
+
+func TestRuntimeKind_Codex(t *testing.T) {
+	if got := (AgentConfig{Runtime: "codex"}).RuntimeKind(); got != "codex" {
+		t.Fatalf("RuntimeKind() = %q, want codex", got)
+	}
+}
+
+func TestInstructionFileName(t *testing.T) {
+	cases := map[string]string{
+		"":            "CLAUDE.local.md", // default = claude-code
+		"claude-code": "CLAUDE.local.md",
+		"claude":      "CLAUDE.local.md",
+		"opencode":    "AGENTS.md",
+		"codex":       "AGENTS.md",
+	}
+	for runtime, want := range cases {
+		if got := (AgentConfig{Runtime: runtime}).InstructionFileName(); got != want {
+			t.Errorf("runtime %q: InstructionFileName() = %q, want %q", runtime, got, want)
+		}
+	}
+}
+
 func TestValidateMCPSidecars_AgentVaultPortCollision(t *testing.T) {
 	cfg := &Config{
 		Project: "t",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -130,11 +130,11 @@ while true; do
     PROMPT='{{.Prompt}}'
     RUNNER_WARNINGS=""
 
-    # Guard: CLAUDE.local.md too large (token waste)
-    if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
-        SIZE=$(stat -c %s "$WORKDIR/CLAUDE.local.md" 2>/dev/null || echo 0)
+    # Guard: {{.InstructionFile}} too large (token waste)
+    if [ -f "$WORKDIR/{{.InstructionFile}}" ]; then
+        SIZE=$(stat -c %s "$WORKDIR/{{.InstructionFile}}" 2>/dev/null || echo 0)
         if (( SIZE > MAX_CLAUDE_MD_BYTES )); then
-            log "WARNING: CLAUDE.local.md is ${SIZE} bytes (max ${MAX_CLAUDE_MD_BYTES}) — alerting"
+            log "WARNING: {{.InstructionFile}} is ${SIZE} bytes (max ${MAX_CLAUDE_MD_BYTES}) — alerting"
             source "$HOME/.env" 2>/dev/null
             {{.AlertCurl}}
         fi
@@ -312,11 +312,11 @@ while true; do
     PROMPT='{{.Prompt}}'
     RUNNER_WARNINGS=""
 
-    # Guard: CLAUDE.local.md too large (token waste)
-    if [ -f "$WORKDIR/CLAUDE.local.md" ]; then
-        SIZE=$(stat -c %s "$WORKDIR/CLAUDE.local.md" 2>/dev/null || echo 0)
+    # Guard: {{.InstructionFile}} too large (token waste)
+    if [ -f "$WORKDIR/{{.InstructionFile}}" ]; then
+        SIZE=$(stat -c %s "$WORKDIR/{{.InstructionFile}}" 2>/dev/null || echo 0)
         if (( SIZE > MAX_CLAUDE_MD_BYTES )); then
-            log "WARNING: CLAUDE.local.md is ${SIZE} bytes (max ${MAX_CLAUDE_MD_BYTES}) — alerting"
+            log "WARNING: {{.InstructionFile}} is ${SIZE} bytes (max ${MAX_CLAUDE_MD_BYTES}) — alerting"
             source "$HOME/.env" 2>/dev/null
             {{.AlertCurl}}
         fi
@@ -333,6 +333,152 @@ while true; do
      sleep 10 && tmux send-keys -l -t {{.AgentKey}} "$PROMPT"
      sleep 2 && tmux send-keys -t {{.AgentKey}} Enter) &
     timeout 7200 $OPENCODE $MODEL_ARG
+
+    EXIT_CODE=$?
+    ELAPSED=$(( $(date +%s) - START ))
+    log "Exited $EXIT_CODE after ${ELAPSED}s"
+
+    HOUR=$(date +%H)
+    if [ "$HOUR" -ge 7 ] && [ "$HOUR" -lt 22 ]; then
+        SLEEP_BETWEEN=$SLEEP_ACTIVE
+    else
+        SLEEP_BETWEEN=$SLEEP_NIGHT
+    fi
+
+    if [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
+        BACKOFF=$SLEEP_BETWEEN
+    else
+        BACKOFF=$(( BACKOFF * 2 ))
+        [ $BACKOFF -gt $MAX_BACKOFF ] && BACKOFF=$MAX_BACKOFF
+    fi
+
+    log "Sleeping ${BACKOFF}s"
+    sleep $BACKOFF
+done
+`
+
+// codexRunnerTemplate is the runner loop for agents using OpenAI's codex CLI.
+// Codex speaks the OpenAI wire format natively (ChatGPT OAuth or OPENAI_API_KEY),
+// so like opencode there is no Anthropic-format translator in the middle. It keeps
+// the same interactive-TUI contract as claude-code: a long-lived TUI, tmux
+// send-keys prompt injection, and the prompt ending in "kill $PPID" to advance
+// the loop. MCP servers are configured via ~/.codex/config.toml (TOML, not JSON).
+// Codex supports streamable-HTTP MCP, so privileged sidecars work here too.
+const codexRunnerTemplate = `#!/bin/bash
+set -m
+BACKOFF=10
+MAX_BACKOFF=900
+RESET_AFTER=300
+CODEX="$HOME/.npm-global/bin/codex"
+WORKDIR="$HOME/{{.Project}}"
+LOGFILE="$HOME/.claude/{{.AgentKey}}-runner.log"
+
+mkdir -p "$HOME/.claude" "$HOME/.codex"
+cd "$WORKDIR" || exit 1
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOGFILE"; }
+tail -500 "$LOGFILE" > "$LOGFILE.tmp" 2>/dev/null && mv "$LOGFILE.tmp" "$LOGFILE" 2>/dev/null
+
+{{.ProxyExport}}
+# Load secrets (written by clem provision, never committed) before the config
+# writer reads them from the environment.
+[ -f "$HOME/.env" ] && source "$HOME/.env"
+
+# Write ~/.codex/config.toml from env. Top-level keys MUST precede any [table]
+# header in TOML, so the auth/trust keys are emitted before the mcp_servers
+# tables. Auth is forced to file-based storage because a systemd OS user has no
+# unlocked OS keyring; forced_login_method=chatgpt matches the clem login flow.
+python3 -c "
+import os
+_backend = '{{.CoordinationBackend}}'
+def _mcp_bin(name):
+    pipx = '/opt/pipx/bin/' + name
+    sysbin = '/usr/local/bin/' + name
+    return pipx if os.path.exists(pipx) else sysbin
+def _s(v):
+    return '\"' + str(v).replace('\\\\', '\\\\\\\\').replace('\"', '\\\\\"') + '\"'
+lines = []
+lines.append('cli_auth_credentials_store = \"file\"')
+lines.append('mcp_oauth_credentials_store = \"file\"')
+lines.append('forced_login_method = \"chatgpt\"')
+lines.append('')
+# Trust the work directory so project-scoped config layers load without a prompt.
+lines.append('[projects.' + _s(os.path.expanduser('~/{{.Project}}')) + ']')
+lines.append('trust_level = \"trusted\"')
+lines.append('')
+def _stdio(name, command, args=None, env=None):
+    lines.append('[mcp_servers.' + name + ']')
+    lines.append('command = ' + _s(command))
+    if args:
+        lines.append('args = [' + ', '.join(_s(a) for a in args) + ']')
+    if env:
+        lines.append('env = { ' + ', '.join(k + ' = ' + _s(v) for k, v in env.items()) + ' }')
+    lines.append('')
+def _http(name, url):
+    lines.append('[mcp_servers.' + name + ']')
+    lines.append('url = ' + _s(url))
+    lines.append('')
+# Discord bot (same gateway-watcher behaviour as the claude runner).
+if _backend != 'github' and os.environ.get('DISCORD_TOKEN'):
+    _denv = {'DISCORD_TOKEN': os.environ['DISCORD_TOKEN']}
+    _watch = '{{.WatchChannelIDs}}'
+    if _watch:
+        _denv['DISCORD_WATCH_CHANNELS'] = _watch
+        _denv['CLEM_TMUX_TARGET'] = '{{.AgentKey}}'
+    _stdio('discord-bot', _mcp_bin('mcp-discord'), env=_denv)
+# Slack (korotovsky/slack-mcp-server), write access on by default.
+if _backend != 'github' and os.environ.get('SLACK_MCP_XOXP_TOKEN'):
+    _sargs = ['--transport', 'stdio']
+    if os.environ.get('SLACK_MCP_ENABLED_TOOLS'):
+        _sargs += ['--enabled-tools', os.environ['SLACK_MCP_ENABLED_TOOLS']]
+    _stdio('slack-mcp', _mcp_bin('slack-mcp-server'), args=_sargs, env={
+        'SLACK_MCP_XOXP_TOKEN': os.environ['SLACK_MCP_XOXP_TOKEN'],
+        'SLACK_MCP_ADD_MESSAGE_TOOL': os.environ.get('SLACK_MCP_ADD_MESSAGE_TOOL', 'true'),
+    })
+# Social media (Typefully backend — local MCP server).
+if os.environ.get('TYPEFULLY_API_KEY'):
+    _stdio('social', _mcp_bin('social-mcp'), env={'TYPEFULLY_API_KEY': os.environ['TYPEFULLY_API_KEY']})
+# Privileged MCP sidecars over loopback streamable-HTTP (codex supports url MCP).
+for _name, _port in {{.SidecarServers}}:
+    _http(_name, 'http://127.0.0.1:%d/mcp' % _port)
+open(os.path.expanduser('~/.codex/config.toml'), 'w').write('\n'.join(lines) + '\n')
+"
+
+SLEEP_ACTIVE={{.SleepActive}}
+SLEEP_NIGHT={{.SleepNight}}
+MAX_CLAUDE_MD_BYTES=12288
+
+while true; do
+    START=$(date +%s)
+    PROMPT='{{.Prompt}}'
+    RUNNER_WARNINGS=""
+
+    # Guard: {{.InstructionFile}} too large (token waste)
+    if [ -f "$WORKDIR/{{.InstructionFile}}" ]; then
+        SIZE=$(stat -c %s "$WORKDIR/{{.InstructionFile}}" 2>/dev/null || echo 0)
+        if (( SIZE > MAX_CLAUDE_MD_BYTES )); then
+            log "WARNING: {{.InstructionFile}} is ${SIZE} bytes (max ${MAX_CLAUDE_MD_BYTES}) — alerting"
+            source "$HOME/.env" 2>/dev/null
+            {{.AlertCurl}}
+        fi
+    fi
+
+    log "Updating codex"
+    npm install -g @openai/codex@latest 2>&1 | tail -3 | tee -a "$LOGFILE" || log "codex update failed, continuing with current version"
+
+    {{.SkillsSyncCmd}}
+
+    [ -n "$RUNNER_WARNINGS" ] && PROMPT="${RUNNER_WARNINGS}${PROMPT}"
+
+    log "Starting {{.AgentName}} (fresh session)"
+    (sleep 1 && tmux send-keys -t {{.AgentKey}} "" Enter
+     sleep 25 && tmux send-keys -l -t {{.AgentKey}} "$PROMPT"
+     sleep 2 && tmux send-keys -t {{.AgentKey}} Enter) &
+    MODEL_ARG=""
+    [ -n '{{.Model}}' ] && MODEL_ARG="--model {{.Model}}"
+    timeout 7200 "$CODEX" --dangerously-bypass-approvals-and-sandbox \
+        $MODEL_ARG \
+        -C "$WORKDIR"
 
     EXIT_CODE=$?
     ELAPSED=$(( $(date +%s) - START ))
@@ -458,6 +604,10 @@ type RunnerParams struct {
 	// to refresh the agent's ~/.claude/skills/ symlinks from the team skills
 	// repo. Empty when cfg.SkillsRepo is unset, in which case no sync runs.
 	SkillsSyncCmd string
+	// InstructionFile is the per-agent instruction file the runtime reads from
+	// the work dir (CLAUDE.local.md for claude-code, AGENTS.md for opencode/codex).
+	// Used by the oversize guard so it checks the file the runtime actually reads.
+	InstructionFile string
 }
 
 // bashDoubleQuoteEscaper escapes the four characters that stay live inside a
@@ -505,7 +655,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 
 	alertChannel := cfg.Coordination.Channels["alerts"]
 	backend, _ := coordination.Known(cfg.Coordination.Backend) // validated at load time
-	alertMsg := fmt.Sprintf(`⚠️ %s: CLAUDE.local.md is ${SIZE} bytes (>${MAX_CLAUDE_MD_BYTES}). Trim it to reduce token waste.`, escapeForAlert(ac.Name))
+	alertMsg := fmt.Sprintf(`⚠️ %s: %s is ${SIZE} bytes (>${MAX_CLAUDE_MD_BYTES}). Trim it to reduce token waste.`, escapeForAlert(ac.Name), ac.InstructionFileName())
 	alertCurlBody := coordination.RenderAlert(backend, coordination.AlertParams{
 		Repo:    cfg.Coordination.GithubRepo,
 		Channel: alertChannel,
@@ -557,10 +707,13 @@ func Generate(cfg *config.Config, agentKey string) string {
 		ProxyExport:         proxyExportBlock(cfg, agentKey),
 		SidecarServers:      sidecarServersLiteral(cfg, agentKey),
 		SkillsSyncCmd:       skillsSyncCmd,
+		InstructionFile:     ac.InstructionFileName(),
 	}
 	switch ac.RuntimeKind() {
 	case "opencode":
 		return renderTemplate(opencodeRunnerTemplate, p)
+	case "codex":
+		return renderTemplate(codexRunnerTemplate, p)
 	default:
 		return renderTemplate(runnerTemplate, p)
 	}
@@ -608,8 +761,8 @@ func buildHardeningDirectives(homeDir, _ string) string {
 	// when present, not required.
 	return fmt.Sprintf(
 		"NoNewPrivileges=yes\nProtectSystem=strict\nPrivateTmp=yes\n"+
-			"ReadOnlyPaths=-%s/CLAUDE.md -%s/CLAUDE.local.md\n",
-		homeDir, homeDir,
+			"ReadOnlyPaths=-%s/CLAUDE.md -%s/CLAUDE.local.md -%s/AGENTS.md\n",
+		homeDir, homeDir, homeDir,
 	)
 }
 
@@ -717,6 +870,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.CoordinationBackend}}", p.CoordinationBackend,
 		"{{.GitHubWatchUnitDeps}}", p.GitHubWatchUnitDeps,
 		"{{.SkillsSyncCmd}}", p.SkillsSyncCmd,
+		"{{.InstructionFile}}", p.InstructionFile,
 	)
 	return r.Replace(tmpl)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -650,7 +650,7 @@ func TestGenerateService_HardeningUsesAbsoluteHomePath(t *testing.T) {
 	}
 }
 
-func TestGenerate_OpencodeRunnerHasClaudeMdGuard(t *testing.T) {
+func TestGenerate_OpencodeRunnerHasInstructionGuard(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:      "Lead",
 		Runtime:   "opencode",
@@ -660,16 +660,79 @@ func TestGenerate_OpencodeRunnerHasClaudeMdGuard(t *testing.T) {
 	})
 	out := Generate(cfg, "lead")
 
+	// opencode reads AGENTS.md, not CLAUDE.local.md, so the oversize guard must
+	// check the file the runtime actually reads.
 	for _, want := range []string{
 		"MAX_CLAUDE_MD_BYTES=12288",
 		"MAX_LESSONS_MESSAGES=25",
-		`if [ -f "$WORKDIR/CLAUDE.local.md" ]`,
+		`if [ -f "$WORKDIR/AGENTS.md" ]`,
 		"SIZE > MAX_CLAUDE_MD_BYTES",
-		"WARNING: CLAUDE.local.md is ${SIZE} bytes",
+		"WARNING: AGENTS.md is ${SIZE} bytes",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("opencode runner missing CLAUDE.local.md guard: expected %q\nfull output:\n%s", want, out)
+			t.Errorf("opencode runner missing AGENTS.md guard: expected %q\nfull output:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "CLAUDE.local.md") {
+		t.Errorf("opencode runner should not reference CLAUDE.local.md (uses AGENTS.md)")
+	}
+}
+
+func TestGenerate_CodexRunnerSelected(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Runtime:   "codex",
+		Model:     "gpt-5.4-codex",
+		Iteration: "1m",
+		Prompt:    "do the thing. When done, run: kill $PPID",
+	})
+	out := Generate(cfg, "lead")
+
+	for _, want := range []string{
+		`CODEX="$HOME/.npm-global/bin/codex"`,            // codex binary path
+		"~/.codex/config.toml",                            // TOML config target
+		`cli_auth_credentials_store = \"file\"`,           // headless auth store
+		`forced_login_method = \"chatgpt\"`,               // clem login OAuth flow
+		"[mcp_servers.",                                    // TOML MCP tables
+		"--dangerously-bypass-approvals-and-sandbox",      // unattended execution
+		`timeout 7200 "$CODEX"`,                            // 2h interactive TUI cap
+		"tmux send-keys -l -t lead",                        // prompt injection contract
+		"--model gpt-5.4-codex",                            // model passthrough
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("codex runner missing %q\nfull output:\n%s", want, out)
+		}
+	}
+
+	// Codex must NOT carry the Anthropic-only quota/effort machinery.
+	if strings.Contains(out, "credentials.json") {
+		t.Errorf("codex runner should not reference claude credentials.json")
+	}
+}
+
+func TestGenerate_CodexRunnerHasInstructionGuard(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Runtime:   "codex",
+		Model:     "gpt-5.4-codex",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+
+	// codex reads AGENTS.md, not CLAUDE.local.md.
+	for _, want := range []string{
+		"MAX_CLAUDE_MD_BYTES=12288",
+		`if [ -f "$WORKDIR/AGENTS.md" ]`,
+		"SIZE > MAX_CLAUDE_MD_BYTES",
+		"WARNING: AGENTS.md is ${SIZE} bytes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("codex runner missing AGENTS.md guard: expected %q\nfull output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "CLAUDE.local.md") {
+		t.Errorf("codex runner should not reference CLAUDE.local.md (uses AGENTS.md)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `agent.runtime: codex` alongside `claude-code` and `opencode`. Codex speaks the OpenAI wire format natively (like opencode), so it needs no Anthropic-format translator — it's the natural runtime for ChatGPT/OpenAI-backed agents.

## What's included

- **config** — `RuntimeKind()` + validation accept `codex`. Sidecars are allowed for codex (it supports streamable-HTTP MCP, unlike opencode).
- **runner** — new codex template that preserves the interactive-TUI contract (tmux `send-keys` injection, `kill $PPID` to advance the loop). Writes `~/.codex/config.toml` (TOML MCP servers, stdio + HTTP sidecars), forces file-based auth + a trusted workdir so a headless service user with no OS keyring works, and self-updates via npm.
- **provision** — `InstallCodex` installs the codex CLI via npm into a per-user prefix (binary owned by the agent user).
- **login** — `clem login` runs `codex login --device-auth` for codex agents; `CodexNeedsLogin` checks `~/.codex/auth.json`.

## Bonus fix: per-runtime instruction file

clem always wrote `CLAUDE.local.md`, but **opencode reads `AGENTS.md` (or `CLAUDE.md`), never `CLAUDE.local.md`** — so opencode agents were silently missing their rendered instructions. Codex has the same convention.

Provision now writes the file each runtime actually reads:

| Runtime | Instruction file |
|---|---|
| claude-code | `CLAUDE.local.md` (unchanged) |
| opencode | `AGENTS.md` |
| codex | `AGENTS.md` |

A single `InstructionFileName()` helper drives provision, the oversize guard, and the alert text so the name can't drift. claude-code's path is byte-for-byte unchanged.

## Tests

Cover runtime validation, per-runtime template selection, the codex config/login path, the instruction-file mapping for all three runtimes, and a regression assertion that the claude-code path is untouched. `go build`, `go vet`, and `go test ./...` all pass.

## Verification

Manually verified end-to-end on a Linux host: provisioning + npm install of codex, OAuth login, interactive session under systemd/tmux, ttyd web terminal, stdio MCP tool calls (read + write round-trip), and confirmed codex loads its rendered `AGENTS.md` (a standing-instruction marker only present in that file showed up in the agent's output).