### PR TITLE
fix: watchdog alerts fail TLS when agent .env exports proxy/CA overrides

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -22,6 +22,12 @@ mkdir -p "$COOLDOWN_DIR"
 # Chat backend token sourced from orchestrator agent's .env
 {{.EnvSource}}
 
+# The agent .env may export egress-proxy and CA-bundle overrides for brokered
+# traffic. The watchdog calls the chat backend directly, so those make every
+# alert curl fail TLS validation (exit 60) — silently, since output is
+# discarded. Drop them; only the token is needed here.
+unset HTTPS_PROXY HTTP_PROXY ALL_PROXY NO_PROXY https_proxy http_proxy all_proxy no_proxy CURL_CA_BUNDLE SSL_CERT_FILE REQUESTS_CA_BUNDLE NODE_EXTRA_CA_CERTS
+
 send_alert() {
     local msg="$1"
     local safe_msg

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -71,6 +71,21 @@ func TestGenerateScript_SkipsDisabledUnits(t *testing.T) {
 	}
 }
 
+func TestGenerateScript_UnsetsProxyEnvBeforeAlertCurl(t *testing.T) {
+	s := GenerateScript(baseCfg())
+	// The sourced agent .env may export egress-proxy/CA overrides; with them
+	// set, direct backend curls fail TLS validation silently. The unset must
+	// come after the env source and before send_alert's curl.
+	unset := "unset HTTPS_PROXY"
+	unsetIdx := strings.Index(s, unset)
+	if unsetIdx == -1 {
+		t.Fatalf("generated script missing proxy-env unset\n---\n%s", s)
+	}
+	if curlIdx := strings.Index(s, "curl -s -X POST"); curlIdx != -1 && unsetIdx > curlIdx {
+		t.Errorf("proxy-env unset must precede alert curl (unset=%d curl=%d)", unsetIdx, curlIdx)
+	}
+}
+
 func TestGenerateScript_DiscordBackendAlertCurl(t *testing.T) {
 	s := GenerateScript(baseCfg())
 	for _, want := range []string{


### PR DESCRIPTION
The generated watchdog script sources the orchestrator agent's .env for the
chat-backend token, but that file may also export egress-proxy and CA-bundle
overrides intended for brokered agent traffic. With those set, send_alert's
direct curl to the backend fails certificate validation (curl exit 60) and
the failure is invisible because output is discarded — alerts are never
delivered. Unset proxy/CA env after sourcing; the watchdog only needs the
token.
