### PR TITLE
fix(login): forward agent args to remote host via --remote

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"sort"
-	"strings"
 
 	"github.com/jahwag/clem/internal/agent"
 	"github.com/jahwag/clem/internal/config"
@@ -28,10 +27,7 @@ func init() {
 
 func runLogin(cmd *cobra.Command, args []string) error {
 	if loginRemote != "" {
-		if len(args) > 0 {
-			return fmt.Errorf("agent args are not supported with --remote; run clem login %s on the remote host instead", strings.Join(args, " "))
-		}
-		return remote.Login(loginRemote)
+		return remote.Login(loginRemote, args)
 	}
 
 	agents, err := selectAgents(cfg.Agents, args)

--- a/internal/remote/names.go
+++ b/internal/remote/names.go
@@ -14,6 +14,15 @@ func validateRepoName(name string) error {
 	return nil
 }
 
+var validAgentKey = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,100}$`)
+
+func validateAgentKey(key string) error {
+	if !validAgentKey.MatchString(key) {
+		return fmt.Errorf("agent key %q contains unsafe characters", key)
+	}
+	return nil
+}
+
 // ValidatedRepoName returns RepoName after rejecting shell-metacharacter payloads.
 func ValidatedRepoName() (string, error) {
 	name, err := RepoName()

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -78,6 +78,10 @@ func SSH(host, command string) error {
 // Tests may replace it to simulate failures.
 var remoteSSH = SSH
 
+// remoteSSHT is the TTY-SSH implementation used by Login.
+// Tests may replace it to simulate failures.
+var remoteSSHT func(host, command string) error = SSHT
+
 // SSHT runs a command on the remote host with a TTY allocated (required for interactive prompts).
 func SSHT(host, command string) error {
 	cmd := exec.Command("ssh", "-t", "-o", "StrictHostKeyChecking=accept-new", host, command)
@@ -151,15 +155,24 @@ func Provision(host, ghToken string) error {
 }
 
 // Login runs clem login on the remote host with a TTY for interactive OAuth.
-func Login(host string) error {
+// agents, if provided, are forwarded as positional args to the remote clem login invocation.
+func Login(host string, agents []string) error {
 	repoName, err := ValidatedRepoName()
 	if err != nil {
 		return err
 	}
+	for _, a := range agents {
+		if err := validateAgentKey(a); err != nil {
+			return err
+		}
+	}
 	fmt.Printf("Remote: %s\n\n", host)
 	loginCmd := fmt.Sprintf("cd ~/%s && clem login", repoName)
-	if err := SSHT(host, loginCmd); err != nil {
-		return fmt.Errorf("remote login: %w\nManual: ssh -t %s 'cd ~/%s && clem login'", err, host, repoName)
+	if len(agents) > 0 {
+		loginCmd += " " + strings.Join(agents, " ")
+	}
+	if err := remoteSSHT(host, loginCmd); err != nil {
+		return fmt.Errorf("remote login: %w\nManual: ssh -t %s '%s'", err, host, loginCmd)
 	}
 	return nil
 }

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -222,3 +222,78 @@ func TestValidateRepoName_RejectsUnsafe(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateAgentKey_AcceptsNormal(t *testing.T) {
+	for _, key := range []string{"lead", "worker", "eng", "agent-1", "my_agent"} {
+		if err := validateAgentKey(key); err != nil {
+			t.Errorf("validateAgentKey(%q): %v", key, err)
+		}
+	}
+}
+
+func TestValidateAgentKey_RejectsUnsafe(t *testing.T) {
+	for _, key := range []string{
+		`lead; touch /tmp/pwned`,
+		"$(id)",
+		"agent name",
+		"../etc",
+		"",
+	} {
+		if err := validateAgentKey(key); err == nil {
+			t.Errorf("validateAgentKey(%q) expected error", key)
+		}
+	}
+}
+
+func TestLogin_ForwardsAgentsToRemoteCommand(t *testing.T) {
+	chdirTempGitRepo(t, "git@github.com:org/clem.git")
+	old := remoteSSHT
+	defer func() { remoteSSHT = old }()
+
+	var gotCmd string
+	remoteSSHT = func(host, cmd string) error {
+		gotCmd = cmd
+		return nil
+	}
+
+	if err := Login("myhost", []string{"lead", "worker"}); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !strings.Contains(gotCmd, "clem login lead worker") {
+		t.Errorf("command %q does not include agent args", gotCmd)
+	}
+}
+
+func TestLogin_NoAgents_RunsAllLogin(t *testing.T) {
+	chdirTempGitRepo(t, "git@github.com:org/clem.git")
+	old := remoteSSHT
+	defer func() { remoteSSHT = old }()
+
+	var gotCmd string
+	remoteSSHT = func(host, cmd string) error {
+		gotCmd = cmd
+		return nil
+	}
+
+	if err := Login("myhost", nil); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !strings.HasSuffix(gotCmd, "clem login") {
+		t.Errorf("command %q should end with bare clem login", gotCmd)
+	}
+}
+
+func TestLogin_InvalidAgentKeyRejected(t *testing.T) {
+	chdirTempGitRepo(t, "git@github.com:org/clem.git")
+	old := remoteSSHT
+	defer func() { remoteSSHT = old }()
+	remoteSSHT = func(host, cmd string) error { return nil }
+
+	err := Login("myhost", []string{"lead; touch /tmp/pwned"})
+	if err == nil {
+		t.Fatal("expected error for agent key with shell metacharacters")
+	}
+	if !strings.Contains(err.Error(), "unsafe characters") {
+		t.Errorf("error %q should mention unsafe characters", err)
+	}
+}


### PR DESCRIPTION
Closes #213.

## What changed

`clem login --remote host agent1 agent2` previously returned an error:
> agent args are not supported with --remote; run clem login eng on the remote host instead

This PR removes that restriction and forwards the positional agent args to the remote `clem login` invocation. Each arg is validated against `^[a-zA-Z0-9_-]{1,100}$` before shell-concatenation so metacharacters can't reach the SSH command.

## Changes

- `cmd/login.go`: drop the early-error branch; pass `args` into `remote.Login()`
- `internal/remote/names.go`: add `validateAgentKey()` with allowlist regex
- `internal/remote/remote.go`: `Login()` accepts `[]string` agents, validates + appends to `loginCmd`; extract `remoteSSHT` var for testability
- `internal/remote/remote_test.go`: 3 new tests covering forwarding, no-args passthrough, and rejection of unsafe keys

## Adversarial review

- Only one caller of `remote.Login()` (`cmd/login.go`) — signature update is complete.
- Agent keys validated before shell concat; allowlist covers alphanumeric, `-`, `_` only.
- No-args path (`nil` or empty slice) produces the same command as before.
- Full test suite: all packages pass.