### PR TITLE
Make Codex/OpenCode adapters consume shared skills and MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ What sets it apart: **secrets and egress are contained at the OS layer, not by t
 | **Kernel egress containment** | Per-agent nftables UID firewall forces all traffic through a loopback proxy; a non-root agent can't disable a firewall it doesn't own. No in-process escape hatch. Opt-in `egress:` block. |
 | **Secret-zero brokering** | Brokered agents hold placeholders + a scoped inject-only token; real credentials live in a vault owned by a *separate* user and are injected on egress. `cat ~/.env` yields nothing usable for the brokered keys. |
 | **Multi-backend coordination** | Discord, Slack, or GitHub Issues via swappable `coordination.backend:` in `clem.yaml`. One config knob. |
-| **Multi-runtime** | `runtime: claude-code \| opencode`. Mix Anthropic cloud, Bedrock, Vertex, Ollama, OpenAI-compat - one surface. |
+| **Multi-runtime** | `runtime: claude-code \| opencode \| codex`. Mix Anthropic cloud, ChatGPT OAuth, Bedrock, Vertex, Ollama, and OpenAI-compatible providers behind one team definition. |
 | **Encrypted secrets** | Per-agent `.env` materialised from age/sops vaults at provision time. Never leave the host after. |
 | **Self-healing** | systemd + tmux per agent. Watchdog timer restarts dead or stalled sessions. Alerts fire only after repeated failures. |
 | **Bring your own model** | Default Claude; one flag away from Ollama Cloud / Bedrock / Vertex / local models. Tested end-to-end on local Gemma 4 (E4B QAT via Ollama). |
@@ -92,7 +92,7 @@ What sets it apart: **secrets and egress are contained at the OS layer, not by t
           └────────────────────────────────────┘
 ```
 
-Each agent runs a loop: launch `claude` (or `opencode`), inject a prompt, wait for the session to finish (up to 2h hard cap), sleep the configured `iteration` duration, repeat. Secrets live encrypted in `secrets.sops.yaml` (age/sops); `clem provision` decrypts them into per-agent `.env` files on the host.
+Each agent runs a loop: launch `claude`, `opencode`, or `codex`, inject a prompt, wait for the session to finish (up to 2h hard cap), sleep the configured `iteration` duration, repeat. Secrets live encrypted in `secrets.sops.yaml` (age/sops); `clem provision` decrypts them into per-agent `.env` files on the host.
 
 ---
 
@@ -408,7 +408,7 @@ agents:
     subagent_model: string  # optional - CLAUDE_CODE_SUBAGENT_MODEL for Task tool / Explore / general-purpose; defaults to claude-sonnet-4-6; set to "off" to inherit main model
     provider: string        # optional - anthropic (default) | bedrock | vertex | ollama | openai-compat
     provider_url: string    # required when provider is ollama or openai-compat
-    runtime: string         # optional - claude-code (default) | opencode
+    runtime: string         # optional - claude-code (default) | opencode | codex
 ```
 
 **Runtimes:**
@@ -417,6 +417,7 @@ agents:
 |---------------|-------------------------------------|-------------------------------------------------------------------------------------|
 | `claude-code` | `~/.local/bin/claude`               | Default. Anthropic-native wire format. Best for cloud Claude.                       |
 | `opencode`    | `~/.opencode/bin/opencode`          | Talks natively to 75+ providers via models.dev. Better tool-use on local models.   |
+| `codex`       | `~/.npm-global/bin/codex`           | OpenAI Codex CLI. Supports ChatGPT OAuth or `OPENAI_API_KEY`.                       |
 
 **Providers:**
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -55,14 +55,23 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		}
 
 		homeDir := fmt.Sprintf("/home/%s", osUser)
-		expiry := agent.TokenExpiry(homeDir)
-		hasRefresh := agent.HasRefreshToken(homeDir)
-		expiryStr := tokenExpiryDisplay(expiry, hasRefresh)
-		// A non-interactive credential (API key or setup-token) means there is
-		// no interactive .credentials.json to read, so report the auth mode
-		// instead of a misleading "missing".
-		if mode := agent.AuthMode(homeDir); mode != "" {
-			expiryStr = mode
+		expiryStr := ""
+		if ac.RuntimeKind() == "codex" {
+			if agent.CodexNeedsLogin(homeDir) {
+				expiryStr = "missing"
+			} else {
+				expiryStr = "codex-auth"
+			}
+		} else {
+			expiry := agent.TokenExpiry(homeDir)
+			hasRefresh := agent.HasRefreshToken(homeDir)
+			expiryStr = tokenExpiryDisplay(expiry, hasRefresh)
+			// A non-interactive credential (API key or setup-token) means there is
+			// no interactive .credentials.json to read, so report the auth mode
+			// instead of a misleading "missing".
+			if mode := agent.AuthMode(homeDir); mode != "" {
+				expiryStr = mode
+			}
 		}
 
 		logPath := fmt.Sprintf("/home/%s/.claude/%s-runner.log", osUser, agentKey)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1378,9 +1378,10 @@ func InstallSkill(username string, s config.SkillConfig) error {
 
 // SyncSkillsRepo clones (or pulls) repoURL into <homeDir>/.cache/<repoName>/
 // as the agent user, then symlinks every subdir under shared/ and <agentKey>/
-// into <homeDir>/.claude/skills/<name>. Symlinks pointing into the cache that
-// no longer resolve are pruned, so removing a skill in the repo propagates on
-// next sync. Idempotent.
+// into every supported runtime's user skill directory: ~/.claude/skills,
+// ~/.agents/skills, and ~/.config/opencode/skills. Symlinks pointing into the
+// cache that no longer resolve are pruned, so removing a skill in the repo
+// propagates on next sync. Idempotent.
 //
 // repoURL is any URL git clone understands (https, ssh, git@host:path).
 // agentKey selects which per-agent subdir to surface. Top-level dirs other
@@ -1435,7 +1436,11 @@ type cmdRunner func(name string, args ...string) ([]byte, error)
 func syncSkillsCommon(homeDir, agentKey, repoURL string, run cmdRunner, mkDir func(string) error) error {
 	repoName := skillsCacheName(repoURL)
 	cache := filepath.Join(homeDir, ".cache", repoName)
-	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+	skillsDirs := []string{
+		filepath.Join(homeDir, ".claude", "skills"),
+		filepath.Join(homeDir, ".agents", "skills"),
+		filepath.Join(homeDir, ".config", "opencode", "skills"),
+	}
 
 	if _, err := os.Stat(cache); os.IsNotExist(err) {
 		if err := mkDir(filepath.Dir(cache)); err != nil {
@@ -1452,8 +1457,10 @@ func syncSkillsCommon(homeDir, agentKey, repoURL string, run cmdRunner, mkDir fu
 		}
 	}
 
-	if err := mkDir(skillsDir); err != nil {
-		return fmt.Errorf("ensuring skills dir: %w", err)
+	for _, skillsDir := range skillsDirs {
+		if err := mkDir(skillsDir); err != nil {
+			return fmt.Errorf("ensuring skills dir %s: %w", skillsDir, err)
+		}
 	}
 
 	expected := make(map[string]string)
@@ -1480,15 +1487,19 @@ func syncSkillsCommon(homeDir, agentKey, repoURL string, run cmdRunner, mkDir fu
 				continue
 			}
 			target := filepath.Join(srcDir, name)
-			link := filepath.Join(skillsDir, name)
-			if out, err := run("ln", "-sfn", target, link); err != nil {
-				return fmt.Errorf("symlinking skill %s: %w\n%s", name, err, out)
+			for _, skillsDir := range skillsDirs {
+				link := filepath.Join(skillsDir, name)
+				if out, err := run("ln", "-sfn", target, link); err != nil {
+					return fmt.Errorf("symlinking skill %s into %s: %w\n%s", name, skillsDir, err, out)
+				}
 			}
 			expected[name] = src
 		}
 	}
 
-	pruneStaleSkillSymlinks(skillsDir, cache, expected, run)
+	for _, skillsDir := range skillsDirs {
+		pruneStaleSkillSymlinks(skillsDir, cache, expected, run)
+	}
 	return nil
 }
 
@@ -1579,7 +1590,29 @@ func SetMCPServers(username, homeDir string, servers []config.MCPServerConfig, s
 	if err := os.WriteFile(claudeJSONPath, append(out, '\n'), 0600); err != nil {
 		return fmt.Errorf("writing .claude.json: %w", err)
 	}
-	return chownToUser(claudeJSONPath, username)
+	if err := chownToUser(claudeJSONPath, username); err != nil {
+		return err
+	}
+
+	// Keep one runtime-neutral generated manifest. Non-Claude runners translate
+	// this into their native config on launch, so clem.yaml remains the only MCP
+	// source of truth across claude-code, opencode, and codex.
+	clemDir := filepath.Join(homeDir, ".clem")
+	if err := os.MkdirAll(clemDir, 0700); err != nil {
+		return fmt.Errorf("creating .clem directory: %w", err)
+	}
+	manifestPath := filepath.Join(clemDir, "mcp-servers.json")
+	manifest, err := json.MarshalIndent(mcpMap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling runtime-neutral MCP manifest: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, append(manifest, '\n'), 0600); err != nil {
+		return fmt.Errorf("writing runtime-neutral MCP manifest: %w", err)
+	}
+	if err := chownToUser(manifestPath, username); err != nil {
+		return err
+	}
+	return chownToUser(clemDir, username)
 }
 
 // InstallExtensions installs marketplaces, plugins, skills, and MCP servers for

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1453,22 +1453,28 @@ func TestSyncSkillsRepo_SymlinksSharedAndAgent(t *testing.T) {
 		t.Fatalf("SyncSkillsRepo: %v", err)
 	}
 
-	skillsDir := filepath.Join(home, ".claude", "skills")
-	for _, name := range []string{"skill-a", "skill-b"} {
-		link := filepath.Join(skillsDir, name)
-		target, err := os.Readlink(link)
-		if err != nil {
-			t.Errorf("%s: expected symlink, got: %v", name, err)
-			continue
-		}
-		if !strings.HasPrefix(target, cache+string(filepath.Separator)) {
-			t.Errorf("%s: symlink target %q not under cache %q", name, target, cache)
-		}
+	skillsDirs := []string{
+		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".config", "opencode", "skills"),
 	}
-	// skill-c (lead) and skill-d (random-dir) must NOT appear for worker
-	for _, name := range []string{"skill-c", "skill-d"} {
-		if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
-			t.Errorf("worker should not see %s", name)
+	for _, skillsDir := range skillsDirs {
+		for _, name := range []string{"skill-a", "skill-b"} {
+			link := filepath.Join(skillsDir, name)
+			target, err := os.Readlink(link)
+			if err != nil {
+				t.Errorf("%s/%s: expected symlink, got: %v", skillsDir, name, err)
+				continue
+			}
+			if !strings.HasPrefix(target, cache+string(filepath.Separator)) {
+				t.Errorf("%s: symlink target %q not under cache %q", name, target, cache)
+			}
+		}
+		// skill-c (lead) and skill-d (random-dir) must NOT appear for worker.
+		for _, name := range []string{"skill-c", "skill-d"} {
+			if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
+				t.Errorf("worker should not see %s in %s", name, skillsDir)
+			}
 		}
 	}
 
@@ -2067,6 +2073,22 @@ func TestSetMCPServersWritesClaudeJSON(t *testing.T) {
 	}
 	if fi, _ := os.Stat(path); fi.Mode().Perm() != 0600 {
 		t.Errorf(".claude.json mode = %v, want 0600 (env holds secrets)", fi.Mode().Perm())
+	}
+	manifestPath := filepath.Join(home, ".clem", "mcp-servers.json")
+	manifestRaw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("runtime-neutral MCP manifest not written: %v", err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(manifestRaw, &manifest); err != nil {
+		t.Fatalf("parsing runtime-neutral MCP manifest: %v", err)
+	}
+	managed := manifest["browser-render"].(map[string]any)
+	if managed["command"] != "mcp-browser-render" {
+		t.Errorf("bad runtime-neutral entry: %v", managed)
+	}
+	if got := managed["env"].(map[string]any)["BROWSER_RENDER_API_KEY"]; got != "sekrit" {
+		t.Errorf("runtime-neutral manifest leaked unresolved vault ref: %v", got)
 	}
 
 	// File present with Claude Code state: other keys preserved.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,10 +240,11 @@ type AgentConfig struct {
 	// than the main session. Accepts model aliases (sonnet, haiku, opus) or
 	// full IDs (claude-sonnet-4-6). Empty = inherit main model.
 	SubagentModel string `yaml:"subagent_model"`
-	// Effort caps extended-thinking budget per session via Claude Code's
-	// effortLevel setting. Accepts "low", "medium", "high", "xhigh", "max".
-	// Empty = use Claude Code's own default (currently medium). Lowering trims
-	// output tokens — the dominant cost driver in agent loops.
+	// Effort caps the runtime's reasoning budget per session. Clem translates
+	// this harness-neutral value to Claude Code's effortLevel or Codex's
+	// model_reasoning_effort. Accepts "low", "medium", "high", "xhigh", "max".
+	// For Codex, "max" maps to its equivalent "xhigh". Empty leaves the
+	// runtime default unchanged.
 	Effort string `yaml:"effort"`
 	// Headroom routes the claude-code session through a local Headroom
 	// proxy (pipx package headroom-ai) that compresses context before it

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -189,14 +189,17 @@ while true; do
     fi
 
     # Per-iteration effort override: the agent writes low|medium|high|xhigh
-    # to ~/.claude/next-effort during an iteration; consumed (and deleted)
-    # here. CLAUDE_CODE_EFFORT_LEVEL is session-scoped and outranks settings
+    # to the harness-neutral ~/.clem/next-effort during an iteration; consumed
+    # (and deleted) here. The legacy Claude path remains supported.
+    # CLAUDE_CODE_EFFORT_LEVEL is session-scoped and outranks settings
     # files, so an absent file simply means settings.json effortLevel
     # applies — no reset bookkeeping, no drift across iterations.
     unset CLAUDE_CODE_EFFORT_LEVEL
-    if [ -f "$HOME/.claude/next-effort" ]; then
-        NEXT_EFFORT=$(tr -cd 'a-z' < "$HOME/.claude/next-effort" | head -c 16)
-        rm -f "$HOME/.claude/next-effort"
+    NEXT_EFFORT_FILE="$HOME/.clem/next-effort"
+    [ -f "$NEXT_EFFORT_FILE" ] || NEXT_EFFORT_FILE="$HOME/.claude/next-effort"
+    if [ -f "$NEXT_EFFORT_FILE" ]; then
+        NEXT_EFFORT=$(tr -cd 'a-z' < "$NEXT_EFFORT_FILE" | head -c 16)
+        rm -f "$NEXT_EFFORT_FILE"
         case "$NEXT_EFFORT" in
             low|medium|high|xhigh)
                 export CLAUDE_CODE_EFFORT_LEVEL="$NEXT_EFFORT"
@@ -240,7 +243,7 @@ while true; do
         SLEEP_BETWEEN=$SLEEP_NIGHT
     fi
 
-    if [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
+    if [ $EXIT_CODE -eq 0 ] || [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
         BACKOFF=$SLEEP_BETWEEN
     else
         BACKOFF=$(( BACKOFF * 2 ))
@@ -385,7 +388,7 @@ while true; do
         SLEEP_BETWEEN=$SLEEP_NIGHT
     fi
 
-    if [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
+    if [ $EXIT_CODE -eq 0 ] || [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
         BACKOFF=$SLEEP_BETWEEN
     else
         BACKOFF=$(( BACKOFF * 2 ))
@@ -440,6 +443,7 @@ lines = []
 lines.append('cli_auth_credentials_store = \"file\"')
 lines.append('mcp_oauth_credentials_store = \"file\"')
 lines.append('forced_login_method = \"chatgpt\"')
+{{.CodexEffortConfig}}
 lines.append('')
 # Trust the work directory so project-scoped config layers load without a prompt.
 lines.append('[projects.' + _s(os.path.expanduser('~/{{.Project}}')) + ']')
@@ -519,6 +523,22 @@ while true; do
 
     [ -n "$RUNNER_WARNINGS" ] && PROMPT="${RUNNER_WARNINGS}${PROMPT}"
 
+    # One-session reasoning override written by the shared effort-control skill.
+    # Arrays preserve the TOML string as one -c argument.
+    CODEX_EFFORT_ARGS=()
+    NEXT_EFFORT_FILE="$HOME/.clem/next-effort"
+    if [ -f "$NEXT_EFFORT_FILE" ]; then
+        NEXT_EFFORT=$(tr -cd 'a-z' < "$NEXT_EFFORT_FILE" | head -c 16)
+        rm -f "$NEXT_EFFORT_FILE"
+        case "$NEXT_EFFORT" in
+            low|medium|high|xhigh)
+                CODEX_EFFORT_ARGS=(-c "model_reasoning_effort=\"$NEXT_EFFORT\"")
+                log "Effort override for this session: $NEXT_EFFORT" ;;
+            *)
+                log "Ignoring invalid next-effort value: $NEXT_EFFORT" ;;
+        esac
+    fi
+
     log "Starting {{.AgentName}} (fresh session)"
     # Claude Code debounces large multi-line pastes: a single Enter sent right
     # after the prompt is swallowed as a soft newline, leaving the prompt typed
@@ -535,6 +555,7 @@ while true; do
     [ -n '{{.Model}}' ] && MODEL_ARG="--model {{.Model}}"
     timeout 7200 "$CODEX" --dangerously-bypass-approvals-and-sandbox \
         $MODEL_ARG \
+        "${CODEX_EFFORT_ARGS[@]}" \
         -C "$WORKDIR"
 
     EXIT_CODE=$?
@@ -548,7 +569,7 @@ while true; do
         SLEEP_BETWEEN=$SLEEP_NIGHT
     fi
 
-    if [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
+    if [ $EXIT_CODE -eq 0 ] || [ $EXIT_CODE -eq 143 ] || [ $ELAPSED -gt $RESET_AFTER ]; then
         BACKOFF=$SLEEP_BETWEEN
     else
         BACKOFF=$(( BACKOFF * 2 ))
@@ -626,6 +647,7 @@ type RunnerParams struct {
 	AgentKey            string
 	AgentName           string
 	Model               string
+	CodexEffortConfig   string
 	SubagentExport      string
 	Prompt              string
 	OSUser              string
@@ -768,15 +790,16 @@ func Generate(cfg *config.Config, agentKey string) string {
 		)
 	}
 	p := RunnerParams{
-		Project:        cfg.Project,
-		AgentKey:       agentKey,
-		AgentName:      ac.Name,
-		Model:          ac.Model,
-		SubagentExport: subagentExport,
-		Prompt:         strings.ReplaceAll(promptText, "'", `'\''`),
-		OSUser:         cfg.OSUsername(agentKey),
-		HomeDir:        fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
-		SleepActive:    iterSec,
+		Project:           cfg.Project,
+		AgentKey:          agentKey,
+		AgentName:         ac.Name,
+		Model:             ac.Model,
+		CodexEffortConfig: codexEffortConfig(ac),
+		SubagentExport:    subagentExport,
+		Prompt:            strings.ReplaceAll(promptText, "'", `'\''`),
+		OSUser:            cfg.OSUsername(agentKey),
+		HomeDir:           fmt.Sprintf("/home/%s", cfg.OSUsername(agentKey)),
+		SleepActive:       iterSec,
 		// Night sleep defaults to the active value; iteration_night overrides.
 		// History: a hardcoded 2x night doubler was removed on the belief the
 		// prompt-cache TTL was 5 min. Subscription Claude Code actually gets
@@ -917,6 +940,7 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.AgentKey}}", p.AgentKey,
 		"{{.AgentName}}", p.AgentName,
 		"{{.Model}}", p.Model,
+		"{{.CodexEffortConfig}}", p.CodexEffortConfig,
 		"{{.Prompt}}", p.Prompt,
 		"{{.HeadroomLaunch}}", p.HeadroomLaunch,
 		"{{.OSUser}}", p.OSUser,
@@ -940,6 +964,26 @@ func renderTemplate(tmpl string, p RunnerParams) string {
 		"{{.InstructionFile}}", p.InstructionFile,
 	)
 	return r.Replace(tmpl)
+}
+
+// codexEffort translates Clem's harness-neutral effort vocabulary to Codex's.
+// Claude Code accepts "max" while Codex calls the same top tier "xhigh".
+func codexEffort(ac config.AgentConfig) string {
+	if ac.RuntimeKind() != "codex" {
+		return ""
+	}
+	if ac.Effort == "max" {
+		return "xhigh"
+	}
+	return ac.Effort
+}
+
+func codexEffortConfig(ac config.AgentConfig) string {
+	effort := codexEffort(ac)
+	if effort == "" {
+		return ""
+	}
+	return fmt.Sprintf(`lines.append('model_reasoning_effort = \"%s\"')`, effort)
 }
 
 // sidecarServersLiteral renders the Python list literal of [toolName, port]

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -517,7 +517,7 @@ while true; do
     fi
 
     log "Updating codex"
-    npm install -g @openai/codex@latest 2>&1 | tail -3 | tee -a "$LOGFILE" || log "codex update failed, continuing with current version"
+    npm install -g @openai/codex@latest --include=optional 2>&1 | tail -3 | tee -a "$LOGFILE" || log "codex update failed, continuing with current version"
 
     {{.SkillsSyncCmd}}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -321,6 +321,24 @@ if _backend != 'github' and os.environ.get('SLACK_MCP_XOXP_TOKEN'):
             'SLACK_MCP_ADD_MESSAGE_TOOL': os.environ.get('SLACK_MCP_ADD_MESSAGE_TOOL', 'true'),
         },
     }
+# Merge Clem's runtime-neutral extension MCP manifest.
+_managed_mcp = os.path.expanduser('~/.clem/mcp-servers.json')
+if os.path.exists(_managed_mcp):
+    with open(_managed_mcp) as f:
+        for name, entry in json.load(f).items():
+            if entry.get('type') == 'stdio':
+                cfg['mcp'][name] = {
+                    'type': 'local',
+                    'command': [entry['command']] + entry.get('args', []),
+                    'enabled': True,
+                    'environment': entry.get('env', {}),
+                }
+            else:
+                cfg['mcp'][name] = {
+                    'type': 'remote',
+                    'url': entry['url'],
+                    'enabled': True,
+                }
 print(json.dumps(cfg, indent=2))
 " > "$WORKDIR/opencode.json"
 
@@ -462,6 +480,16 @@ if os.environ.get('TYPEFULLY_API_KEY'):
 # Privileged MCP sidecars over loopback streamable-HTTP (codex supports url MCP).
 for _name, _port in {{.SidecarServers}}:
     _http(_name, 'http://127.0.0.1:%d/mcp' % _port)
+# Merge Clem's runtime-neutral extension MCP manifest.
+_managed_mcp = os.path.expanduser('~/.clem/mcp-servers.json')
+if os.path.exists(_managed_mcp):
+    import json
+    with open(_managed_mcp) as f:
+        for name, entry in json.load(f).items():
+            if entry.get('type') == 'stdio':
+                _stdio(name, entry['command'], entry.get('args'), entry.get('env'))
+            else:
+                _http(name, entry['url'])
 open(os.path.expanduser('~/.codex/config.toml'), 'w').write('\n'.join(lines) + '\n')
 "
 
@@ -499,6 +527,9 @@ while true; do
     # submits the input box is empty and any further Enter is a harmless no-op.
     (sleep 1 && tmux send-keys -t {{.AgentKey}} "" Enter
      sleep 25 && tmux send-keys -l -t {{.AgentKey}} "$PROMPT"
+     # A literal '$' in shell instructions opens Codex's skill picker. Close
+     # any mention picker before attempting submission.
+     sleep 1 && tmux send-keys -t {{.AgentKey}} Escape
      for _ in 1 2 3 4 5; do sleep 3; tmux send-keys -t {{.AgentKey}} Enter; done) &
     MODEL_ARG=""
     [ -n '{{.Model}}' ] && MODEL_ARG="--model {{.Model}}"

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -745,19 +745,20 @@ func TestGenerate_CodexRunnerSelected(t *testing.T) {
 	out := Generate(cfg, "lead")
 
 	for _, want := range []string{
-		`CODEX="$HOME/.npm-global/bin/codex"`,        // codex binary path
-		"~/.codex/config.toml",                       // TOML config target
-		`cli_auth_credentials_store = \"file\"`,      // headless auth store
-		`forced_login_method = \"chatgpt\"`,          // clem login OAuth flow
-		`model_reasoning_effort = \"high\"`,          // harness-neutral effort passthrough
-		"[mcp_servers.",                              // TOML MCP tables
-		"~/.clem/mcp-servers.json",                   // harness-neutral extension MCPs
-		"--dangerously-bypass-approvals-and-sandbox", // unattended execution
-		`timeout 7200 "$CODEX"`,                      // 2h interactive TUI cap
-		"tmux send-keys -l -t lead",                  // prompt injection contract
-		"tmux send-keys -t lead Escape",              // close $ skill picker before submit
-		"--model gpt-5.4-codex",                      // model passthrough
-		`NEXT_EFFORT_FILE="$HOME/.clem/next-effort"`, // shared one-session effort handoff
+		`CODEX="$HOME/.npm-global/bin/codex"`,                    // codex binary path
+		"~/.codex/config.toml",                                   // TOML config target
+		`cli_auth_credentials_store = \"file\"`,                  // headless auth store
+		`forced_login_method = \"chatgpt\"`,                      // clem login OAuth flow
+		`model_reasoning_effort = \"high\"`,                      // harness-neutral effort passthrough
+		"[mcp_servers.",                                          // TOML MCP tables
+		"~/.clem/mcp-servers.json",                               // harness-neutral extension MCPs
+		"--dangerously-bypass-approvals-and-sandbox",             // unattended execution
+		`timeout 7200 "$CODEX"`,                                  // 2h interactive TUI cap
+		"npm install -g @openai/codex@latest --include=optional", // platform package must survive updates
+		"tmux send-keys -l -t lead",                              // prompt injection contract
+		"tmux send-keys -t lead Escape",                          // close $ skill picker before submit
+		"--model gpt-5.4-codex",                                  // model passthrough
+		`NEXT_EFFORT_FILE="$HOME/.clem/next-effort"`,             // shared one-session effort handoff
 		`CODEX_EFFORT_ARGS=(-c "model_reasoning_effort=\"$NEXT_EFFORT\"")`,
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -749,9 +749,11 @@ func TestGenerate_CodexRunnerSelected(t *testing.T) {
 		`cli_auth_credentials_store = \"file\"`,      // headless auth store
 		`forced_login_method = \"chatgpt\"`,          // clem login OAuth flow
 		"[mcp_servers.",                              // TOML MCP tables
+		"~/.clem/mcp-servers.json",                   // harness-neutral extension MCPs
 		"--dangerously-bypass-approvals-and-sandbox", // unattended execution
 		`timeout 7200 "$CODEX"`,                      // 2h interactive TUI cap
 		"tmux send-keys -l -t lead",                  // prompt injection contract
+		"tmux send-keys -t lead Escape",              // close $ skill picker before submit
 		"--model gpt-5.4-codex",                      // model passthrough
 	} {
 		if !strings.Contains(out, want) {
@@ -762,6 +764,18 @@ func TestGenerate_CodexRunnerSelected(t *testing.T) {
 	// Codex must NOT carry the Anthropic-only quota/effort machinery.
 	if strings.Contains(out, "credentials.json") {
 		t.Errorf("codex runner should not reference claude credentials.json")
+	}
+}
+
+func TestGenerate_OpencodeRunnerMergesManagedMCPManifest(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Runtime: "opencode", Iteration: "1m", Prompt: "do the thing",
+	})
+	out := Generate(cfg, "lead")
+	for _, want := range []string{"~/.clem/mcp-servers.json", "'type': 'local'", "'type': 'remote'"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("opencode runner missing managed MCP adapter %q", want)
+		}
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -738,6 +738,7 @@ func TestGenerate_CodexRunnerSelected(t *testing.T) {
 		Name:      "Lead",
 		Runtime:   "codex",
 		Model:     "gpt-5.4-codex",
+		Effort:    "high",
 		Iteration: "1m",
 		Prompt:    "do the thing. When done, run: kill $PPID",
 	})
@@ -748,6 +749,7 @@ func TestGenerate_CodexRunnerSelected(t *testing.T) {
 		"~/.codex/config.toml",                       // TOML config target
 		`cli_auth_credentials_store = \"file\"`,      // headless auth store
 		`forced_login_method = \"chatgpt\"`,          // clem login OAuth flow
+		`model_reasoning_effort = \"high\"`,          // harness-neutral effort passthrough
 		"[mcp_servers.",                              // TOML MCP tables
 		"~/.clem/mcp-servers.json",                   // harness-neutral extension MCPs
 		"--dangerously-bypass-approvals-and-sandbox", // unattended execution
@@ -755,13 +757,15 @@ func TestGenerate_CodexRunnerSelected(t *testing.T) {
 		"tmux send-keys -l -t lead",                  // prompt injection contract
 		"tmux send-keys -t lead Escape",              // close $ skill picker before submit
 		"--model gpt-5.4-codex",                      // model passthrough
+		`NEXT_EFFORT_FILE="$HOME/.clem/next-effort"`, // shared one-session effort handoff
+		`CODEX_EFFORT_ARGS=(-c "model_reasoning_effort=\"$NEXT_EFFORT\"")`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("codex runner missing %q\nfull output:\n%s", want, out)
 		}
 	}
 
-	// Codex must NOT carry the Anthropic-only quota/effort machinery.
+	// Codex must NOT carry the Anthropic-only quota machinery.
 	if strings.Contains(out, "credentials.json") {
 		t.Errorf("codex runner should not reference claude credentials.json")
 	}
@@ -776,6 +780,36 @@ func TestGenerate_OpencodeRunnerMergesManagedMCPManifest(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("opencode runner missing managed MCP adapter %q", want)
 		}
+	}
+}
+
+func TestGenerate_CodexEffortMaxMapsToXHigh(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Runtime: "codex", Effort: "max", Iteration: "1m", Prompt: "work",
+	})
+	out := Generate(cfg, "lead")
+	if !strings.Contains(out, `model_reasoning_effort = \"xhigh\"`) {
+		t.Fatalf("codex max effort should map to xhigh:\n%s", out)
+	}
+}
+
+func TestGenerate_CodexEmptyEffortLeavesDefault(t *testing.T) {
+	cfg := baseCfg("lead", config.AgentConfig{
+		Name: "Lead", Runtime: "codex", Iteration: "1m", Prompt: "work",
+	})
+	out := Generate(cfg, "lead")
+	if strings.Contains(out, "model_reasoning_effort =") {
+		t.Fatalf("empty effort should leave the Codex default unchanged:\n%s", out)
+	}
+}
+
+func TestGenerate_CodexSuccessfulShortRunUsesConfiguredInterval(t *testing.T) {
+	cfg := baseCfg("ops", config.AgentConfig{
+		Name: "Ops", Runtime: "codex", Iteration: "3h", Prompt: "check",
+	})
+	out := Generate(cfg, "ops")
+	if !strings.Contains(out, "if [ $EXIT_CODE -eq 0 ] || [ $EXIT_CODE -eq 143 ]") {
+		t.Fatalf("successful Codex exits must use the configured iteration interval:\n%s", out)
 	}
 }
 
@@ -1011,7 +1045,8 @@ func TestGenerate_NextEffortAndQuotaBlocks(t *testing.T) {
 	cfg := baseCfg("lead", config.AgentConfig{Name: "L", Iteration: "1m", Prompt: "p"})
 	out := Generate(cfg, "lead")
 	for _, want := range []string{
-		`if [ -f "$HOME/.claude/next-effort" ]`,
+		`NEXT_EFFORT_FILE="$HOME/.clem/next-effort"`,
+		`NEXT_EFFORT_FILE="$HOME/.claude/next-effort"`,
 		`export CLAUDE_CODE_EFFORT_LEVEL="$NEXT_EFFORT"`,
 		"unset CLAUDE_CODE_EFFORT_LEVEL",
 		`QUOTA_FILE="$HOME/.claude/quota.json"`,


### PR DESCRIPTION
## Summary
- sync one `skills_repo` into Claude Code, Codex, and OpenCode discovery paths
- generate one runtime-neutral MCP manifest and translate it in Codex/OpenCode runners
- reliably submit Codex prompts containing `$` shell variables
- report Codex authentication correctly in `clem status`
- document the existing `runtime: codex` support

## Verification
- `go test ./...`
- exercised generated runners for each supported runtime
- verified skill discovery and MCP translation across runtime adapters