### PR TITLE
fix(runner): skip claude install on egress-proxy hosts

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -140,8 +140,15 @@ while true; do
         fi
     fi
 
-    log "Updating claude"
-    "$CLAUDE" install 2>&1 | tail -5 | tee -a "$LOGFILE" || log "claude install failed, continuing with current version"
+    # claude install (bun fetch) can't traverse the pipelock proxy — it fails
+    # "Socket is closed" every iteration on egress-contained hosts. Skip it
+    # there; updates for contained agents happen at (re)provision time.
+    if [ -n "$HTTPS_PROXY" ]; then
+        log "Skipping claude update (egress proxy host)"
+    else
+        log "Updating claude"
+        "$CLAUDE" install 2>&1 | tail -5 | tee -a "$LOGFILE" || log "claude install failed, continuing with current version"
+    fi
 
     {{.SkillsSyncCmd}}
 
@@ -214,9 +221,9 @@ while true; do
     # DISABLE_AUTOUPDATER is scoped to the interactive session only: Claude
     # Code's in-session updater can't reach downloads.claude.ai through the
     # brokered https:// proxy (curl can, its bun fetch closes the socket), so it
-    # shows a persistent "Auto-update failed" banner. Updates still happen via
-    # the explicit "claude install" above, which runs without this and is
-    # unaffected.
+    # shows a persistent "Auto-update failed" banner. On non-proxy hosts updates
+    # still happen via the explicit "claude install" above; proxy hosts skip it
+    # (same bun fetch limitation) and update at provision time.
     DISABLE_AUTOUPDATER=1 timeout 7200 $CLAUDE --dangerously-skip-permissions \
         --model '{{.Model}}' \
         --name '{{.AgentName}}' \

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -85,6 +85,21 @@ func TestGenerate_DisablesAutoUpdaterForSessionOnly(t *testing.T) {
 	}
 }
 
+func TestGenerate_SkipsClaudeInstallOnProxyHosts(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-7",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+	// claude install (bun fetch) can't traverse the pipelock proxy — it fails
+	// "Socket is closed" every iteration. Skip it when HTTPS_PROXY is set.
+	if !strings.Contains(out, `if [ -n "$HTTPS_PROXY" ]; then`) {
+		t.Errorf("expected claude install gated on HTTPS_PROXY, got:\n%s", out)
+	}
+}
+
 func TestGenerate_CavemanOffNoInjection(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{
 		Name:      "Lead",
@@ -472,7 +487,7 @@ func TestGenerate_NoProxyExportWhenEgressDisabled(t *testing.T) {
 	})
 
 	out := Generate(cfg, "worker")
-	if strings.Contains(out, "HTTPS_PROXY") {
+	if strings.Contains(out, "export HTTPS_PROXY") {
 		t.Errorf("expected no HTTPS_PROXY export when egress disabled, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
On egress-contained hosts the per-iteration `claude install` fails every loop with:

```
Failed to fetch version from https://downloads.claude.ai/claude-code-releases/latest after 3 attempt(s): Socket is closed
Try running with --force to override checks
```

Same root cause as #251 (bun fetch can't traverse the pipelock proxy — curl can), but #251 only silenced the in-session updater via `DISABLE_AUTOUPDATER`; the explicit `claude install` in the runner loop still runs and fails noisily.

Fix: gate the install on `HTTPS_PROXY`. Proxy hosts log a one-line skip; contained agents get updates at (re)provision time. Non-proxy hosts are unchanged. Corrected the now-wrong comment claiming `claude install` was unaffected by the proxy.