### PR TITLE
feat(agent): opt-in headroom context-compression proxy

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -124,6 +124,15 @@ func provisionAgent(agentKey string, ac config.AgentConfig) error {
 		return fmt.Errorf("installing %s for %s: %w", runtimeKind, osUser, err)
 	}
 
+	// 1b. Optional headroom context-compression proxy. Non-fatal: the runner
+	// falls back to a direct claude launch when the binary is missing.
+	if ac.Headroom {
+		fmt.Printf("  installing headroom for %s\n", osUser)
+		if err := agent.InstallHeadroom(osUser); err != nil {
+			fmt.Printf("  WARNING: %v (agent will run without headroom)\n", err)
+		}
+	}
+
 	// 2. Decrypt and write .env (merged with provider env vars)
 	secrets, ghToken, envChanged, err := writeAgentEnv(agentKey, ac, osUser, homeDir)
 	if err != nil {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1294,16 +1294,22 @@ func InstallClaude(username string) error {
 	return nil
 }
 
-// InstallHeadroom installs the Headroom context-compression proxy (pipx
+// InstallHeadroom installs the Headroom context-compression proxy (PyPI
 // package headroom-ai) as the given user, landing at ~/.local/bin/headroom.
-// Idempotent: install if absent, upgrade if present. Requires pipx on the
-// host. The runner falls back to a direct claude launch when the binary is
-// missing, so callers may treat a failure here as a warning rather than
-// aborting the provision.
+// Idempotent: install if absent, upgrade if present. Portable across hosts:
+// prefers pipx when available, otherwise falls back to a pip --user install
+// (adding --break-system-packages on PEP 668 externally-managed environments
+// like Ubuntu 24.04). The runner falls back to a direct claude launch when the
+// binary is missing, so callers may treat a failure here as a warning rather
+// than aborting the provision.
 func InstallHeadroom(username string) error {
 	cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
-		"command -v pipx >/dev/null || { echo 'pipx not found on host' >&2; exit 1; }; "+
-			"pipx install headroom-ai 2>/dev/null || pipx upgrade headroom-ai")
+		"if command -v pipx >/dev/null; then "+
+			"pipx install headroom-ai 2>/dev/null || pipx upgrade headroom-ai; "+
+			"else "+
+			"python3 -m pip install --user --upgrade headroom-ai 2>/dev/null || "+
+			"python3 -m pip install --user --upgrade --break-system-packages headroom-ai; "+
+			"fi")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("installing headroom for %s: %w\n%s", username, err, out)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1294,6 +1294,31 @@ func InstallClaude(username string) error {
 	return nil
 }
 
+// InstallHeadroom installs the Headroom context-compression proxy (pipx
+// package headroom-ai) as the given user, landing at ~/.local/bin/headroom.
+// Idempotent: install if absent, upgrade if present. Requires pipx on the
+// host. The runner falls back to a direct claude launch when the binary is
+// missing, so callers may treat a failure here as a warning rather than
+// aborting the provision.
+func InstallHeadroom(username string) error {
+	cmd := exec.Command("sudo", "-iu", username, "bash", "-c",
+		"command -v pipx >/dev/null || { echo 'pipx not found on host' >&2; exit 1; }; "+
+			"pipx install headroom-ai 2>/dev/null || pipx upgrade headroom-ai")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("installing headroom for %s: %w\n%s", username, err, out)
+	}
+	binPath := fmt.Sprintf("/home/%s/.local/bin/headroom", username)
+	info, err := os.Stat(binPath)
+	if err != nil {
+		return fmt.Errorf("headroom not found at %s after install: %w", binPath, err)
+	}
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("headroom at %s is not executable", binPath)
+	}
+	return nil
+}
+
 // InstallCaveman installs the caveman plugin for the agent user. Idempotent.
 // https://github.com/JuliusBrussee/caveman
 func InstallCaveman(username string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,12 @@ type AgentConfig struct {
 	// Empty = use Claude Code's own default (currently medium). Lowering trims
 	// output tokens — the dominant cost driver in agent loops.
 	Effort string `yaml:"effort"`
+	// Headroom routes the claude-code session through a local Headroom
+	// proxy (pipx package headroom-ai) that compresses context before it
+	// reaches the API (~12% fewer tokens measured), stretching subscription
+	// rate limits. The runner falls back to a direct claude launch when the
+	// binary is missing. claude-code runtime only; ignored for opencode/codex.
+	Headroom bool `yaml:"headroom"`
 	// GitName and GitEmail set the agent's git user identity during provision.
 	// Without these, commits are authored with whatever identity the OAuth login
 	// stored, which may leak the operator's personal email into public history.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -224,7 +224,8 @@ while true; do
     # shows a persistent "Auto-update failed" banner. On non-proxy hosts updates
     # still happen via the explicit "claude install" above; proxy hosts skip it
     # (same bun fetch limitation) and update at provision time.
-    DISABLE_AUTOUPDATER=1 timeout 7200 $CLAUDE --dangerously-skip-permissions \
+{{.HeadroomLaunch}}
+    DISABLE_AUTOUPDATER=1 timeout 7200 $LAUNCH --dangerously-skip-permissions \
         --model '{{.Model}}' \
         --name '{{.AgentName}}' \
         --add-dir ~/.claude
@@ -636,6 +637,32 @@ type RunnerParams struct {
 	// the work dir (CLAUDE.local.md for claude-code, AGENTS.md for opencode/codex).
 	// Used by the oversize guard so it checks the file the runtime actually reads.
 	InstructionFile string
+	// HeadroomLaunch is the bash snippet that sets $LAUNCH to either the
+	// plain claude binary or a `headroom wrap claude` invocation when the
+	// agent has headroom: true. claude-code template only.
+	HeadroomLaunch string
+}
+
+// headroomLaunchSnippet returns the bash block that sets $LAUNCH for the
+// claude-code runner. With headroom enabled, the session is wrapped in
+// `headroom wrap claude` — a local context-compression proxy that trims
+// tokens before they reach the API, stretching subscription rate limits.
+// The proxy port is picked fresh each iteration so multiple agents on one
+// host never collide, and a missing binary falls back to a direct launch so
+// a failed install never strands the agent. wrap resolves 'claude' via
+// PATH, hence the export.
+func headroomLaunchSnippet(enabled bool) string {
+	if !enabled {
+		return `    LAUNCH="$CLAUDE"`
+	}
+	return `    if [ -x "$HOME/.local/bin/headroom" ]; then
+        export PATH="$HOME/.local/bin:$PATH"
+        HEADROOM_PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1])')
+        LAUNCH="$HOME/.local/bin/headroom wrap claude -p $HEADROOM_PORT --no-context-tool --no-serena"
+    else
+        log "headroom enabled but not installed; launching claude directly"
+        LAUNCH="$CLAUDE"
+    fi`
 }
 
 // bashDoubleQuoteEscaper escapes the four characters that stay live inside a
@@ -736,6 +763,7 @@ func Generate(cfg *config.Config, agentKey string) string {
 		SidecarServers:      sidecarServersLiteral(cfg, agentKey),
 		SkillsSyncCmd:       skillsSyncCmd,
 		InstructionFile:     ac.InstructionFileName(),
+		HeadroomLaunch:      headroomLaunchSnippet(ac.Headroom),
 	}
 	switch ac.RuntimeKind() {
 	case "opencode":
@@ -879,6 +907,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.AgentName}}", p.AgentName,
 		"{{.Model}}", p.Model,
 		"{{.Prompt}}", p.Prompt,
+		"{{.HeadroomLaunch}}", p.HeadroomLaunch,
 		"{{.OSUser}}", p.OSUser,
 		"{{.HomeDir}}", p.HomeDir,
 		"{{.SleepActive}}", fmt.Sprintf("%d", p.SleepActive),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -33,6 +33,42 @@ func baseCfg(agentKey string, ac config.AgentConfig) *config.Config {
 	}
 }
 
+func TestGenerate_HeadroomWrapsClaudeLaunch(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-8",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+		Headroom:  true,
+	})
+	out := Generate(cfg, "lead")
+	for _, want := range []string{
+		"headroom wrap claude -p $HEADROOM_PORT --no-context-tool --no-serena",
+		`log "headroom enabled but not installed; launching claude directly"`,
+		"timeout 7200 $LAUNCH --dangerously-skip-permissions",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in runner, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerate_HeadroomOffLaunchesClaudeDirectly(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name:      "Lead",
+		Model:     "claude-opus-4-8",
+		Iteration: "1m",
+		Prompt:    "do the thing",
+	})
+	out := Generate(cfg, "lead")
+	if strings.Contains(out, "headroom") {
+		t.Errorf("headroom disabled but wrap present in runner:\n%s", out)
+	}
+	if !strings.Contains(out, `LAUNCH="$CLAUDE"`) {
+		t.Errorf("expected direct claude launch, got:\n%s", out)
+	}
+}
+
 func TestGenerate_CavemanInjectsLevel(t *testing.T) {
 	for _, level := range []config.CavemanLevel{config.CavemanLite, config.CavemanFull, config.CavemanUltra} {
 		cfg := baseCfg("lead", config.AgentConfig{
@@ -76,7 +112,7 @@ func TestGenerate_DisablesAutoUpdaterForSessionOnly(t *testing.T) {
 	out := Generate(cfg, "lead")
 	// The interactive TUI launch disables the in-session auto-updater (its
 	// banner can't be cleared on a brokered-proxy host).
-	if !strings.Contains(out, "DISABLE_AUTOUPDATER=1 timeout 7200 $CLAUDE") {
+	if !strings.Contains(out, "DISABLE_AUTOUPDATER=1 timeout 7200 $LAUNCH") {
 		t.Errorf("expected DISABLE_AUTOUPDATER on the claude launch, got:\n%s", out)
 	}
 	// ...but the explicit `claude install` must stay enabled so updates happen.


### PR DESCRIPTION
## Why

Measured that Headroom offers modest token savings of 12%. This is a useful feature to have in clem.

## What

- `headroom: true` per-agent flag in clem.yaml (default off, claude-code runtime only)
- Provision installs `headroom-ai` via pipx as the agent user; failure is a warning, not fatal
- Runner wraps the session in `headroom wrap claude -p $PORT --no-context-tool --no-serena`
  - free port picked per iteration → no collisions between co-hosted agents (Ada/Amara/Athena)
  - missing binary → direct claude launch with a log line, agent never stranded
  - MCP retrieve tool registration kept (default) so compression markers stay actionable for the agent

## Contract check

- Interactive TUI preserved — wrap launches the same claude TUI, tmux liveness and ttyd attach unaffected
- `kill $PPID` still advances the loop (claude remains the parent of its tool shells; wrap exits with its child)
- `DISABLE_AUTOUPDATER` scoping unchanged

## Testing

- `go test ./...` green, `go vet` clean
- Rendered runner.sh for headroom on/off passes `bash -n`; wrap line and fallback branch verified in output
