### PR TITLE
fix(watchdog): scope check_oom grep to current project

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -134,7 +134,7 @@ check_oom() {
     local hits
     hits=$(journalctl --since "$since" --no-pager 2>/dev/null \
         | grep -E "killed by the OOM killer" \
-        | grep -oE "clem-[a-zA-Z0-9_-]+\.service" \
+        | grep -oE "clem-${PROJECT}-[a-zA-Z0-9_-]+\.service" \
         | sort | uniq -c | awk '{printf "%s x%s\n", $2, $1}')
     if [ -n "$hits" ]; then
         local mem

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -1,6 +1,7 @@
 package watchdog
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -151,7 +152,7 @@ func TestGenerateScript_OOMCheckPresent(t *testing.T) {
 		`check_oom()`,
 		`journalctl --since "$since" --no-pager`,
 		`killed by the OOM killer`,
-		`clem-[a-zA-Z0-9_-]+\.service`,
+		`clem-${PROJECT}-[a-zA-Z0-9_-]+\.service`,
 		`OOM-kill detected`,
 		`free -h`,
 	} {
@@ -166,6 +167,20 @@ func TestGenerateScript_OOMCheckPresent(t *testing.T) {
 	callIdx := strings.LastIndex(s, "check_oom")
 	if defIdx == -1 || callIdx == -1 || callIdx <= defIdx {
 		t.Errorf("check_oom must be defined and then invoked (def=%d call=%d)", defIdx, callIdx)
+	}
+}
+
+// TestGenerateScript_OOMCheckScopedToProject regression-tests #148: the OOM
+// grep must match only this project's services, not every clem-* service
+// on the host (which double-reports OOM kills across co-located projects).
+func TestGenerateScript_OOMCheckScopedToProject(t *testing.T) {
+	s := GenerateScript(baseCfg())
+	re := regexp.MustCompile(`grep -oE "clem-\$\{PROJECT\}-\[a-zA-Z0-9_-\]\+\\.service"`)
+	if !re.MatchString(s) {
+		t.Errorf("expected project-scoped OOM service grep, got:\n%s", s)
+	}
+	if strings.Contains(s, `grep -oE "clem-[a-zA-Z0-9_-]+\.service"`) {
+		t.Errorf("OOM grep must not match all clem-* services host-wide:\n%s", s)
 	}
 
 	// marker must be written after the journalctl scan to avoid silently


### PR DESCRIPTION
Closes #148.

`check_oom` grepped `clem-[a-zA-Z0-9_-]+\.service` host-wide, so on a host running multiple clem projects an OOM kill in one project's agent service would show up in every other project's watchdog alert (misattributed + double-reported).

Fix: anchor the grep to `clem-${PROJECT}-...` — `PROJECT` is already validated at `Load()` against `^[a-z][a-z0-9-]{0,30}$`, so it's safe to embed directly in the ERE (no injection).

Adversarial review: confirmed diff is source (1 line) + test only, checked PROJECT sanitization at the validation boundary before embedding in the grep pattern, verified `go build`/`go test ./internal/watchdog/...` green. Added a regression test asserting the OOM grep excludes the old host-wide pattern.