### PR TITLE
fix(agent): register MCP servers in ~/.claude.json, not settings.json

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1578,17 +1578,24 @@ func pruneStaleSkillSymlinks(skillsDir, cache string, expected map[string]string
 	}
 }
 
-// SetMCPServers overwrites the mcpServers key in ~/.claude/settings.json while
-// preserving all other settings. Vault refs in env values are expanded via secrets.
-func SetMCPServers(homeDir string, servers []config.MCPServerConfig, secrets map[string]string) error {
-	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
-	raw, err := os.ReadFile(settingsPath)
-	if err != nil {
-		return fmt.Errorf("reading settings.json: %w", err)
-	}
-	var doc map[string]any
-	if err := json.Unmarshal(raw, &doc); err != nil {
-		return fmt.Errorf("parsing settings.json: %w", err)
+// SetMCPServers overwrites the mcpServers key in the agent's ~/.claude.json
+// while preserving everything else Claude Code keeps there. Claude Code does
+// not load MCP servers from settings.json — only ~/.claude.json or a project
+// .mcp.json count (and the runner regenerates .mcp.json, so it is not ours to
+// write). The file may not exist before the agent's first session. Vault refs
+// in env values are expanded via secrets, so the result is chowned to the
+// agent and kept 0600.
+func SetMCPServers(username, homeDir string, servers []config.MCPServerConfig, secrets map[string]string) error {
+	claudeJSONPath := filepath.Join(homeDir, ".claude.json")
+	doc := map[string]any{}
+	raw, err := os.ReadFile(claudeJSONPath)
+	switch {
+	case err == nil:
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return fmt.Errorf("parsing .claude.json: %w", err)
+		}
+	case !os.IsNotExist(err):
+		return fmt.Errorf("reading .claude.json: %w", err)
 	}
 	mcpMap := make(map[string]any, len(servers))
 	for _, srv := range servers {
@@ -1615,9 +1622,12 @@ func SetMCPServers(homeDir string, servers []config.MCPServerConfig, secrets map
 	doc["mcpServers"] = mcpMap
 	out, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshaling settings.json: %w", err)
+		return fmt.Errorf("marshaling .claude.json: %w", err)
 	}
-	return os.WriteFile(settingsPath, append(out, '\n'), 0644)
+	if err := os.WriteFile(claudeJSONPath, append(out, '\n'), 0600); err != nil {
+		return fmt.Errorf("writing .claude.json: %w", err)
+	}
+	return chownToUser(claudeJSONPath, username)
 }
 
 // InstallExtensions installs marketplaces, plugins, skills, and MCP servers for
@@ -1649,7 +1659,7 @@ func InstallExtensions(username, homeDir string, ext config.ExtensionsConfig, ca
 		}
 	}
 	if len(ext.MCPServers) > 0 {
-		if err := SetMCPServers(homeDir, ext.MCPServers, secrets); err != nil {
+		if err := SetMCPServers(username, homeDir, ext.MCPServers, secrets); err != nil {
 			return err
 		}
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -2094,3 +2094,60 @@ func TestProxyTokenValid_ProbesThroughProxy(t *testing.T) {
 		t.Error("failed probe (407/unreachable) must report invalid so caller rotates")
 	}
 }
+
+func TestSetMCPServersWritesClaudeJSON(t *testing.T) {
+	withStub(t) // chown is stubbed
+	home := t.TempDir()
+
+	servers := []config.MCPServerConfig{{
+		Name:    "browser-render",
+		Command: "mcp-browser-render",
+		Env: map[string]string{
+			"BROWSER_RENDER_API_KEY": "${vault:infra.BROWSER_RENDER_API_KEY}",
+		},
+	}}
+	secrets := map[string]string{"infra.BROWSER_RENDER_API_KEY": "sekrit"}
+
+	// File absent: created from scratch.
+	if err := SetMCPServers("cdev_worker", home, servers, secrets); err != nil {
+		t.Fatalf("SetMCPServers (no file): %v", err)
+	}
+	path := filepath.Join(home, ".claude.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf(".claude.json not written: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing .claude.json: %v", err)
+	}
+	entry := doc["mcpServers"].(map[string]any)["browser-render"].(map[string]any)
+	if entry["type"] != "stdio" || entry["command"] != "mcp-browser-render" {
+		t.Errorf("bad entry: %v", entry)
+	}
+	if got := entry["env"].(map[string]any)["BROWSER_RENDER_API_KEY"]; got != "sekrit" {
+		t.Errorf("vault ref not expanded: %v", got)
+	}
+	if fi, _ := os.Stat(path); fi.Mode().Perm() != 0600 {
+		t.Errorf(".claude.json mode = %v, want 0600 (env holds secrets)", fi.Mode().Perm())
+	}
+
+	// File present with Claude Code state: other keys preserved.
+	if err := os.WriteFile(path, []byte(`{"oauthAccount":{"x":1},"mcpServers":{"old":{}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetMCPServers("cdev_worker", home, servers, secrets); err != nil {
+		t.Fatalf("SetMCPServers (existing file): %v", err)
+	}
+	raw, _ = os.ReadFile(path)
+	doc = map[string]any{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := doc["oauthAccount"]; !ok {
+		t.Error("existing .claude.json keys must be preserved")
+	}
+	if _, ok := doc["mcpServers"].(map[string]any)["old"]; ok {
+		t.Error("mcpServers must be overwritten, not merged")
+	}
+}

--- a/internal/config/extensions.go
+++ b/internal/config/extensions.go
@@ -75,7 +75,7 @@ type SkillConfig struct {
 	Path   string `yaml:"path"`
 }
 
-// MCPServerConfig declares an MCP server to register in ~/.claude/settings.json.
+// MCPServerConfig declares an MCP server to register in the agent's ~/.claude.json.
 // Env values may contain ${vault:BUCKET.KEY} refs resolved at provision time.
 // command/args run as the agent OS user; clem.yaml is operator-controlled.
 type MCPServerConfig struct {


### PR DESCRIPTION
Claude Code does not read `mcpServers` from `~/.claude/settings.json` — only `~/.claude.json` and project `.mcp.json` are loaded. Servers declared under `extensions.mcp_servers` were written with correct vault-expanded env, but never appeared in `claude mcp list`, so agents never had the tools.

## Changes
- `SetMCPServers` now writes the `mcpServers` key into the agent's `~/.claude.json` (creating it if absent — first provision precedes the first Claude session), preserving all other state Claude Code keeps there.
- File is chowned to the agent user and written 0600, since env values contain expanded secrets.
- Added `TestSetMCPServersWritesClaudeJSON` covering create-from-scratch, vault-ref expansion, key preservation, overwrite semantics, and mode.

Not written to the project `.mcp.json` because the runner regenerates that file on every start.