### PR TITLE
feat: rtk output filter as per-agent provision option

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -147,6 +147,15 @@ func provisionAgent(agentKey string, ac config.AgentConfig) error {
 	}
 	fmt.Printf("  wrote %s/.claude/settings.json\n", homeDir)
 
+	// 3ac. Optional rtk output filter. Must follow step 3: WriteSettings
+	// rewrites settings.json wholesale and would drop the hook `rtk init`
+	// writes there. Non-fatal like headroom.
+	if ac.RTK {
+		if err := agent.InstallRTK(osUser); err != nil {
+			fmt.Printf("  WARNING: %v (agent will run without rtk)\n", err)
+		}
+	}
+
 	// 3aa. Install extensions (marketplaces, plugins, skills, MCP servers).
 	// caveman: true is handled as a shorthand inside InstallExtensions.
 	ext := ac.Extensions

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1286,6 +1286,64 @@ func InstallHeadroom(username string) error {
 	return nil
 }
 
+// RTKVersion is the pinned rtk (github.com/rtk-ai/rtk) release clem installs.
+// Bump the version and the digests in rtkSHA256 together, from the release's
+// checksums.txt.
+const RTKVersion = "0.43.0"
+
+// rtkAsset and rtkSHA256 map GOARCH to the release asset and its digest.
+// Unlike InstallAgentVault's checksums.txt flow, the digests are clem-pinned
+// (in-source), so a replaced release asset fails verification instead of
+// installing.
+var rtkAsset = map[string]string{
+	"amd64": "rtk-x86_64-unknown-linux-musl.tar.gz",
+	"arm64": "rtk-aarch64-unknown-linux-gnu.tar.gz",
+}
+
+var rtkSHA256 = map[string]string{
+	"amd64": "ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609",
+	"arm64": "5519f7ca12e5c143a609f0d28a0a77b97413a8dce31c2681f1a41c24519a8731",
+}
+
+// rtkInstallScript returns the bash that downloads the pinned rtk release
+// asset, verifies it against the clem-pinned digest, and lands the binary at
+// /usr/local/bin/rtk. Split from InstallRTK so tests can pin the
+// supply-chain contract without network or root.
+func rtkInstallScript(asset, sha string) string {
+	return fmt.Sprintf(`set -euo pipefail
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT; cd "$TMP"
+curl -fsSL -o "%[1]s" "https://github.com/rtk-ai/rtk/releases/download/v%[2]s/%[1]s"
+echo "%[3]s  %[1]s" | sha256sum -c --quiet -
+tar -xzf "%[1]s" rtk
+install -m 0755 rtk /usr/local/bin/rtk`, asset, RTKVersion, sha)
+}
+
+// InstallRTK installs the rtk output-filter CLI and its hook for the given
+// user. The binary install is host-global and idempotent (skipped when the
+// pinned version is already at /usr/local/bin/rtk); `rtk init` then writes
+// rtk's PreToolUse hook into the user's ~/.claude/settings.json, so callers
+// must run this after WriteSettings, which rewrites that file wholesale and
+// would drop the hook. Callers may treat failure as a warning: agents run
+// fine without rtk.
+func InstallRTK(username string) error {
+	sha, ok := rtkSHA256[runtime.GOARCH]
+	if !ok {
+		return fmt.Errorf("unsupported arch %q for rtk install", runtime.GOARCH)
+	}
+	verCheck := "/usr/local/bin/rtk --version 2>/dev/null"
+	if out, err := sys.Run("bash", "-c", verCheck); err != nil ||
+		!strings.Contains(string(out), RTKVersion) {
+		fmt.Printf("  installing rtk %s (%s)\n", RTKVersion, runtime.GOARCH)
+		if out, err := sys.Run("bash", "-c", rtkInstallScript(rtkAsset[runtime.GOARCH], sha)); err != nil {
+			return fmt.Errorf("installing rtk %s: %w\n%s", RTKVersion, err, out)
+		}
+	}
+	if out, err := sys.Run("sudo", "-iu", username, "rtk", "init", "-g", "--hook-only", "--auto-patch"); err != nil {
+		return fmt.Errorf("rtk init for %s: %w\n%s", username, err, out)
+	}
+	return nil
+}
+
 // InstallCaveman installs the caveman plugin for the agent user. Idempotent.
 // https://github.com/JuliusBrussee/caveman
 func InstallCaveman(username string) error {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -49,6 +49,49 @@ func withStub(t *testing.T) *stubExec {
 	return stub
 }
 
+// TestRTKInstallScript_PinsDigestAndDest pins the supply-chain contract: the
+// install script must fetch the exact pinned release asset, refuse a tarball
+// whose sha256 differs from the clem-pinned digest, and land the binary at
+// /usr/local/bin/rtk. Would catch a pin bump that forgot the digest, or a
+// refactor that drops verification.
+func TestRTKInstallScript_PinsDigestAndDest(t *testing.T) {
+	for arch, asset := range rtkAsset {
+		s := rtkInstallScript(asset, rtkSHA256[arch])
+		for _, want := range []string{
+			"set -euo pipefail",
+			"releases/download/v" + RTKVersion + "/" + asset,
+			rtkSHA256[arch] + "  " + asset,
+			"sha256sum -c",
+			"install -m 0755 rtk /usr/local/bin/rtk",
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("%s install script missing %q:\n%s", arch, want, s)
+			}
+		}
+	}
+}
+
+// TestInstallRTK_InstallsThenInitsHook pins the flow and its order: ensure
+// the pinned binary (version probe, then verified download) before running
+// `rtk init` as the agent user — init would fail with no binary, and the
+// hook must be written for the nag-suppression contract to hold.
+func TestInstallRTK_InstallsThenInitsHook(t *testing.T) {
+	stub := withStub(t)
+	if err := InstallRTK("myteam-lead"); err != nil {
+		t.Fatalf("InstallRTK: %v", err)
+	}
+	if len(stub.calls) != 3 {
+		t.Fatalf("want 3 calls (version probe, install, init), got %d: %v", len(stub.calls), stub.calls)
+	}
+	if got := stub.calls[1][2]; !strings.Contains(got, "sha256sum -c") {
+		t.Errorf("second call should run the verified install script, got %q", got)
+	}
+	init := strings.Join(stub.calls[2], " ")
+	if init != "sudo -iu myteam-lead rtk init -g --hook-only --auto-patch" {
+		t.Errorf("unexpected init call: %q", init)
+	}
+}
+
 // TestSecretPatternRegex_MatchesKnownCredentials verifies the regex actually
 // matches the secret shapes we claim to detect. Would catch a typo in any
 // length bound or character class that silently lets real tokens through.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,6 +252,15 @@ type AgentConfig struct {
 	// rate limits. The runner falls back to a direct claude launch when the
 	// binary is missing. claude-code runtime only; ignored for opencode/codex.
 	Headroom bool `yaml:"headroom"`
+	// RTK installs the rtk output-filter CLI (github.com/rtk-ai/rtk) at
+	// provision: one pinned static binary at /usr/local/bin/rtk shared by
+	// all agents, plus rtk's PreToolUse hook in the agent's settings.json
+	// (60-90% fewer tokens on git/test/build output). The hook rewrites
+	// commands automatically under the claude-code runtime only; for
+	// codex/opencode it is inert but still installed — it silences rtk's
+	// per-command "No hook installed" hint, and those runtimes adopt rtk
+	// through prompt instructions instead.
+	RTK bool `yaml:"rtk"`
 	// GitName and GitEmail set the agent's git user identity during provision.
 	// Without these, commits are authored with whatever identity the OAuth login
 	// stored, which may leak the operator's personal email into public history.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -102,6 +102,38 @@ agents:
 	}
 }
 
+// TestLoad_ParsesAgentRTK pins the rtk opt-in: `rtk: true` on an agent must
+// survive strict decoding and land on AgentConfig.RTK, defaulting to off.
+func TestLoad_ParsesAgentRTK(t *testing.T) {
+	path := writeYAML(t, `
+project: myteam
+coordination:
+  backend: discord
+  server_id: "1"
+  channels: {general: "g"}
+operator:
+  discord_ids: ["277434478803156993"]
+agents:
+  lead:
+    name: "Lead"
+    model: "claude-sonnet-4-6"
+    rtk: true
+  worker:
+    name: "Worker"
+    model: "claude-sonnet-4-6"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Agents["lead"].RTK {
+		t.Error("lead should have RTK enabled")
+	}
+	if cfg.Agents["worker"].RTK {
+		t.Error("worker should default to RTK disabled")
+	}
+}
+
 // TestLoad_AllowsAnchorHolderExtensionKeys pins the escape hatch that keeps
 // strict decoding compatible with shared YAML anchors: top-level "x-" keys
 // are collected (not rejected), and merge keys referencing anchors defined in


### PR DESCRIPTION
## Why
Teams adopting rtk (github.com/rtk-ai/rtk) to cut shell-output tokens 60-90% had to hand-install the binary and per-user hook on the host — config drift waiting to happen. This makes `rtk: true` in clem.yaml the single source of truth, following the `headroom:` precedent.

## What
- `AgentConfig.RTK` (`rtk: true`) — strict-decoder-safe, defaults off
- `agent.InstallRTK`: host-global pinned binary at /usr/local/bin/rtk (sha256 pinned **in-source**, so a replaced release asset fails verification — the hardening InstallAgentVault's TOFU comment tracks as follow-up), then `rtk init -g --hook-only --auto-patch` per agent user
- Provision step 3ac, deliberately **after** WriteSettings: that step rewrites settings.json wholesale and would drop the hook. Non-fatal like headroom.
- Codex/opencode note: the hook is inert there but still wanted — it silences rtk's per-command "No hook installed" hint; those runtimes adopt rtk via the operator's prompt instructions instead.

## Tests
- `TestLoad_ParsesAgentRTK` — strict decoding accepts the new key, defaults off
- `TestRTKInstallScript_PinsDigestAndDest` — supply-chain contract (pinned asset, digest check, dest)
- `TestInstallRTK_InstallsThenInitsHook` — flow order via the stub executor

Verified end-to-end on a production host: provision installs the pinned binary and hooks each agent user; re-runs are idempotent.
