### PR TITLE
feat(vault): add rename command for vaults and secret keys

### DIFF
--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -66,6 +66,21 @@ var vaultDeleteCmd = &cobra.Command{
 	},
 }
 
+var vaultRenameCmd = &cobra.Command{
+	Use:   "rename <vault> <new-vault> | <vault> <old-key> <new-key>",
+	Short: "Rename a vault, or a secret key within a vault, in secrets.sops.yaml",
+	Long: "Two args renames a vault; three args renames a key within a vault.\n" +
+		"Each secret is re-encrypted under the new name (sops binds the YAML\n" +
+		"key path into every value's AAD, so a raw key edit breaks decryption).",
+	Args: cobra.RangeArgs(2, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 2 {
+			return vault.RenameVault(args[0], args[1])
+		}
+		return vault.RenameKey(args[0], args[1], args[2])
+	},
+}
+
 var vaultMigrateAddr string
 
 var vaultMigrateCmd = &cobra.Command{
@@ -109,6 +124,6 @@ var vaultMigrateCmd = &cobra.Command{
 
 func init() {
 	vaultMigrateCmd.Flags().StringVar(&vaultMigrateAddr, "addr", "", "agent-vault management API address")
-	vaultCmd.AddCommand(vaultInitCmd, vaultSetCmd, vaultGetCmd, vaultListCmd, vaultDeleteCmd, vaultMigrateCmd)
+	vaultCmd.AddCommand(vaultInitCmd, vaultSetCmd, vaultGetCmd, vaultListCmd, vaultDeleteCmd, vaultRenameCmd, vaultMigrateCmd)
 	rootCmd.AddCommand(vaultCmd)
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -169,6 +169,124 @@ func Delete(vaultName, key string) error {
 	return nil
 }
 
+// looseVaultName also accepts the legacy underscore names that ValidateVaultName
+// now rejects, so a vault stuck with an old illegal name can still be renamed away.
+var looseVaultName = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]{0,30}$`)
+
+func validateLooseVaultName(name string) error {
+	if !looseVaultName.MatchString(name) {
+		return fmt.Errorf("vault name %q has characters unsafe as a yq path segment", name)
+	}
+	return nil
+}
+
+// RenameVault renames an entire vault. sops binds the YAML key path into each
+// value's AAD, so a raw key edit breaks decryption — every secret must be
+// re-encrypted under the new name via sops --set, then the old vault unset.
+func RenameVault(oldName, newName string) error {
+	if err := validateLooseVaultName(oldName); err != nil {
+		return err
+	}
+	if err := ValidateVaultName(newName); err != nil {
+		return err
+	}
+	if oldName == newName {
+		return fmt.Errorf("old and new vault names are identical: %q", oldName)
+	}
+	if err := ensureSops(); err != nil {
+		return err
+	}
+	decrypted, err := sopsDecrypt()
+	if err != nil {
+		return err
+	}
+	if exists, _ := yamlKeyExists(".vaults."+oldName, decrypted); !exists {
+		return fmt.Errorf("vault %q not found in %s", oldName, secretsFile)
+	}
+	if taken, _ := yamlKeyExists(".vaults."+newName, decrypted); taken {
+		return fmt.Errorf("vault %q already exists — refusing to overwrite", newName)
+	}
+	entries, err := vaultEntries(oldName, decrypted)
+	if err != nil {
+		return err
+	}
+	for _, kv := range entries {
+		setExpr := fmt.Sprintf(`["vaults"]["%s"]["%s"] "%s"`,
+			jqEscape(newName), jqEscape(kv[0]), jqEscape(kv[1]))
+		if out, err := exec.Command("sops", "--set", setExpr, secretsFile).CombinedOutput(); err != nil {
+			return fmt.Errorf("sops --set %s.%s: %w\n%s", newName, kv[0], err, out)
+		}
+	}
+	unsetExpr := fmt.Sprintf(`["vaults"]["%s"]`, jqEscape(oldName))
+	if out, err := exec.Command("sops", "unset", secretsFile, unsetExpr).CombinedOutput(); err != nil {
+		return fmt.Errorf("sops unset %s: %w\n%s", oldName, err, out)
+	}
+	fmt.Printf("Renamed vault %s -> %s (%d secret(s))\n", oldName, newName, len(entries))
+	return nil
+}
+
+// RenameKey renames a single secret key within a vault, re-encrypting its value
+// under the new key (same AAD constraint as RenameVault).
+func RenameKey(vaultName, oldKey, newKey string) error {
+	if err := validateLooseVaultName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretKey(newKey); err != nil {
+		return err
+	}
+	if oldKey == newKey {
+		return fmt.Errorf("old and new key names are identical: %q", oldKey)
+	}
+	if err := ensureSops(); err != nil {
+		return err
+	}
+	decrypted, err := sopsDecrypt()
+	if err != nil {
+		return err
+	}
+	if exists, _ := yamlKeyExists(fmt.Sprintf(".vaults.%s.%s", vaultName, oldKey), decrypted); !exists {
+		return fmt.Errorf("%s.%s not found in %s", vaultName, oldKey, secretsFile)
+	}
+	if taken, _ := yamlKeyExists(fmt.Sprintf(".vaults.%s.%s", vaultName, newKey), decrypted); taken {
+		return fmt.Errorf("%s.%s already exists — refusing to overwrite", vaultName, newKey)
+	}
+	value, err := runYQ(fmt.Sprintf(".vaults.%s.%s", vaultName, oldKey), decrypted)
+	if err != nil {
+		return fmt.Errorf("yq reading %s.%s: %w", vaultName, oldKey, err)
+	}
+	setExpr := fmt.Sprintf(`["vaults"]["%s"]["%s"] "%s"`,
+		jqEscape(vaultName), jqEscape(newKey), jqEscape(strings.TrimRight(value, "\n")))
+	if out, err := exec.Command("sops", "--set", setExpr, secretsFile).CombinedOutput(); err != nil {
+		return fmt.Errorf("sops --set %s.%s: %w\n%s", vaultName, newKey, err, out)
+	}
+	unsetExpr := fmt.Sprintf(`["vaults"]["%s"]["%s"]`, jqEscape(vaultName), jqEscape(oldKey))
+	if out, err := exec.Command("sops", "unset", secretsFile, unsetExpr).CombinedOutput(); err != nil {
+		return fmt.Errorf("sops unset %s.%s: %w\n%s", vaultName, oldKey, err, out)
+	}
+	fmt.Printf("Renamed %s.%s -> %s.%s\n", vaultName, oldKey, vaultName, newKey)
+	return nil
+}
+
+// vaultEntries returns the KEY/value pairs of a vault from already-decrypted YAML.
+func vaultEntries(vaultName, decrypted string) ([][2]string, error) {
+	expr := fmt.Sprintf(".vaults.%s | to_entries | .[] | .key + \"=\" + .value", vaultName)
+	out, err := runYQ(expr, decrypted)
+	if err != nil {
+		return nil, fmt.Errorf("yq reading vault %s: %w", vaultName, err)
+	}
+	var entries [][2]string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			entries = append(entries, [2]string{parts[0], parts[1]})
+		}
+	}
+	return entries, nil
+}
+
 // Get retrieves a secret key for a vault from secrets.sops.yaml.
 func Get(vaultName, key string) error {
 	if err := ValidateVaultName(vaultName); err != nil {

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -132,6 +132,81 @@ func TestSet_AddsKeyToExistingFile(t *testing.T) {
 	}
 }
 
+func TestRenameVault_ReEncryptsUnderNewName(t *testing.T) {
+	requireSopsAndAge(t)
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	// Legacy underscore name that ValidateVaultName now rejects: Set won't make
+	// it, so seed it straight via sops (mirrors a pre-existing illegal vault).
+	if err := Set("seed", "K=1"); err != nil {
+		t.Fatalf("Set seed: %v", err)
+	}
+	if out, err := exec.Command("sops", "--set",
+		`["vaults"]["dev_to"]["DEV_TO_API_KEY"] "tok123"`, secretsFile).CombinedOutput(); err != nil {
+		t.Fatalf("seed dev_to: %v\n%s", err, out)
+	}
+	if err := RenameVault("dev_to", "dev-to"); err != nil {
+		t.Fatalf("RenameVault: %v", err)
+	}
+
+	out, err := exec.Command("sops", "-d", secretsFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("sops -d: %v\n%s", err, out)
+	}
+	plain := string(out)
+	if !strings.Contains(plain, "dev-to:") {
+		t.Errorf("expected new vault dev-to: after rename, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "dev_to:") {
+		t.Errorf("old vault dev_to: still present after rename:\n%s", plain)
+	}
+	if !strings.Contains(plain, "tok123") {
+		t.Errorf("secret value not preserved through rename:\n%s", plain)
+	}
+}
+
+func TestRenameVault_RefusesOverwrite(t *testing.T) {
+	requireSopsAndAge(t)
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	if err := Set("a", "K=1"); err != nil {
+		t.Fatalf("Set a: %v", err)
+	}
+	if err := Set("b", "K=2"); err != nil {
+		t.Fatalf("Set b: %v", err)
+	}
+	if err := RenameVault("a", "b"); err == nil {
+		t.Fatal("expected error renaming onto an existing vault, got nil")
+	}
+}
+
+func TestRenameKey_ReEncryptsUnderNewKey(t *testing.T) {
+	requireSopsAndAge(t)
+	cleanup := setupVaultDir(t)
+	defer cleanup()
+
+	if err := Set("v1", "OLD_KEY=val42"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := RenameKey("v1", "OLD_KEY", "NEW_KEY"); err != nil {
+		t.Fatalf("RenameKey: %v", err)
+	}
+
+	out, err := exec.Command("sops", "-d", secretsFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("sops -d: %v\n%s", err, out)
+	}
+	plain := string(out)
+	if !strings.Contains(plain, "NEW_KEY:") || strings.Contains(plain, "OLD_KEY:") {
+		t.Errorf("expected OLD_KEY renamed to NEW_KEY, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "val42") {
+		t.Errorf("value not preserved through key rename:\n%s", plain)
+	}
+}
+
 func TestSet_RejectsMalformedKeyval(t *testing.T) {
 	cleanup := setupVaultDir(t)
 	defer cleanup()


### PR DESCRIPTION
## What

Adds `clem vault rename` for renaming a vault or a single secret key within a vault.

```
clem vault rename <vault> <new-vault>          # rename a vault
clem vault rename <vault> <old-key> <new-key>  # rename a key in a vault
```

## Why

sops binds each value's YAML key path into its AAD, so renaming a vault or key by editing the encrypted file directly breaks decryption (`message authentication failed`). This command re-encrypts every affected secret under the new name via `sops --set`, then unsets the old path.

## Notes

- Source name is validated loosely, so a vault stuck with a now-illegal name (e.g. one with an underscore, which `ValidateVaultName` rejects) can be renamed away from it. The destination is validated strictly.
- Refuses to overwrite an existing target.
- Known gap: a multi-key vault rename is not atomic — if a re-encrypt fails mid-loop, the old vault stays intact but the new one is partial, and the overwrite guard then blocks a rerun. Worth a temp-file swap if large vaults become common.

## Tests

Three integration tests (skip when sops/age absent): vault rename round-trips and preserves values, refuses overwrite, and key rename round-trips. Full suite green.