### PR TITLE
fix(runner): silence the false "Auto-update failed" banner on proxy hosts

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -206,7 +206,13 @@ while true; do
     (sleep 1 && tmux send-keys -t {{.AgentKey}} "" Enter
      sleep 25 && tmux send-keys -l -t {{.AgentKey}} "$PROMPT"
      sleep 2 && tmux send-keys -t {{.AgentKey}} Enter) &
-    timeout 7200 $CLAUDE --dangerously-skip-permissions \
+    # DISABLE_AUTOUPDATER is scoped to the interactive session only: Claude
+    # Code's in-session updater can't reach downloads.claude.ai through the
+    # brokered https:// proxy (curl can, its bun fetch closes the socket), so it
+    # shows a persistent "Auto-update failed" banner. Updates still happen via
+    # the explicit "claude install" above, which runs without this and is
+    # unaffected.
+    DISABLE_AUTOUPDATER=1 timeout 7200 $CLAUDE --dangerously-skip-permissions \
         --model '{{.Model}}' \
         --name '{{.AgentName}}' \
         --add-dir ~/.claude

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -66,6 +66,25 @@ func TestGenerate_GatesExpiryWarningOnNonInteractiveCreds(t *testing.T) {
 	}
 }
 
+func TestGenerate_DisablesAutoUpdaterForSessionOnly(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+	// The interactive TUI launch disables the in-session auto-updater (its
+	// banner can't be cleared on a brokered-proxy host).
+	if !strings.Contains(out, "DISABLE_AUTOUPDATER=1 timeout 7200 $CLAUDE") {
+		t.Errorf("expected DISABLE_AUTOUPDATER on the claude launch, got:\n%s", out)
+	}
+	// ...but the explicit `claude install` must stay enabled so updates happen.
+	if strings.Contains(out, `DISABLE_AUTOUPDATER=1 "$CLAUDE" install`) {
+		t.Error("claude install must not be neutered by DISABLE_AUTOUPDATER")
+	}
+}
+
 func TestGenerate_CavemanOffNoInjection(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:      "Lead",


### PR DESCRIPTION
## Why

On a brokered-proxy / egress-contained host, the agent TUI persistently shows **"Auto-update failed · Run /doctor"** (visible over `tmux attach` and the ttyd web terminal).

Diagnosis on a live box:
- `curl` reaches `https://downloads.claude.ai/claude-code-releases/latest` **through the agent's proxy → HTTP 200**, and claude is at **2.1.197 (current)**. So it's not a network block and no update is even needed.
- Claude Code's **in-session auto-updater** (bun `fetch`) can't use the `https://`-scheme broker proxy — it fails with `Socket is closed` where curl succeeds. That failed background check is the banner.

## Fix

Scope `DISABLE_AUTOUPDATER=1` to the **interactive TUI launch only**:

```sh
DISABLE_AUTOUPDATER=1 timeout 7200 $CLAUDE --dangerously-skip-permissions ...
```

The runner's explicit `claude install` (run every iteration) is **unaffected** and keeps claude current — so this silences the broken/redundant in-session updater without stopping updates. claude-code runtime only; opencode/codex launches unchanged.

## Test

`TestGenerate_DisablesAutoUpdaterForSessionOnly` — asserts the launch carries `DISABLE_AUTOUPDATER=1` and that `claude install` is not neutered by it.

`go build`, `go test ./...`, gofmt (changed lines), golangci-lint all clean.