### PR TITLE
feat(status): report agent auth mode; silence false expiry warning

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -58,6 +58,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		expiry := agent.TokenExpiry(homeDir)
 		hasRefresh := agent.HasRefreshToken(homeDir)
 		expiryStr := tokenExpiryDisplay(expiry, hasRefresh)
+		// A non-interactive credential (API key or setup-token) means there is
+		// no interactive .credentials.json to read, so report the auth mode
+		// instead of a misleading "missing".
+		if mode := agent.AuthMode(homeDir); mode != "" {
+			expiryStr = mode
+		}
 
 		logPath := fmt.Sprintf("/home/%s/.claude/%s-runner.log", osUser, agentKey)
 		lastLog := agent.LastLogLine(logPath)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1047,6 +1047,44 @@ func HasRefreshToken(homeDir string) bool {
 	return ok && creds.ClaudeAiOauth.RefreshToken != ""
 }
 
+// AuthMode reports the non-interactive credential an agent is configured with,
+// read from <homeDir>/.env (written by provision). Returns "api-key" when
+// ANTHROPIC_API_KEY is set, "env-token" when CLAUDE_CODE_OAUTH_TOKEN is set, or
+// "" when neither is present — in which case the agent relies on the
+// interactive ~/.claude/.credentials.json login, reported via TokenExpiry.
+// When both are set this reports "api-key"; it's a status hint, not a claim
+// about which credential Claude Code picks at runtime. A brokered key appears
+// in .env as a placeholder (the real secret stays in agent-vault); that still
+// counts as api-key, since the agent authenticates with a key either way.
+func AuthMode(homeDir string) string {
+	env, err := os.ReadFile(filepath.Join(homeDir, ".env"))
+	if err != nil {
+		return ""
+	}
+	if envHasValue(env, "ANTHROPIC_API_KEY") {
+		return "api-key"
+	}
+	if envHasValue(env, "CLAUDE_CODE_OAUTH_TOKEN") {
+		return "env-token"
+	}
+	return ""
+}
+
+// envHasValue reports whether env exports key with a non-empty value, matching
+// the `export KEY='value'` form WriteEnvFile writes. Commented lines and
+// empty values do not count.
+func envHasValue(env []byte, key string) bool {
+	prefix := "export " + key + "="
+	for _, raw := range strings.Split(string(env), "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		return strings.Trim(strings.TrimPrefix(line, prefix), "'\"") != ""
+	}
+	return false
+}
+
 // NeedsLogin returns true only when manual `claude /login` is actually
 // required: the credentials file is missing, unreadable, or carries no
 // refresh token. Access-token expiry is intentionally NOT checked — those

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1940,3 +1940,57 @@ func TestWriteWranglerConfig_SkipsWhenSecretsAbsent(t *testing.T) {
 		t.Error("config file should not be written when secrets absent")
 	}
 }
+
+func TestEnvHasValue(t *testing.T) {
+	// ESCAPED mirrors the WriteEnvFile escaping for a value with an embedded
+	// single quote (a'b -> 'a'\''b'): the value must still read as non-empty.
+	env := []byte("export FOO='bar'\nexport EMPTY=''\nexport ESCAPED='a'\\''b'\nexport CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-abc'\n# export COMMENTED='x'\n")
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		{"FOO", true},
+		{"ESCAPED", true}, // embedded-quote escaping still non-empty
+		{"CLAUDE_CODE_OAUTH_TOKEN", true},
+		{"EMPTY", false},     // exported but empty
+		{"MISSING", false},   // not present
+		{"COMMENTED", false}, // commented out, not a real export
+	}
+	for _, c := range cases {
+		if got := envHasValue(env, c.key); got != c.want {
+			t.Errorf("envHasValue(%q) = %v, want %v", c.key, got, c.want)
+		}
+	}
+}
+
+func TestAuthMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		envBody string
+		want    string
+	}{
+		{"env-token", "export CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-x'\n", "env-token"},
+		{"api-key", "export ANTHROPIC_API_KEY='sk-ant-api03-x'\n", "api-key"},
+		{"api-key reported when both set", "export ANTHROPIC_API_KEY='k'\nexport CLAUDE_CODE_OAUTH_TOKEN='t'\n", "api-key"},
+		{"brokered placeholder still api-key", "export ANTHROPIC_API_KEY='__anthropic_api_key__'\n", "api-key"},
+		{"neither — interactive login", "export DISCORD_TOKEN='x'\n", ""},
+		{"empty token ignored", "export CLAUDE_CODE_OAUTH_TOKEN=''\n", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.WriteFile(filepath.Join(home, ".env"), []byte(c.envBody), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if got := AuthMode(home); got != c.want {
+				t.Errorf("AuthMode = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestAuthMode_NoEnvFile(t *testing.T) {
+	if got := AuthMode(t.TempDir()); got != "" {
+		t.Errorf("AuthMode with no .env = %q, want empty", got)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -146,12 +146,17 @@ while true; do
     {{.SkillsSyncCmd}}
 
     # Surface a near-expired OAuth token to the agent itself: a dead token
-    # mid-session shows up as opaque 401/407 API errors otherwise.
-    EXP_MS=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.claude/.credentials.json'))).get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo 0)
-    NOW_MS=$(( $(date +%s) * 1000 ))
-    if [ "$EXP_MS" -gt 0 ] 2>/dev/null && [ "$EXP_MS" -lt $(( NOW_MS + 3600000 )) ]; then
-        log "WARNING: OAuth token expires within 1h (or already expired)"
-        RUNNER_WARNINGS="${RUNNER_WARNINGS}[runner] Your OAuth token expires within 1h or is already expired; if you hit 401/407 API errors, escalate to the alerts channel. "
+    # mid-session shows up as opaque 401/407 API errors otherwise. Skipped when
+    # a non-interactive credential (API key or setup-token) is configured —
+    # there is no interactive .credentials.json to expire, so the check would
+    # inject a false warning into every prompt.
+    if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+        EXP_MS=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.claude/.credentials.json'))).get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo 0)
+        NOW_MS=$(( $(date +%s) * 1000 ))
+        if [ "$EXP_MS" -gt 0 ] 2>/dev/null && [ "$EXP_MS" -lt $(( NOW_MS + 3600000 )) ]; then
+            log "WARNING: OAuth token expires within 1h (or already expired)"
+            RUNNER_WARNINGS="${RUNNER_WARNINGS}[runner] Your OAuth token expires within 1h or is already expired; if you hit 401/407 API errors, escalate to the alerts channel. "
+        fi
     fi
 
     # Per-agent quota snapshot (TTL 25m). Agents read this file instead of

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -50,6 +50,22 @@ func TestGenerate_CavemanInjectsLevel(t *testing.T) {
 	}
 }
 
+func TestGenerate_GatesExpiryWarningOnNonInteractiveCreds(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+	// When ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is set, the runner must
+	// not inject the ".credentials.json expires soon" warning (false alarm).
+	want := `if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then`
+	if !strings.Contains(out, want) {
+		t.Errorf("expected expiry-warning guard %q in runner, got:\n%s", want, out)
+	}
+}
+
 func TestGenerate_CavemanOffNoInjection(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:      "Lead",


### PR DESCRIPTION
## Why

clem only understood the interactive `~/.claude/.credentials.json` login. An agent authenticating with a **non-interactive credential** — `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` — therefore:
- showed a misleading `TOKEN EXPIRES: missing` in `clem status` (there's no credentials file to read), and
- got a false **"OAuth token expires within 1h"** warning injected into *every* prompt by the runner (it keys off `.credentials.json` only).

Both are wrong for API-key and setup-token users alike.

## What changed

- **`agent.AuthMode(homeDir)`** reads the agent's `.env` and reports `api-key` (ANTHROPIC_API_KEY), `env-token` (CLAUDE_CODE_OAUTH_TOKEN), or `""` (interactive login). `clem status` shows that instead of `missing`.
- **Runner** wraps the expiry-warning block in `if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]` so the false alarm is only computed for interactive logins.

Auth-agnostic: helps API-key users as much as setup-token users.

## Tests

- `TestEnvHasValue` — present / empty `''` / missing / commented.
- `TestAuthMode` — env-token, api-key, both-set (reports api-key), neither, empty token, no `.env` file.
- `TestGenerate_GatesExpiryWarningOnNonInteractiveCreds` — runner emits the guard.

`go build ./...`, `go vet`, `go test ./...`, gofmt, and golangci-lint all clean.

## Note

Display heuristic only: when both env vars are set, `AuthMode` reports `api-key` — it's a status hint, not a claim about which credential Claude Code picks at runtime.