### PR TITLE
fix(runner): single-quote sidecar literal in .mcp.json generator

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -883,7 +883,13 @@ func sidecarServersLiteral(cfg *config.Config, agentKey string) string {
 	for _, l := range cfg.SidecarListeners() {
 		for _, ak := range l.Subscribers {
 			if ak == agentKey {
-				parts = append(parts, fmt.Sprintf("[%q, %d]", l.Server.ToolName(), l.Port))
+				// Single-quote the tool name: this literal is interpolated into the
+				// runner's `python3 -c "..."` block, which is itself double-quoted at
+				// the shell level. %q's double quotes would close that shell string,
+				// so the name reached python as a bare identifier (NameError, 0-byte
+				// .mcp.json). ToolName is validated to validName (no quotes), so
+				// single-quoting is safe.
+				parts = append(parts, fmt.Sprintf("['%s', %d]", l.Server.ToolName(), l.Port))
 				break
 			}
 		}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -774,7 +774,7 @@ func TestGenerate_SidecarHTTPEntryForSubscriber(t *testing.T) {
 	cfg := sidecarRunnerCfg()
 	out := Generate(cfg, "lead")
 	for _, want := range []string{
-		`for _name, _port in [["es-ro", 14500]]:`,
+		`for _name, _port in [['es-ro', 14500]]:`,
 		`'type': 'http'`,
 		`'url': 'http://127.0.0.1:%d/mcp' % _port`,
 	} {
@@ -794,7 +794,10 @@ func TestGenerate_NoSidecarEntryForNonSubscriber(t *testing.T) {
 
 func TestSidecarServersLiteral(t *testing.T) {
 	cfg := sidecarRunnerCfg()
-	if got := sidecarServersLiteral(cfg, "lead"); got != `[["es-ro", 14500]]` {
+	// Single-quoted: the literal is interpolated into the runner's double-quoted
+	// `python3 -c "..."` block, so double quotes would break out of the shell
+	// string and python would see a bare identifier (NameError).
+	if got := sidecarServersLiteral(cfg, "lead"); got != `[['es-ro', 14500]]` {
 		t.Errorf("subscriber literal = %q", got)
 	}
 	if got := sidecarServersLiteral(cfg, "solo"); got != `[]` {


### PR DESCRIPTION
The privileged MCP sidecar list is interpolated into the runner's `python3 -c "..."` block, which is double-quoted at the shell level. `sidecarServersLiteral` rendered the tool name with `%q` (double quotes), so the inner quotes closed the shell string and python received a bare identifier:

```
for _name, _port in [[foo, 14500]]:   # NameError: name 'foo' is not defined
```

python crashed, the redirect left a **0-byte `.mcp.json`**, and the agent lost **all** its MCP servers (not just the sidecar). Any agent subscribing to a sidecar hits this — the claude-code runner path was never exercised end to end.

## Fix
Render the name single-quoted (`[['foo', 14500]]`). Single quotes inside the double-quoted `python3 -c` string are passed through literally and are valid python. `ToolName` is validated against `validName` (no quotes possible), so single-quoting is injection-safe.

## Tests
Updated the two tests that had codified the broken double-quoted output (`TestSidecarServersLiteral`, `TestGenerate_SidecarHTTPEntryForSubscriber`). `go test ./internal/runner/` passes.