### PR TITLE
docs(security): fix egress/broker overclaim — dispositions are mutually exclusive per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ An autonomous agent is an untrusted workload: prompt injection, a poisoned depen
 | **remove** | drop the credential/MCP entirely | nowhere | unused attack surface |
 | **egress firewall** | per-agent nftables UID rule forces all traffic through a loopback proxy; everything else is rejected by the kernel | n/a | data exfiltration to unapproved hosts |
 
-**Why this is stronger than in-process or single-container sandboxes:** the boundary is a **per-OS-UID kernel firewall a non-root agent cannot disable**, plus a credential broker running as a **different user the agent cannot read** — neither depends on the agent's cooperation, and there is no in-process escape hatch. A compromised agent holds no usable secrets and can reach no unapproved network.
+**Why this is stronger than in-process or single-container sandboxes:** each agent takes one disposition — a **per-OS-UID kernel firewall a non-root agent cannot disable**, *or* a credential broker running as a **different user the agent cannot read**. Neither depends on the agent's cooperation, there is no in-process escape hatch, and a fleet freely mixes both dispositions across agents.
 
-Honest about the parts that are borrowed: the egress proxy and credential broker are battle-tested OSS primitives ([pipelock](https://github.com/luckyPipewrench/pipelock), [Infisical agent-vault](https://github.com/Infisical/agent-vault)). clem's contribution is the **OS-level composition** — per-agent UID identity + kernel firewall + secret supply, wired so the agent literally cannot route around either.
+Honest about the parts that are borrowed: the egress proxy and credential broker are battle-tested OSS primitives ([pipelock](https://github.com/luckyPipewrench/pipelock), [Infisical agent-vault](https://github.com/Infisical/agent-vault)). clem's contribution is the **OS-level composition** — per-agent UID identity wired to whichever boundary applies, so the agent cannot route around it.
 
 → Full threat model, guarantees, and known limitations: **[docs/threat-model.md](docs/threat-model.md)**.
 → Worked reference config: **[samples/secure-fleet/](samples/secure-fleet/)**.

--- a/docs/index.html
+++ b/docs/index.html
@@ -580,7 +580,7 @@ agents:
            <span class="eyebrow kicker">Autonomous, not unsupervised</span>
            <h2 class="display" style="font-size:clamp(30px,4vw,48px);margin:0 0 24px">They run on their own. You hold the keys.</h2>
            <p class="lead" style="max-width:520px;margin:0 0 22px">An autonomous agent is an untrusted workload. It needs secrets and network access to do real work, but you should not trust it to hold a raw credential or to decide for itself what it can reach.</p>
-           <p style="font-size:16px;color:var(--ink-soft);max-width:520px;margin:0">clem puts the boundary below the agent. Each one runs as its own non-root user. Secrets and egress are enforced by the kernel and a separate user the agent cannot read or override. Compromise the agent and the boundary still holds.</p>
+           <p style="font-size:16px;color:var(--ink-soft);max-width:520px;margin:0">clem puts the boundary below the agent. Each one runs as its own non-root user. You pick a disposition per agent: egress pinned by a kernel rule it cannot disable, or credentials held by a separate user it cannot read. Either way, compromise the agent and its boundary still holds.</p>
            <blockquote class="quote-side">&ldquo;It did all the work it was allowed to. The last call is still yours.&rdquo;</blockquote>
          </div>
          <div class="checks">


### PR DESCRIPTION
Closes #195.

## What changed

`README.md` and `docs/index.html` presented the kernel egress firewall and the secret-zero credential broker as simultaneously applied to every agent ("plus" / "Secrets **and** egress are enforced by the kernel **and** a separate user"). `threat-model.md:47` states they are mutually exclusive per agent; `config.Load()` enforces this at runtime.

### README.md (~line 110)

- `"plus a credential broker"` → `"or a credential broker"` — one disposition per agent
- Remove `"A compromised agent holds no usable secrets and can reach no unapproved network"` — untrue for a single-disposition agent (egress-only agent still holds real secrets; brokered agent is not egress-contained)
- Replace with `"a fleet freely mixes both dispositions across agents"` — which is true and accurate
- Composition line: `"kernel firewall + secret supply"` → `"wired to whichever boundary applies"` — avoids implying both wired to one agent

### docs/index.html (security section callout, line 583)

- `"Secrets and egress are enforced by the kernel and a separate user the agent cannot read or override."` → `"You pick a disposition per agent: egress pinned by a kernel rule it cannot disable, or credentials held by a separate user it cannot read. Either way, compromise the agent and its boundary still holds."`

## Adversarial review

- No true claim dropped. The old `"A compromised agent holds no usable secrets and can reach no unapproved network"` was the false claim — removed, not replaced with another overclaim.
- New framing verified against `threat-model.md:47` and `samples/secure-fleet/clem.yaml:70`, both of which state the either/or constraint explicitly.
- Line 7 and line 29 of README.md already used correct "or" framing — new text is consistent with them.
- Sections already fixed by PR #190 (FAQ `<details>` answers and feature card at line 549) are untouched.